### PR TITLE
Wolverdude/update regions gleam

### DIFF
--- a/regions-gleam.csv
+++ b/regions-gleam.csv
@@ -87,7 +87,7 @@ G-AJL,Aizawl,,,gleam_basin,,W-AS,,IN,IND,,23.841,92.62,283000.0,1072
 G-AJN,Anjouan,,,gleam_basin,,W-AF,,KM,COM,,-12.132,44.43,,1359
 G-AJR,Arvidsjaur,,,gleam_basin,,W-EU,,SE,SWE,,65.59,19.282,,2550
 G-AJU,Aracaju,,,gleam_basin,,W-SA,,BR,BRA,,-10.984,-37.07,685000.0,1977
-G-AJY,Agadez,,,gleam_basin,,W-AF,,NE,NER,,16.966,8.0,118000.0,71
+G-AJY,Agadez,,,gleam_basin,,W-AF,,NE,NER,,16.966,8,118000.0,71
 G-AKB,Atka,,,gleam_basin,,W-NA,,US,USA,US-AK,52.22,-174.206,,2178
 G-AKF,Kufra,,,gleam_basin,,W-AF,,LY,LBY,,24.179,23.314,,157
 G-AKJ,Asahikawa,,,gleam_basin,,W-AS,,JP,JPN,,43.671,142.447,357000.0,3111
@@ -174,7 +174,7 @@ G-AUH,Abu Dhabi,,,gleam_basin,,W-AS,,AE,ARE,,24.433,54.651,603000.0,3179
 G-AUQ,Hiva Oa,,,gleam_basin,,W-OC,,PF,PYF,,-9.769,-139.011,,686
 G-AUR,Aurillac,,,gleam_basin,,W-EU,,FR,FRA,,44.891,2.422,35000.0,1502
 G-AUS,Austin,,,gleam_basin,,W-NA,,US,USA,US-TX,30.194,-97.67,1639000.0,2181
-G-AUU,Aurukun ,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-13.354,141.721,,1601
+G-AUU,Aurukun,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-13.354,141.721,,1601
 G-AUX,Araguaina,,,gleam_basin,,W-SA,,BR,BRA,,-7.228,-48.241,50000.0,1962
 G-AUY,Aneityum,,,gleam_basin,,W-OC,,VU,VUT,,-20.249,169.771,,1317
 G-AVA,Anshun,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.261,105.873,849000.0,337
@@ -263,7 +263,7 @@ G-BHO,Bhopal,,,gleam_basin,,W-AS,,IN,IND,,23.288,77.337,1727000.0,1104
 G-BHQ,Broken Hill,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.001,141.472,17000.0,1662
 G-BHR,Bharatpur,,,gleam_basin,,W-AS,,NP,NPL,,27.678,84.429,229000.0,565
 G-BHU,Bhavnagar,,,gleam_basin,,W-AS,,IN,IND,,21.752,72.185,555000.0,1105
-G-BHV,Bahawalpur,,,gleam_basin,,W-AS,,PK,PAK,,29.348,71.718,553000.0,130
+G-BHV,Bahawalpur,,,gleam_basin,,W-AS,,PK,PAK,,29.348,71.718,10000000.0,130
 G-BHX,Birmingham (UK),,,gleam_basin,,W-EU,,GB,GBR,,52.454,-1.748,,786
 G-BHY,Beihai,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,21.539,109.294,729000.0,451
 G-BIA,Bastia,,,gleam_basin,,W-EU,,FR,FRA,,42.553,9.484,41000.0,1529
@@ -421,7 +421,7 @@ G-BZO,Bolzano,,,gleam_basin,,W-EU,,IT,ITA,,46.46,11.326,96000.0,3091
 G-BZR,Beziers,,,gleam_basin,,W-EU,,FR,FRA,,43.324,3.354,81000.0,1524
 G-BZV,Brazzaville,,,gleam_basin,,W-AF,,CG,COG,,-4.252,15.253,1355000.0,1346
 G-CAB,Cabinda,,,gleam_basin,,W-AF,,AO,AGO,,-5.597,12.188,92000.0,6
-G-CAC,Cascavel,,,gleam_basin,,W-SA,,BR,BRA,,-25.0,-53.501,257000.0,2018
+G-CAC,Cascavel,,,gleam_basin,,W-SA,,BR,BRA,,-25,-53.501,257000.0,2018
 G-CAE,Columbia (US-SC),,,gleam_basin,,W-NA,,US,USA,US-SC,33.939,-81.119,,2295
 G-CAG,Cagliari,,,gleam_basin,,W-EU,,IT,ITA,,39.251,9.054,292000.0,3088
 G-CAH,Ca Mau,,,gleam_basin,,W-AS,,VN,VNM,,9.178,105.178,357000.0,1131
@@ -511,7 +511,7 @@ G-CJA,Cajamarca,,,gleam_basin,,W-SA,,PE,PER,,-7.139,-78.489,143000.0,1214
 G-CJB,Coimbatore,,,gleam_basin,,W-AS,,IN,IND,,11.03,77.043,1696000.0,1063
 G-CJC,Calama,,,gleam_basin,,W-SA,,CL,CHL,,-22.498,-68.904,143000.0,294
 G-CJJ,Cheongju,,,gleam_basin,,W-AS,,KR,KOR,,36.717,127.499,775000.0,2800
-G-CJL,Chitral,,,gleam_basin,,W-AS,,PK,PAK,,35.887,71.801,447362.0,111
+G-CJL,Chitral,,,gleam_basin,,W-AS,,PK,PAK,,35.887,71.801,2000000.0,111
 G-CJM,Chumphon,,,gleam_basin,,W-AS,,TH,THA,,10.711,99.362,86000.0,526
 G-CJS,Ciudad Juarez,,,gleam_basin,,W-NA,,MX,MEX,,31.636,-106.429,1512000.0,990
 G-CJU,Jeju,,,gleam_basin,,W-AS,,KR,KOR,,33.511,126.493,408000.0,2801
@@ -599,7 +599,7 @@ G-CVJ,Cuernavaca,,,gleam_basin,,W-NA,,MX,MEX,,18.835,-99.261,834000.0,987
 G-CVM,Ciudad Victoria,,,gleam_basin,,W-NA,,MX,MEX,,23.703,-98.956,275000.0,986
 G-CVN,Clovis,,,gleam_basin,,W-NA,,US,USA,US-CA,34.425,-103.079,110000.0,2126
 G-CWA,Wausau,,,gleam_basin,,W-NA,,US,USA,US-WI,44.778,-89.667,74000.0,2103
-G-CWB,Curitiba ,,,gleam_basin,,W-SA,,BR,BRA,,-25.528,-49.176,,1947
+G-CWB,Curitiba,,,gleam_basin,,W-SA,,BR,BRA,,-25.528,-49.176,,1947
 G-CWC,Chernivtsi,,,gleam_basin,,W-EU,,UA,UKR,,48.259,25.981,298000.0,2782
 G-CXB,Cox's Bazar,,,gleam_basin,,W-AS,,BD,BGD,,21.452,91.964,254000.0,64
 G-CXF,Coldfoot,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2132
@@ -627,7 +627,7 @@ G-DAU,Daru,,,gleam_basin,,W-OC,,PG,PNG,,-9.087,143.208,15000.0,3003
 G-DAV,David,,,gleam_basin,,W-NA,,PA,PAN,,8.391,-82.435,110000.0,3009
 G-DAX,Dazhou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,31.13,107.43,131000.0,487
 G-DAY,Dayton,,,gleam_basin,,W-NA,,US,USA,US-OH,39.902,-84.219,718000.0,2534
-G-DBA,Dalbandin,,,gleam_basin,,W-AS,,PK,PAK,,28.878,64.4,16319.0,107
+G-DBA,Dalbandin,,,gleam_basin,,W-AS,,PK,PAK,,28.878,64.4,465000.0,107
 G-DBO,Dubbo,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.217,148.575,32000.0,1578
 G-DBQ,Dubuque,,,gleam_basin,,W-NA,,US,USA,US-IA,42.402,-90.71,69000.0,2082
 G-DBV,Dubrovnik,,,gleam_basin,,W-EU,,HR,HRV,,42.561,18.268,37000.0,285
@@ -635,8 +635,8 @@ G-DCN,Derby,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-17.581,123.828,24000.0,1582
 G-DCY,Daocheng,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,29.323,100.053,,326
 G-DDC,Dodge City,,,gleam_basin,,W-NA,,US,USA,US-KS,37.763,-99.966,28000.0,2345
 G-DDG,Dandong,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,40.025,124.286,870000.0,428
-G-DDU,Dadu,,,gleam_basin,,W-AS,,PK,PAK,,,,140000.0,126
-G-DEA,Dera Ghazi Khan,,,gleam_basin,,W-AS,,PK,PAK,,29.961,70.486,236000.0,129
+G-DDU,Dadu,,,gleam_basin,,W-AS,,PK,PAK,,,,2900000.0,126
+G-DEA,Dera Ghazi Khan,,,gleam_basin,,W-AS,,PK,PAK,,29.961,70.486,4100000.0,129
 G-DEB,Debrecen,,,gleam_basin,,W-EU,,HU,HUN,,47.489,21.615,231000.0,831
 G-DEC,Decatur,,,gleam_basin,,W-NA,,US,USA,US-IL,39.835,-88.866,89000.0,2367
 G-DED,Dehra Dun,,,gleam_basin,,W-AS,,IN,IND,,30.19,78.18,714000.0,1100
@@ -709,7 +709,7 @@ G-DRT,Del Rio,,,gleam_basin,,W-NA,,US,USA,US-TX,29.374,-100.927,44000.0,2127
 G-DRV,Dharavandhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,5.156,73.13,,1478
 G-DRW,Darwin,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.415,130.877,93000.0,1589
 G-DSA,Doncaster,,,gleam_basin,,W-EU,,GB,GBR,,53.481,-1.011,18000.0,778
-G-DSK,Dera Ismail Khan,,,gleam_basin,,W-AS,,PK,PAK,,31.909,70.897,102000.0,116
+G-DSK,Dera Ismail Khan,,,gleam_basin,,W-AS,,PK,PAK,,31.909,70.897,9100000.0,116
 G-DSM,Des Moines,,,gleam_basin,,W-NA,,US,USA,US-IA,41.534,-93.663,481000.0,2173
 G-DSN,Ordos,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,39.49,109.861,1941000.0,349
 G-DTD,Datadawai,,,gleam_basin,,W-AS,,ID,IDN,,0.811,114.531,,1293
@@ -936,7 +936,7 @@ G-GHA,Ghardaia,,,gleam_basin,,W-AF,,DZ,DZA,,32.384,3.794,125000.0,33
 G-GHT,Ghat,,,gleam_basin,,W-AF,,LY,LBY,,25.146,10.143,24000.0,161
 G-GIB,Gibraltar,,,gleam_basin,,W-EU,,GI,GIB,,,,,493
 G-GIG,Rio de Janeiro,,,gleam_basin,,W-SA,,BR,BRA,,-22.81,-43.251,11748000.0,1990
-G-GIL,Gilgit,,,gleam_basin,,W-AS,,PK,PAK,,35.919,74.334,217000.0,106
+G-GIL,Gilgit,,,gleam_basin,,W-AS,,PK,PAK,,35.919,74.334,3500000.0,106
 G-GIS,Gisborne,,,gleam_basin,,W-OC,,NZ,NZL,,-38.663,177.978,34000.0,3051
 G-GIZ,Jazan,,,gleam_basin,,W-AS,,SA,SAU,,16.901,42.586,105000.0,258
 G-GJA,Guanaja,,,gleam_basin,,W-NA,,HN,HND,,16.445,-85.907,,1194
@@ -1006,7 +1006,7 @@ G-GUR,Alotau,,,gleam_basin,,W-OC,,PG,PNG,,-10.311,150.334,12000.0,2989
 G-GUW,Atyrau,,,gleam_basin,,W-AS,,KZ,KAZ,,47.122,51.821,183000.0,663
 G-GVA,Geneva,,,gleam_basin,,W-EU,,CH,CHE,,46.238,6.109,1240000.0,279
 G-GVR,Governador Valadares,,,gleam_basin,,W-SA,,BR,BRA,,-18.895,-41.982,251000.0,2013
-G-GWD,Gwadar,,,gleam_basin,,W-AS,,PK,PAK,,25.233,62.329,52000.0,127
+G-GWD,Gwadar,,,gleam_basin,,W-AS,,PK,PAK,,25.233,62.329,197000.0,127
 G-GWL,Gwalior,,,gleam_basin,,W-AS,,IN,IND,,26.293,78.228,978000.0,1093
 G-GWT,Westerland,,,gleam_basin,,W-EU,,DE,DEU,,54.913,8.34,,741
 G-GXF,Sayun,,,gleam_basin,,W-AS,,YE,YEM,,15.966,48.788,,582
@@ -1036,7 +1036,7 @@ G-HBA,Hobart,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-42.836,147.51,81000.0,1618
 G-HBE,Alexandria (EG),,,gleam_basin,,W-AF,,EG,EGY,,30.918,29.696,,56
 G-HBX,Hubli,,,gleam_basin,,W-AS,,IN,IND,,15.362,75.085,890000.0,1080
 G-HCR,Holy Cross,,,gleam_basin,,W-NA,,US,USA,US-AK,62.188,-159.775,,2283
-G-HDD,Hyderabad,,Hyderabad (PK),gleam_basin,,W-AS,,PK,PAK,,25.318,68.366,2201079.0,123
+G-HDD,Hyderabad,,Hyderabad (PK),gleam_basin,,W-AS,,PK,PAK,,25.318,68.366,10300000.0,123
 G-HDF,Heringsdorf,,,gleam_basin,,W-EU,,DE,DEU,,53.879,14.152,,740
 G-HDG,Handan,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,36.526,114.426,1631000.0,408
 G-HDM,Hamadan,,,gleam_basin,,W-AS,,IR,IRN,,34.869,48.553,528000.0,2948
@@ -1208,7 +1208,7 @@ G-IRM,Igrim,,,gleam_basin,,W-EU,,RU,RUS,,,,10000.0,1844
 G-IRP,Isiro,,,gleam_basin,,W-AF,,CD,COD,,2.828,27.588,157000.0,1337
 G-IRZ,Santa Isabel Rio Negro,,,gleam_basin,,W-SA,,BR,BRA,,-0.379,-64.992,,1982
 G-ISA,Mount Isa,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.664,139.489,33000.0,1605
-G-ISB,Islamabad,,,gleam_basin,,W-AS,,PK,PAK,,33.561,72.852,780000.0,108
+G-ISB,Islamabad,,,gleam_basin,,W-AS,,PK,PAK,,33.561,72.852,15300000.0,108
 G-ISC,Isles of Scilly,,,gleam_basin,,W-EU,,GB,GBR,,49.913,-6.292,,777
 G-ISE,Isparta,,,gleam_basin,,W-AS,,TR,TUR,,37.855,30.368,172000.0,1754
 G-ISG,New Ishigaki,,,gleam_basin,,W-AS,,JP,JPN,,24.396,124.245,,3102
@@ -1233,7 +1233,7 @@ G-IXC,Chandigarh,,,gleam_basin,,W-AS,,IN,IND,,30.674,76.788,979000.0,1045
 G-IXD,Allahabad,,,gleam_basin,,W-AS,,IN,IND,,25.44,81.734,1201000.0,1049
 G-IXE,Mangalore,,,gleam_basin,,W-AS,,IN,IND,,12.961,74.89,777000.0,1050
 G-IXG,Belgaum,,,gleam_basin,,W-AS,,IN,IND,,15.859,74.618,609000.0,1048
-G-IXJ,Jammu,,,gleam_basin,,W-AS,,IN,IND,,32.689,74.837,791000.0,1041
+G-IXJ,Jammu,,,gleam_basin,,W-AS,,IN,IND,,32.689,74.837,4100000.0,1041
 G-IXL,Leh,,,gleam_basin,,W-AS,,IN,IND,,34.136,77.547,37000.0,1042
 G-IXM,Madurai,,,gleam_basin,,W-AS,,IN,IND,,9.835,78.093,910000.0,1043
 G-IXR,Ranchi,,,gleam_basin,,W-AS,,IN,IND,,23.314,85.322,1044000.0,1056
@@ -1337,7 +1337,7 @@ G-KBR,Kota Bharu,,,gleam_basin,,W-AS,,MY,MYS,,6.167,102.293,506000.0,178
 G-KBU,Kotabaru,,,gleam_basin,,W-AS,,ID,IDN,,,,,1270
 G-KBV,Krabi,,,gleam_basin,,W-AS,,TH,THA,,8.099,98.986,31000.0,523
 G-KCA,Kuqa,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.678,82.873,111000.0,385
-G-KCF,Kadanwari,,,gleam_basin,,W-AS,,PK,PAK,,27.167,69.317,,120
+G-KCF,Kadanwari,,,gleam_basin,,W-AS,,PK,PAK,,27.167,69.317,3700000.0,120
 G-KCH,Kuching,,,gleam_basin,,W-AS,,MY,MYS,,1.485,110.347,570000.0,177
 G-KCK,Kirensk,,,gleam_basin,,W-EU,,RU,RUS,,57.773,108.064,13000.0,1899
 G-KCM,Kahramanmaras,,,gleam_basin,,W-AS,,TR,TUR,,37.539,36.954,376000.0,1763
@@ -1349,7 +1349,7 @@ G-KDI,Kendari,,,gleam_basin,,W-AS,,ID,IDN,,-4.082,122.418,165000.0,1280
 G-KDL,Kardla,,,gleam_basin,,W-EU,,EE,EST,,58.991,22.831,,2868
 G-KDM,Kaadedhdhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,0.488,72.997,,1483
 G-KDO,Kadhdhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,1.859,73.522,,1484
-G-KDU,Skardu,,,gleam_basin,,W-AS,,PK,PAK,,35.335,75.536,214848.0,128
+G-KDU,Skardu,,,gleam_basin,,W-AS,,PK,PAK,,35.335,75.536,1900000.0,128
 G-KDV,Kadavu Island,,,gleam_basin,,W-OC,,FJ,FJI,,-19.058,178.157,,1189
 G-KDZ,Kandy,,,gleam_basin,,W-AS,,LK,LKA,,,,112000.0,756
 G-KEF,Reykjavik,,,gleam_basin,,W-EU,,IS,ISL,,63.985,-22.606,166000.0,1350
@@ -1374,7 +1374,7 @@ G-KHD,Khorramabad,,,gleam_basin,,W-AS,,IR,IRN,,33.435,48.283,375000.0,2970
 G-KHE,Kherson,,,gleam_basin,,W-EU,,UA,UKR,,46.676,32.506,320000.0,2790
 G-KHG,Kashi,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,39.543,76.02,,474
 G-KHH,Kaohsiung,,,gleam_basin,,W-AS,,TW,TWN,,22.577,120.35,2769000.0,2828
-G-KHI,Karachi,,,gleam_basin,,W-AS,,PK,PAK,,24.907,67.161,12130000.0,105
+G-KHI,Karachi,,,gleam_basin,,W-AS,,PK,PAK,,24.907,67.161,16800000.0,105
 G-KHN,Nanchang,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,28.865,115.9,2350000.0,472
 G-KHS,Khasab,,,gleam_basin,,W-AS,,OM,OMN,,26.171,56.241,18000.0,1786
 G-KHV,Khabarovsk,,,gleam_basin,,W-EU,,RU,RUS,,48.528,135.188,579000.0,1882
@@ -1553,7 +1553,7 @@ G-LGI,Deadmans Cay,,,gleam_basin,,W-NA,,BS,BHS,,23.179,-75.094,,3227
 G-LGK,Langkawi,,,gleam_basin,,W-AS,,MY,MYS,,6.33,99.729,,183
 G-LGP,Legaspi,,,gleam_basin,,W-AS,,PH,PHL,,13.158,123.735,179000.0,609
 G-LGQ,Lago Agrio,,,gleam_basin,,W-SA,,EC,ECU,,,,,1467
-G-LHE,Lahore,,,gleam_basin,,W-AS,,PK,PAK,,31.522,74.404,6577000.0,115
+G-LHE,Lahore,,,gleam_basin,,W-AS,,PK,PAK,,31.522,74.404,16400000.0,115
 G-LHR,London (UK),,,gleam_basin,,W-EU,,GB,GBR,,51.471,-0.462,,791
 G-LHW,Lanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,36.515,103.62,2561000.0,343
 G-LIF,Lifou,,,gleam_basin,,W-OC,,NC,NCL,,-20.775,167.24,,3169
@@ -1655,7 +1655,7 @@ G-LYC,Lycksele,,,gleam_basin,,W-EU,,SE,SWE,,64.548,18.716,,2555
 G-LYG,Lianyungang,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,34.572,118.874,687000.0,380
 G-LYH,Lynchburg,,,gleam_basin,,W-NA,,US,USA,US-VA,37.327,-79.2,125000.0,2247
 G-LYI,Linyi,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,35.046,118.412,2081999.0,382
-G-LYP,Faisalabad,,,gleam_basin,,W-AS,,PK,PAK,,31.365,72.995,2617000.0,118
+G-LYP,Faisalabad,,,gleam_basin,,W-AS,,PK,PAK,,31.365,72.995,30800000.0,118
 G-LYR,Longyearbyen,,,gleam_basin,,W-EU,,SJ,SJM,,78.246,15.466,2000.0,1700
 G-LYS,Lyon,,,gleam_basin,,W-EU,,FR,FRA,,45.726,5.081,1423000.0,1513
 G-LYX,Lydd,,,gleam_basin,,W-EU,,GB,GBR,,50.956,0.939,,775
@@ -1743,7 +1743,7 @@ G-MII,Marilia,,,gleam_basin,,W-SA,,BR,BRA,,-22.197,-49.926,212000.0,1964
 G-MIM,Merimbula,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.909,149.901,6000.0,1609
 G-MIS,Misima Island,,,gleam_basin,,W-OC,,PG,PNG,,-10.689,152.838,,2990
 G-MIU,Maiduguri,,,gleam_basin,,W-AF,,NG,NGA,,11.855,13.081,896000.0,1419
-G-MJD,Mohenjodaro,,,gleam_basin,,W-AS,,PK,PAK,,27.335,68.143,,122
+G-MJD,Mohenjodaro,,,gleam_basin,,W-AS,,PK,PAK,,27.335,68.143,4500000.0,122
 G-MJF,Mosjoen,,,gleam_basin,,W-EU,,NO,NOR,,65.784,13.215,,1151
 G-MJM,Mbuji-Mayi,,,gleam_basin,,W-AF,,CD,COD,,-6.121,23.569,1295000.0,1339
 G-MJN,Mahajanga,,,gleam_basin,,W-AF,,MG,MDG,,-15.667,46.351,155000.0,1450
@@ -1849,7 +1849,7 @@ G-MUC,Munich,,,gleam_basin,,W-EU,,DE,DEU,,48.354,11.786,1275000.0,748
 G-MUH,Mersa Matruh,,,gleam_basin,,W-AF,,EG,EGY,,31.325,27.222,62000.0,48
 G-MUN,Maturin,,,gleam_basin,,W-SA,,VE,VEN,,9.755,-63.147,411000.0,1719
 G-MUW,Mascara,,,gleam_basin,,W-AF,,DZ,DZA,,35.208,0.147,108000.0,44
-G-MUX,Multan,,,gleam_basin,,W-AS,,PK,PAK,,30.203,71.419,1522000.0,131
+G-MUX,Multan,,,gleam_basin,,W-AS,,PK,PAK,,30.203,71.419,12600000.0,131
 G-MVD,Montevideo,,,gleam_basin,,W-SA,,UY,URY,,-34.838,-56.031,1513000.0,519
 G-MVP,Mitu,,,gleam_basin,,W-SA,,CO,COL,,1.254,-70.234,6000.0,1393
 G-MVR,Maroua,,,gleam_basin,,W-AF,,CM,CMR,,10.451,14.257,320000.0,809
@@ -1989,7 +1989,7 @@ G-NZH,Manzhouli,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,49.567,117.33,94000.0,359
 G-OAG,Orange,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.382,149.133,141000.0,1663
 G-OAJ,Jacksonville (US-NC),,,gleam_basin,,W-NA,,US,USA,US-NC,34.829,-77.612,,2095
 G-OAL,Cacoal,,,gleam_basin,,W-SA,,BR,BRA,,-11.496,-61.451,56000.0,1950
-G-OAX,Oaxaca,,,gleam_basin,,W-NA,,MX,MEX,,17.0,-96.727,531000.0,1019
+G-OAX,Oaxaca,,,gleam_basin,,W-NA,,MX,MEX,,17,-96.727,531000.0,1019
 G-OAZ,Camp Bastion,,,gleam_basin,,W-AS,,AF,AFG,,31.864,64.225,,895
 G-OBN,Oban,,,gleam_basin,,W-EU,,GB,GBR,,56.464,-5.4,,768
 G-OBO,Obihiro,,,gleam_basin,,W-AS,,JP,JPN,,42.733,143.217,174000.0,3155
@@ -2105,7 +2105,7 @@ G-PER,Perth,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-31.94,115.967,1532000.0,1615
 G-PES,Petrozavodsk,,,gleam_basin,,W-EU,,RU,RUS,,61.885,34.155,265000.0,1850
 G-PET,Pelotas,,,gleam_basin,,W-SA,,BR,BRA,,-31.718,-52.328,321000.0,1981
 G-PEU,Puerto Lempira,,,gleam_basin,,W-NA,,HN,HND,,15.262,-83.781,5000.0,1193
-G-PEW,Peshawar,,,gleam_basin,,W-AS,,PK,PAK,,33.994,71.515,1303000.0,119
+G-PEW,Peshawar,,,gleam_basin,,W-AS,,PK,PAK,,33.994,71.515,12300000.0,119
 G-PEX,Pechora,,,gleam_basin,,W-EU,,RU,RUS,,65.121,57.131,46000.0,1930
 G-PEZ,Penza,,,gleam_basin,,W-EU,,RU,RUS,,53.111,45.021,513000.0,1841
 G-PFB,Passo Fundo,,,gleam_basin,,W-SA,,BR,BRA,,-28.244,-52.327,180000.0,1989
@@ -2133,7 +2133,7 @@ G-PIT,Pittsburgh,,,gleam_basin,,W-NA,,US,USA,US-PA,40.492,-80.233,1715000.0,2125
 G-PIU,Piura,,,gleam_basin,,W-SA,,PE,PER,,-5.206,-80.616,397000.0,1213
 G-PIZ,Point Lay,,,gleam_basin,,W-NA,,US,USA,US-AK,69.733,-163.005,,2362
 G-PJA,Pajala,,,gleam_basin,,W-EU,,SE,SWE,,67.246,23.069,,2565
-G-PJG,Panjgur,,,gleam_basin,,W-AS,,PK,PAK,,26.955,64.132,316385.0,113
+G-PJG,Panjgur,,,gleam_basin,,W-AS,,PK,PAK,,26.955,64.132,723000.0,113
 G-PJM,Puerto Jimenez,,,gleam_basin,,W-NA,,CR,CRI,,8.533,-83.3,,804
 G-PKB,Parkersburg,,,gleam_basin,,W-NA,,US,USA,US-WV,39.345,-81.439,64000.0,2440
 G-PKC,Petropavlovsk (RU),,,gleam_basin,,W-EU,,RU,RUS,,53.168,158.454,,1907
@@ -2241,7 +2241,7 @@ G-PXU,Pleiku,,,gleam_basin,,W-AS,,VN,VNM,,14.005,108.017,143000.0,1128
 G-PYH,Puerto Ayacucho,,,gleam_basin,,W-SA,,VE,VEN,,5.62,-67.606,53000.0,1712
 G-PYJ,Polyarny,,,gleam_basin,,W-EU,,RU,RUS,,66.4,112.03,,1868
 G-PZB,Pietermaritzburg,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.649,30.399,751000.0,634
-G-PZH,Zhob,,,gleam_basin,,W-AS,,PK,PAK,,31.358,69.464,88000.0,124
+G-PZH,Zhob,,,gleam_basin,,W-AS,,PK,PAK,,31.358,69.464,2000000.0,124
 G-PZI,Panzhihua,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,26.54,101.799,691000.0,417
 G-PZO,Puerto Ordaz,,,gleam_basin,,W-SA,,VE,VEN,,8.289,-62.76,,1713
 G-PZU,Port Sudan,,,gleam_basin,,W-AF,,SD,SDN,,19.434,37.234,490000.0,3016
@@ -2298,7 +2298,7 @@ G-RHD,Rio Hondo,,,gleam_basin,,W-SA,,AR,ARG,,-27.497,-64.936,5000.0,3217
 G-RHI,Rhinelander,,,gleam_basin,,W-NA,,US,USA,US-WI,45.631,-89.467,9000.0,2513
 G-RHO,Rhodes,,,gleam_basin,,W-EU,,GR,GRC,,36.405,28.086,,914
 G-RIA,Santa Maria,,,gleam_basin,,W-SA,,BR,BRA,,-29.711,-53.688,249000.0,1979
-G-RIB,Riberalta,,,gleam_basin,,W-SA,,BO,BOL,,-11.0,-66.0,74000.0,92
+G-RIB,Riberalta,,,gleam_basin,,W-SA,,BO,BOL,,-11,-66,74000.0,92
 G-RIC,Richmond (US),,,gleam_basin,,W-NA,,US,USA,US-VA,37.505,-77.32,,2223
 G-RIS,Rishiri,,,gleam_basin,,W-AS,,JP,JPN,,45.242,141.186,,3118
 G-RIW,Riverton,,,gleam_basin,,W-NA,,US,USA,US-UT,43.064,-108.46,43000.0,2220
@@ -2364,7 +2364,7 @@ G-RVN,Rovaniemi,,,gleam_basin,,W-EU,,FI,FIN,,66.565,25.83,35000.0,499
 G-RVT,Ravensthorpe,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.797,120.208,1000.0,1590
 G-RVV,Raivavae,,,gleam_basin,,W-OC,,PF,PYF,,-23.885,-147.662,,681
 G-RYG,Moss,,,gleam_basin,,W-EU,,NO,NOR,,59.379,10.785,37000.0,1158
-G-RYK,Rahim Yar Khan,,,gleam_basin,,W-AS,,PK,PAK,,28.384,70.28,789000.0,114
+G-RYK,Rahim Yar Khan,,,gleam_basin,,W-AS,,PK,PAK,,28.384,70.28,6800000.0,114
 G-RZE,Rzeszow,,,gleam_basin,,W-EU,,PL,POL,,50.11,22.019,246000.0,2850
 G-RZR,Ramsar,,,gleam_basin,,W-AS,,IR,IRN,,36.91,50.68,,2928
 G-SAF,Santa Fe (US),,,gleam_basin,,W-NA,,US,USA,US-NM,35.617,-106.089,,2391
@@ -2405,7 +2405,7 @@ G-SDL,Sundsvall,,,gleam_basin,,W-EU,,SE,SWE,,62.528,17.444,73000.0,2554
 G-SDP,Sand Point,,,gleam_basin,,W-NA,,US,USA,US-AK,55.315,-160.523,,2240
 G-SDQ,Santo Domingo (DO),,,gleam_basin,,W-NA,,DO,DOM,,18.43,-69.669,,1201
 G-SDR,Santander,,,gleam_basin,,W-EU,,ES,ESP,,43.427,-3.82,209000.0,2890
-G-SDT,Saidu Sharif,,,gleam_basin,,W-AS,,PK,PAK,,34.814,72.353,1860000.0,117
+G-SDT,Saidu Sharif,,,gleam_basin,,W-AS,,PK,PAK,,34.814,72.353,8500000.0,117
 G-SDY,Sidney,,,gleam_basin,,W-NA,,US,USA,US-OH,47.707,-104.193,21000.0,2326
 G-SEA,Seattle,,,gleam_basin,,W-NA,,US,USA,US-WA,47.449,-122.309,3644000.0,2429
 G-SEB,Sebha,,,gleam_basin,,W-AF,,LY,LBY,,26.987,14.472,,156
@@ -2463,10 +2463,10 @@ G-SKH,Surkhet,,,gleam_basin,,W-AS,,NP,NPL,,28.586,81.636,,562
 G-SKK,Shaktoolik,,,gleam_basin,,W-NA,,US,USA,US-AK,64.371,-161.224,,2342
 G-SKO,Sokoto,,,gleam_basin,,W-AF,,NG,NGA,,12.916,5.207,732000.0,1422
 G-SKP,Skopje,,,gleam_basin,,W-EU,,MK,MKD,,41.962,21.621,494000.0,1327
-G-SKT,Sialkot,,,gleam_basin,,W-AS,,PK,PAK,,32.536,74.364,477000.0,125
+G-SKT,Sialkot,,,gleam_basin,,W-AS,,PK,PAK,,32.536,74.364,15500000.0,125
 G-SKU,Skyros,,,gleam_basin,,W-EU,,GR,GRC,,38.968,24.487,,926
 G-SKX,Saransk,,,gleam_basin,,W-EU,,RU,RUS,,54.125,45.212,303000.0,1881
-G-SKZ,Sukkur,,,gleam_basin,,W-AS,,PK,PAK,,27.722,68.792,418000.0,110
+G-SKZ,Sukkur,,,gleam_basin,,W-AS,,PK,PAK,,27.722,68.792,3800000.0,110
 G-SLA,Salta,,,gleam_basin,,W-SA,,AR,ARG,,-24.856,-65.486,513000.0,3214
 G-SLC,Salt Lake City,,,gleam_basin,,W-NA,,US,USA,US-UT,40.788,-111.978,1098000.0,2303
 G-SLD,Sliac,,,gleam_basin,,W-EU,,SK,SVK,,48.638,19.134,,2815
@@ -2541,7 +2541,7 @@ G-SUF,Lamezia Terme,,,gleam_basin,,W-EU,,IT,ITA,,38.905,16.242,71000.0,3072
 G-SUG,Surigao,,,gleam_basin,,W-AS,,PH,PHL,,9.756,125.481,88000.0,598
 G-SUJ,Satu Mare,,,gleam_basin,,W-EU,,RO,ROU,,47.703,22.886,112000.0,142
 G-SUK,Sakkyryr,,,gleam_basin,,W-EU,,RU,RUS,,67.792,130.394,,1816
-G-SUL,Sui,,,gleam_basin,,W-AS,,PK,PAK,,28.645,69.177,119983.0,112
+G-SUL,Sui,,,gleam_basin,,W-AS,,PK,PAK,,28.645,69.177,3100000.0,112
 G-SUN,Sun Valley,,,gleam_basin,,W-NA,,US,USA,US-NV,43.504,-114.296,21000.0,2145
 G-SUR,Summer Beaver,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.709,-88.542,,2612
 G-SUT,Sumbawanga,,,gleam_basin,,W-AF,,TZ,TZA,,,,89000.0,202
@@ -2752,7 +2752,7 @@ G-TUC,Tucuman,,,gleam_basin,,W-SA,,AR,ARG,,-26.841,-65.105,,3184
 G-TUF,Tours,,,gleam_basin,,W-EU,,FR,FRA,,47.432,0.728,236000.0,1495
 G-TUG,Tuguegarao,,,gleam_basin,,W-AS,,PH,PHL,,17.643,121.733,115000.0,592
 G-TUI,Turaif,,,gleam_basin,,W-AS,,SA,SAU,,31.692,38.732,41000.0,246
-G-TUK,Turbat,,,gleam_basin,,W-AS,,PK,PAK,,25.986,63.03,148000.0,109
+G-TUK,Turbat,,,gleam_basin,,W-AS,,PK,PAK,,25.986,63.03,643000.0,109
 G-TUL,Tulsa,,,gleam_basin,,W-NA,,US,USA,US-OK,36.198,-95.888,672000.0,2099
 G-TUN,Tunis,,,gleam_basin,,W-AF,,TN,TUN,,36.851,10.227,2413000.0,1790
 G-TUO,Taupo,,,gleam_basin,,W-OC,,NZ,NZL,,-38.74,176.084,23000.0,3043
@@ -2790,7 +2790,7 @@ G-UDJ,Uzhhorod,,,gleam_basin,,W-EU,,UA,UKR,,48.634,22.263,151000.0,2786
 G-UDR,Udaipur,,,gleam_basin,,W-AS,,IN,IND,,24.618,73.896,470000.0,1086
 G-UEL,Quelimane,,,gleam_basin,,W-AF,,MZ,MOZ,,-17.855,36.869,189000.0,972
 G-UEO,Kume Jima,,,gleam_basin,,W-AS,,JP,JPN,,26.364,126.714,,3124
-G-UET,Quetta,,,gleam_basin,,W-AS,,PK,PAK,,30.251,66.938,768000.0,121
+G-UET,Quetta,,,gleam_basin,,W-AS,,PK,PAK,,30.251,66.938,3600000.0,121
 G-UFA,Ufa,,,gleam_basin,,W-EU,,RU,RUS,,54.557,55.874,1018000.0,1861
 G-UGB,Pilot Point,,,gleam_basin,,W-NA,,US,USA,US-TX,,,4000.0,2537
 G-UGC,Urgench,,,gleam_basin,,W-AS,,UZ,UZB,,41.584,60.642,,2847
@@ -2867,7 +2867,7 @@ G-VDB,Fagernes,,,gleam_basin,,W-EU,,NO,NOR,,61.016,9.288,,1163
 G-VDC,Vitoria Da Conquista,,,gleam_basin,,W-SA,,BR,BRA,,-14.863,-40.863,308000.0,1983
 G-VDE,Valverde,,,gleam_basin,,W-EU,,ES,ESP,,27.815,-17.887,10.0,2892
 G-VDH,Dong Hoi,,,gleam_basin,,W-AS,,VN,VNM,,17.515,106.591,189000.0,1127
-G-VDM,Viedma,,,gleam_basin,,W-SA,,AR,ARG,,-40.869,-63.0,59000.0,3193
+G-VDM,Viedma,,,gleam_basin,,W-SA,,AR,ARG,,-40.869,-63,59000.0,3193
 G-VDZ,Valdez,,,gleam_basin,,W-NA,,US,USA,US-AK,61.134,-146.248,11000.0,2254
 G-VEE,Venetie,,,gleam_basin,,W-NA,,US,USA,US-AK,67.009,-146.366,,2166
 G-VEL,Vernal,,,gleam_basin,,W-NA,,US,USA,US-UT,40.441,-109.51,20000.0,2168
@@ -2960,7 +2960,7 @@ G-WNH,Wenshan,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,,,,464
 G-WNN,Wunnummin Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.894,-89.289,,2763
 G-WNP,Naga,,,gleam_basin,,W-AS,,PH,PHL,,13.585,123.27,29000.0,618
 G-WNR,Windorah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.413,142.667,0.0,1675
-G-WNS,Nawabshah,,,gleam_basin,,W-AS,,PK,PAK,,26.219,68.39,230000.0,132
+G-WNS,Nawabshah,,,gleam_basin,,W-AS,,PK,PAK,,26.219,68.39,3900000.0,132
 G-WNZ,Wenzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,27.912,120.852,2350000.0,465
 G-WRE,Whangarei,,,gleam_basin,,W-OC,,NZ,NZL,,-35.768,174.365,52000.0,3058
 G-WRL,Worland,,,gleam_basin,,W-NA,,US,USA,US-WY,43.966,-107.951,5000.0,2390

--- a/regions-gleam.csv
+++ b/regions-gleam.csv
@@ -2,3251 +2,3251 @@ Code,Name,OfficialName,OtherNames,Level,M49Code,ContinentCode,SubregionCode,Coun
 G-AAA,Anaa,,,gleam_basin,,W-OC,,PF,PYF,,-17.353,-145.51,,710
 G-AAB,Arrabury,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,,,,1668
 G-AAC,El Arish,,,gleam_basin,,W-AF,,EG,EGY,,31.073,33.836,,59
-G-AAE,Annaba,,,gleam_basin,,W-AF,,DZ,DZA,,36.822,7.809,504000.0,45
-G-AAL,Aalborg,,,gleam_basin,,W-EU,,DK,DNK,,57.093,9.849,122000.0,1565
-G-AAN,Al Ain,,,gleam_basin,,W-AS,,AE,ARE,,24.262,55.609,409000.0,3180
-G-AAQ,Anapa,,,gleam_basin,,W-EU,,RU,RUS,,45.002,37.347,54000.0,1913
-G-AAR,Aarhus,,,gleam_basin,,W-EU,,DK,DNK,,56.3,10.619,238000.0,1566
-G-AAT,Altay,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,47.75,88.086,142000.0,459
-G-AAX,Araxa,,,gleam_basin,,W-SA,,BR,BRA,,-19.563,-46.96,83000.0,2023
+G-AAE,Annaba,,,gleam_basin,,W-AF,,DZ,DZA,,36.822,7.809,504000,45
+G-AAL,Aalborg,,,gleam_basin,,W-EU,,DK,DNK,,57.093,9.849,122000,1565
+G-AAN,Al Ain,,,gleam_basin,,W-AS,,AE,ARE,,24.262,55.609,409000,3180
+G-AAQ,Anapa,,,gleam_basin,,W-EU,,RU,RUS,,45.002,37.347,54000,1913
+G-AAR,Aarhus,,,gleam_basin,,W-EU,,DK,DNK,,56.3,10.619,238000,1566
+G-AAT,Altay,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,47.75,88.086,142000,459
+G-AAX,Araxa,,,gleam_basin,,W-SA,,BR,BRA,,-19.563,-46.96,83000,2023
 G-AAY,Al Ghaydah,,,gleam_basin,,W-AS,,YE,YEM,,16.192,52.175,,587
-G-ABA,Abakan,,,gleam_basin,,W-EU,,RU,RUS,,53.74,91.385,167000.0,1901
-G-ABB,Asaba,,,gleam_basin,,W-AF,,NG,NGA,,6.204,6.665,73000.0,1425
-G-ABD,Abadan,,,gleam_basin,,W-AS,,IR,IRN,,30.371,48.228,41000.0,2962
+G-ABA,Abakan,,,gleam_basin,,W-EU,,RU,RUS,,53.74,91.385,167000,1901
+G-ABB,Asaba,,,gleam_basin,,W-AF,,NG,NGA,,6.204,6.665,73000,1425
+G-ABD,Abadan,,,gleam_basin,,W-AS,,IR,IRN,,30.371,48.228,41000,2962
 G-ABE,Lehigh Valley,,,gleam_basin,,W-NA,,US,USA,US-PA,40.652,-75.441,,2415
-G-ABI,Abilene,,,gleam_basin,,W-NA,,US,USA,US-TX,32.411,-99.682,115000.0,2416
-G-ABJ,Abidjan,,,gleam_basin,,W-AF,,CI,CIV,,5.261,-3.926,3802000.0,2050
+G-ABI,Abilene,,,gleam_basin,,W-NA,,US,USA,US-TX,32.411,-99.682,115000,2416
+G-ABJ,Abidjan,,,gleam_basin,,W-AF,,CI,CIV,,5.261,-3.926,3802000,2050
 G-ABK,Kebri Dehar,,,gleam_basin,,W-AF,,ET,ETH,,6.734,44.253,,240
-G-ABL,Ambler,,,gleam_basin,,W-NA,,US,USA,US-PA,67.106,-157.857,7000.0,2486
-G-ABQ,Albuquerque,,,gleam_basin,,W-NA,,US,USA,US-NM,35.04,-106.609,759000.0,2417
+G-ABL,Ambler,,,gleam_basin,,W-NA,,US,USA,US-PA,67.106,-157.857,7000,2486
+G-ABQ,Albuquerque,,,gleam_basin,,W-NA,,US,USA,US-NM,35.04,-106.609,759000,2417
 G-ABR,Aberdeen (US),,,gleam_basin,,W-NA,,US,USA,US-SD,45.449,-98.422,,2418
 G-ABS,Abu Simbel,,,gleam_basin,,W-AF,,EG,EGY,,22.376,31.612,,57
 G-ABT,Al Baha,,,gleam_basin,,W-AS,,SA,SAU,,20.296,41.634,,263
-G-ABU,Atambua,,,gleam_basin,,W-AS,,ID,IDN,,,,36000.0,1297
-G-ABV,Abuja,,,gleam_basin,,W-AF,,NG,NGA,,9.007,7.263,1576000.0,1426
-G-ABX,Albury,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.068,146.958,104000.0,1660
+G-ABU,Atambua,,,gleam_basin,,W-AS,,ID,IDN,,,,36000,1297
+G-ABV,Abuja,,,gleam_basin,,W-AF,,NG,NGA,,9.007,7.263,1576000,1426
+G-ABX,Albury,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.068,146.958,104000,1660
 G-ABY,Albany (US-GA),,,gleam_basin,,W-NA,,US,USA,US-GA,31.535,-84.195,,2419
 G-ABZ,Aberdeen (UK),,,gleam_basin,,W-EU,,GB,GBR,,57.202,-2.198,,785
 G-ACA,Acapulco,,,gleam_basin,,W-NA,,MX,MEX,,16.757,-99.754,,1021
-G-ACC,Accra,,,gleam_basin,,W-AF,,GH,GHA,,5.605,-0.167,2121000.0,103
+G-ACC,Accra,,,gleam_basin,,W-AF,,GH,GHA,,5.605,-0.167,2121000,103
 G-ACE,Lanzarote,,,gleam_basin,,W-EU,,ES,ESP,,28.945,-13.605,,2902
 G-ACH,Altenrhein,,,gleam_basin,,W-EU,,CH,CHE,,47.485,9.561,,278
-G-ACP,Maragheh,,,gleam_basin,,W-AS,,IR,IRN,,37.348,46.128,151000.0,2959
+G-ACP,Maragheh,,,gleam_basin,,W-AS,,IR,IRN,,37.348,46.128,151000,2959
 G-ACR,Araracuara,,,gleam_basin,,W-SA,,CO,COL,,-0.583,-72.408,,1391
-G-ACT,Waco,,,gleam_basin,,W-NA,,US,USA,US-TX,31.611,-97.23,188000.0,2370
+G-ACT,Waco,,,gleam_basin,,W-NA,,US,USA,US-TX,31.611,-97.23,188000,2370
 G-ACU,Achutupo,,,gleam_basin,,W-NA,,PA,PAN,,,,,3008
-G-ACV,Arcata,,,gleam_basin,,W-NA,,US,USA,US-CA,40.978,-124.109,34000.0,2369
-G-ACX,Xingyi,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,25.086,104.959,816000.0,437
-G-ACY,Atlantic City,,,gleam_basin,,W-NA,,US,USA,US-NJ,39.458,-74.577,241000.0,2371
-G-ACZ,Zabol,,,gleam_basin,,W-AS,,IR,IRN,,31.098,61.544,234000.0,2960
-G-ADA,Adana,,,gleam_basin,,W-AS,,TR,TUR,,36.982,35.28,1293000.0,1759
-G-ADB,Izmir,,,gleam_basin,,W-AS,,TR,TUR,,38.292,27.157,2587000.0,1746
-G-ADD,Addis Ababa,,,gleam_basin,,W-AF,,ET,ETH,,8.978,38.799,3100000.0,228
-G-ADE,Aden,,,gleam_basin,,W-AS,,YE,YEM,,12.83,45.029,1000000.0,579
-G-ADF,Adiyaman,,,gleam_basin,,W-AS,,TR,TUR,,37.731,38.469,224000.0,1745
-G-ADH,Aldan,,,gleam_basin,,W-EU,,RU,RUS,,58.603,125.409,24000.0,1819
+G-ACV,Arcata,,,gleam_basin,,W-NA,,US,USA,US-CA,40.978,-124.109,34000,2369
+G-ACX,Xingyi,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,25.086,104.959,816000,437
+G-ACY,Atlantic City,,,gleam_basin,,W-NA,,US,USA,US-NJ,39.458,-74.577,241000,2371
+G-ACZ,Zabol,,,gleam_basin,,W-AS,,IR,IRN,,31.098,61.544,234000,2960
+G-ADA,Adana,,,gleam_basin,,W-AS,,TR,TUR,,36.982,35.28,1293000,1759
+G-ADB,Izmir,,,gleam_basin,,W-AS,,TR,TUR,,38.292,27.157,2587000,1746
+G-ADD,Addis Ababa,,,gleam_basin,,W-AF,,ET,ETH,,8.978,38.799,3100000,228
+G-ADE,Aden,,,gleam_basin,,W-AS,,YE,YEM,,12.83,45.029,1000000,579
+G-ADF,Adiyaman,,,gleam_basin,,W-AS,,TR,TUR,,37.731,38.469,224000,1745
+G-ADH,Aldan,,,gleam_basin,,W-EU,,RU,RUS,,58.603,125.409,24000,1819
 G-ADK,Adak Island,,,gleam_basin,,W-NA,,US,USA,US-AK,51.878,-176.646,,2150
-G-ADL,Adelaide,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-34.945,138.531,1145000.0,1595
-G-ADQ,Kodiak,,,gleam_basin,,W-NA,,US,USA,US-AK,57.75,-152.494,9000.0,2483
-G-ADU,Ardabil,,,gleam_basin,,W-AS,,IR,IRN,,38.326,48.424,415000.0,2935
+G-ADL,Adelaide,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-34.945,138.531,1145000,1595
+G-ADQ,Kodiak,,,gleam_basin,,W-NA,,US,USA,US-AK,57.75,-152.494,9000,2483
+G-ADU,Ardabil,,,gleam_basin,,W-AS,,IR,IRN,,38.326,48.424,415000,2935
 G-ADV,Addeain,,,gleam_basin,,W-AF,,SD,SDN,,,,,3012
 G-ADZ,San Andres Island,,,gleam_basin,,W-SA,,CO,COL,,12.584,-81.711,,1369
-G-AEB,Baise,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,23.721,106.96,340000.0,331
+G-AEB,Baise,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,23.721,106.96,340000,331
 G-AEG,Aek Godang,,,gleam_basin,,W-AS,,ID,IDN,,1.4,99.43,,1244
-G-AER,Sochi,,,gleam_basin,,W-EU,,RU,RUS,,43.45,39.957,328000.0,1910
-G-AES,Alesund,,,gleam_basin,,W-EU,,NO,NOR,,62.562,6.12,48000.0,1145
+G-AER,Sochi,,,gleam_basin,,W-EU,,RU,RUS,,43.45,39.957,328000,1910
+G-AES,Alesund,,,gleam_basin,,W-EU,,NO,NOR,,62.562,6.12,48000,1145
 G-AET,Allakaket,,,gleam_basin,,W-NA,,US,USA,US-AK,66.552,-152.622,,2446
 G-AEX,Alexandria (US),,,gleam_basin,,W-NA,,US,USA,US-LA,31.327,-92.55,,2114
-G-AEY,Akureyri,,,gleam_basin,,W-EU,,IS,ISL,,65.66,-18.073,17000.0,1348
-G-AFA,San Rafael,,,gleam_basin,,W-SA,,AR,ARG,,-34.588,-68.404,109000.0,3183
-G-AFL,Alta Floresta,,,gleam_basin,,W-SA,,BR,BRA,,-9.866,-56.105,40000.0,1942
+G-AEY,Akureyri,,,gleam_basin,,W-EU,,IS,ISL,,65.66,-18.073,17000,1348
+G-AFA,San Rafael,,,gleam_basin,,W-SA,,AR,ARG,,-34.588,-68.404,109000,3183
+G-AFL,Alta Floresta,,,gleam_basin,,W-SA,,BR,BRA,,-9.866,-56.105,40000,1942
 G-AFS,Zarafshan,,,gleam_basin,,W-AS,,UZ,UZB,,41.614,64.233,,2836
-G-AFZ,Sabzevar,,,gleam_basin,,W-AS,,IR,IRN,,36.168,57.595,226000.0,2930
-G-AGA,Agadir,,,gleam_basin,,W-AF,,MA,MAR,,30.325,-9.413,825000.0,810
-G-AGB,Augsburg,,,gleam_basin,,W-EU,,DE,DEU,,48.425,10.932,359000.0,724
-G-AGF,Agen,,,gleam_basin,,W-EU,,FR,FRA,,44.175,0.591,58000.0,1489
+G-AFZ,Sabzevar,,,gleam_basin,,W-AS,,IR,IRN,,36.168,57.595,226000,2930
+G-AGA,Agadir,,,gleam_basin,,W-AF,,MA,MAR,,30.325,-9.413,825000,810
+G-AGB,Augsburg,,,gleam_basin,,W-EU,,DE,DEU,,48.425,10.932,359000,724
+G-AGF,Agen,,,gleam_basin,,W-EU,,FR,FRA,,44.175,0.591,58000,1489
 G-AGH,Angelholm,,,gleam_basin,,W-EU,,SE,SWE,,56.296,12.847,,2551
-G-AGP,Malaga,,,gleam_basin,,W-EU,,ES,ESP,,36.675,-4.499,550000.0,2873
-G-AGR,Agra,,,gleam_basin,,W-AS,,IN,IND,,27.156,77.961,1592000.0,1040
+G-AGP,Malaga,,,gleam_basin,,W-EU,,ES,ESP,,36.675,-4.499,550000,2873
+G-AGR,Agra,,,gleam_basin,,W-AS,,IN,IND,,27.156,77.961,1592000,1040
 G-AGS,Augusta (US-GA),,,gleam_basin,,W-NA,,US,USA,US-GA,33.37,-81.965,,2055
-G-AGT,Ciudad del Este,,,gleam_basin,,W-SA,,PY,PRY,,-25.455,-54.843,321000.0,243
-G-AGU,Aguascalientes,,,gleam_basin,,W-NA,,MX,MEX,,21.706,-102.318,869000.0,980
+G-AGT,Ciudad del Este,,,gleam_basin,,W-SA,,PY,PRY,,-25.455,-54.843,321000,243
+G-AGU,Aguascalientes,,,gleam_basin,,W-NA,,MX,MEX,,21.706,-102.318,869000,980
 G-AGX,Agatti Island,,,gleam_basin,,W-AS,,IN,IND,,10.824,72.176,,1039
-G-AHB,Abha,,,gleam_basin,,W-AS,,SA,SAU,,18.24,42.657,211000.0,259
+G-AHB,Abha,,,gleam_basin,,W-AS,,SA,SAU,,18.24,42.657,211000,259
 G-AHN,Athens (US),,,gleam_basin,,W-NA,,US,USA,US-GA,33.949,-83.326,,2278
-G-AHO,Alghero,,,gleam_basin,,W-EU,,IT,ITA,,40.632,8.291,34000.0,3084
-G-AHU,Al Hoceima,,,gleam_basin,,W-AF,,MA,MAR,,35.177,-3.84,396000.0,818
-G-AIA,Alliance,,,gleam_basin,,W-NA,,US,USA,US-OH,42.053,-102.804,32000.0,2238
+G-AHO,Alghero,,,gleam_basin,,W-EU,,IT,ITA,,40.632,8.291,34000,3084
+G-AHU,Al Hoceima,,,gleam_basin,,W-AF,,MA,MAR,,35.177,-3.84,396000,818
+G-AIA,Alliance,,,gleam_basin,,W-NA,,US,USA,US-OH,42.053,-102.804,32000,2238
 G-AIN,Wainwright,,,gleam_basin,,W-NA,,US,USA,US-AK,70.638,-159.995,,2292
 G-AIT,Aitutaki Island,,,gleam_basin,,W-OC,,CK,COK,,-18.831,-159.764,,1355
 G-AIU,Atiu Island,,,gleam_basin,,W-OC,,CK,COK,,-19.968,-158.119,,1357
-G-AJA,Ajaccio,,,gleam_basin,,W-EU,,FR,FRA,,41.924,8.803,54000.0,1499
+G-AJA,Ajaccio,,,gleam_basin,,W-EU,,FR,FRA,,41.924,8.803,54000,1499
 G-AJF,Jouf,,,gleam_basin,,W-AS,,SA,SAU,,29.785,40.1,,251
-G-AJI,Agri,,,gleam_basin,,W-AS,,TR,TUR,,39.655,43.026,88000.0,1756
-G-AJL,Aizawl,,,gleam_basin,,W-AS,,IN,IND,,23.841,92.62,283000.0,1072
+G-AJI,Agri,,,gleam_basin,,W-AS,,TR,TUR,,39.655,43.026,88000,1756
+G-AJL,Aizawl,,,gleam_basin,,W-AS,,IN,IND,,23.841,92.62,283000,1072
 G-AJN,Anjouan,,,gleam_basin,,W-AF,,KM,COM,,-12.132,44.43,,1359
 G-AJR,Arvidsjaur,,,gleam_basin,,W-EU,,SE,SWE,,65.59,19.282,,2550
-G-AJU,Aracaju,,,gleam_basin,,W-SA,,BR,BRA,,-10.984,-37.07,685000.0,1977
-G-AJY,Agadez,,,gleam_basin,,W-AF,,NE,NER,,16.966,8,118000.0,71
+G-AJU,Aracaju,,,gleam_basin,,W-SA,,BR,BRA,,-10.984,-37.07,685000,1977
+G-AJY,Agadez,,,gleam_basin,,W-AF,,NE,NER,,16.966,8,118000,71
 G-AKB,Atka,,,gleam_basin,,W-NA,,US,USA,US-AK,52.22,-174.206,,2178
 G-AKF,Kufra,,,gleam_basin,,W-AF,,LY,LBY,,24.179,23.314,,157
-G-AKJ,Asahikawa,,,gleam_basin,,W-AS,,JP,JPN,,43.671,142.447,357000.0,3111
-G-AKL,Auckland,,,gleam_basin,,W-OC,,NZ,NZL,,-37.008,174.792,1377000.0,3046
+G-AKJ,Asahikawa,,,gleam_basin,,W-AS,,JP,JPN,,43.671,142.447,357000,3111
+G-AKL,Auckland,,,gleam_basin,,W-OC,,NZ,NZL,,-37.008,174.792,1377000,3046
 G-AKN,King Salmon,,,gleam_basin,,W-NA,,US,USA,US-AK,58.677,-156.649,,2385
 G-AKP,Anaktuvuk Pass,,,gleam_basin,,W-NA,,US,USA,US-AK,68.134,-151.743,,2177
 G-AKS,Auki,,,gleam_basin,,W-OC,,SB,SLB,,-8.703,160.682,,3025
-G-AKU,Aksu,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.263,80.292,340000.0,351
+G-AKU,Aksu,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.263,80.292,340000,351
 G-AKV,Akulivik,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,60.819,-78.149,,2627
-G-AKX,Aktobe,,,gleam_basin,,W-AS,,KZ,KAZ,,50.246,57.207,313000.0,659
-G-AKY,Sittwe,,,gleam_basin,,W-AS,,MM,MMR,,20.133,92.873,179000.0,873
-G-ALA,Almaty,,,gleam_basin,,W-AS,,KZ,KAZ,,43.352,77.04,1209000.0,668
+G-AKX,Aktobe,,,gleam_basin,,W-AS,,KZ,KAZ,,50.246,57.207,313000,659
+G-AKY,Sittwe,,,gleam_basin,,W-AS,,MM,MMR,,20.133,92.873,179000,873
+G-ALA,Almaty,,,gleam_basin,,W-AS,,KZ,KAZ,,43.352,77.04,1209000,668
 G-ALB,Albany (US-NY),,,gleam_basin,,W-NA,,US,USA,US-NY,42.748,-73.802,,2408
-G-ALC,Alicante,,,gleam_basin,,W-EU,,ES,ESP,,38.282,-0.558,316000.0,2904
-G-ALF,Alta,,,gleam_basin,,W-EU,,NO,NOR,,69.976,23.372,12000.0,1164
-G-ALG,Algiers,,,gleam_basin,,W-AF,,DZ,DZA,,36.691,3.215,3354000.0,43
-G-ALH,Albany,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-34.943,117.809,597000.0,1656
-G-ALO,Waterloo,,,gleam_basin,,W-NA,,US,USA,US-IA,42.557,-92.4,112000.0,2407
-G-ALP,Aleppo,,,gleam_basin,,W-AS,,SY,SYR,,36.181,37.224,2738000.0,652
-G-ALS,Alamosa,,,gleam_basin,,W-NA,,US,USA,US-CO,37.435,-105.867,11000.0,2410
-G-ALW,Walla Walla,,,gleam_basin,,W-NA,,US,USA,US-WA,46.095,-118.288,58000.0,2409
-G-AMA,Amarillo,,,gleam_basin,,W-NA,,US,USA,US-TX,35.219,-101.706,206000.0,2368
-G-AMD,Ahmedabad,,,gleam_basin,,W-AS,,IN,IND,,23.077,72.635,3720000.0,1101
+G-ALC,Alicante,,,gleam_basin,,W-EU,,ES,ESP,,38.282,-0.558,316000,2904
+G-ALF,Alta,,,gleam_basin,,W-EU,,NO,NOR,,69.976,23.372,12000,1164
+G-ALG,Algiers,,,gleam_basin,,W-AF,,DZ,DZA,,36.691,3.215,3354000,43
+G-ALH,Albany,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-34.943,117.809,597000,1656
+G-ALO,Waterloo,,,gleam_basin,,W-NA,,US,USA,US-IA,42.557,-92.4,112000,2407
+G-ALP,Aleppo,,,gleam_basin,,W-AS,,SY,SYR,,36.181,37.224,2738000,652
+G-ALS,Alamosa,,,gleam_basin,,W-NA,,US,USA,US-CO,37.435,-105.867,11000,2410
+G-ALW,Walla Walla,,,gleam_basin,,W-NA,,US,USA,US-WA,46.095,-118.288,58000,2409
+G-AMA,Amarillo,,,gleam_basin,,W-NA,,US,USA,US-TX,35.219,-101.706,206000,2368
+G-AMD,Ahmedabad,,,gleam_basin,,W-AS,,IN,IND,,23.077,72.635,3720000,1101
 G-AMF,Ama,,,gleam_basin,,W-OC,,PG,PNG,,,,,2992
-G-AMH,Arba Minch,,,gleam_basin,,W-AF,,ET,ETH,,6.039,37.59,70000.0,237
-G-AMM,Amman,,,gleam_basin,,W-AS,,JO,JOR,,31.723,35.993,1060000.0,151
-G-AMQ,Ambon,,,gleam_basin,,W-AS,,ID,IDN,,-3.71,128.089,356000.0,1285
-G-AMS,Amsterdam,,,gleam_basin,,W-EU,,NL,NLD,,52.309,4.764,1030999.0,837
-G-AMV,Amderma,,,gleam_basin,,W-EU,,RU,RUS,,69.763,61.556,0.0,1889
-G-ANC,Anchorage,,,gleam_basin,,W-NA,,US,USA,US-AK,61.174,-149.996,253000.0,2346
-G-ANE,Angers,,,gleam_basin,,W-EU,,FR,FRA,,47.56,-0.312,188000.0,1533
-G-ANF,Antofagasta,,,gleam_basin,,W-SA,,CL,CHL,,-23.445,-70.445,310000.0,302
+G-AMH,Arba Minch,,,gleam_basin,,W-AF,,ET,ETH,,6.039,37.59,70000,237
+G-AMM,Amman,,,gleam_basin,,W-AS,,JO,JOR,,31.723,35.993,1060000,151
+G-AMQ,Ambon,,,gleam_basin,,W-AS,,ID,IDN,,-3.71,128.089,356000,1285
+G-AMS,Amsterdam,,,gleam_basin,,W-EU,,NL,NLD,,52.309,4.764,1030999,837
+G-AMV,Amderma,,,gleam_basin,,W-EU,,RU,RUS,,69.763,61.556,0,1889
+G-ANC,Anchorage,,,gleam_basin,,W-NA,,US,USA,US-AK,61.174,-149.996,253000,2346
+G-ANE,Angers,,,gleam_basin,,W-EU,,FR,FRA,,47.56,-0.312,188000,1533
+G-ANF,Antofagasta,,,gleam_basin,,W-SA,,CL,CHL,,-23.445,-70.445,310000,302
 G-ANI,Aniak,,,gleam_basin,,W-NA,,US,USA,US-AK,61.582,-159.543,,2347
-G-ANM,Antalaha,,,gleam_basin,,W-AF,,MG,MDG,,-14.999,50.32,47000.0,1453
-G-ANS,Andahuaylas,,,gleam_basin,,W-SA,,PE,PER,,-13.706,-73.35,17000.0,1225
+G-ANM,Antalaha,,,gleam_basin,,W-AF,,MG,MDG,,-14.999,50.32,47000,1453
+G-ANS,Andahuaylas,,,gleam_basin,,W-SA,,PE,PER,,-13.706,-73.35,17000,1225
 G-ANU,Antigua,,,gleam_basin,,W-NA,,AG,ATG,,17.137,-61.793,,1180
 G-ANX,Andenes,,,gleam_basin,,W-EU,,NO,NOR,,69.293,16.144,,1160
-G-AOE,Eskisehir,,,gleam_basin,,W-AS,,TR,TUR,,39.81,30.519,515000.0,1767
-G-AOG,Anshan,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.105,122.854,1639000.0,406
-G-AOI,Ancona,,,gleam_basin,,W-EU,,IT,ITA,,43.616,13.362,101000.0,3089
-G-AOJ,Aomori,,,gleam_basin,,W-AS,,JP,JPN,,40.735,140.691,298000.0,3128
+G-AOE,Eskisehir,,,gleam_basin,,W-AS,,TR,TUR,,39.81,30.519,515000,1767
+G-AOG,Anshan,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.105,122.854,1639000,406
+G-AOI,Ancona,,,gleam_basin,,W-EU,,IT,ITA,,43.616,13.362,101000,3089
+G-AOJ,Aomori,,,gleam_basin,,W-AS,,JP,JPN,,40.735,140.691,298000,3128
 G-AOK,Karpathos,,,gleam_basin,,W-EU,,GR,GRC,,35.421,27.146,,922
-G-AOR,Alor Setar,,,gleam_basin,,W-AS,,MY,MYS,,6.19,100.398,336000.0,180
-G-APL,Nampula,,,gleam_basin,,W-AF,,MZ,MOZ,,-15.106,39.282,389000.0,963
-G-APN,Alpena,,,gleam_basin,,W-NA,,US,USA,US-MI,45.078,-83.56,14000.0,2080
-G-APO,Apartado,,,gleam_basin,,W-SA,,CO,COL,,7.812,-76.716,86000.0,1363
-G-APW,Apia,,,gleam_basin,,W-OC,,WS,WSM,,-13.83,-172.008,62000.0,1739
-G-AQA,Araraquara,,,gleam_basin,,W-SA,,BR,BRA,,-21.812,-48.133,168000.0,2048
-G-AQG,Anqing,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,30.582,117.05,580000.0,471
-G-AQI,Qaisumah,,,gleam_basin,,W-AS,,SA,SAU,,28.335,46.125,21000.0,268
-G-AQJ,Aqaba,,,gleam_basin,,W-AS,,JO,JOR,,29.612,35.018,95000.0,152
-G-AQP,Arequipa,,,gleam_basin,,W-SA,,PE,PER,,-16.341,-71.583,815000.0,1231
+G-AOR,Alor Setar,,,gleam_basin,,W-AS,,MY,MYS,,6.19,100.398,336000,180
+G-APL,Nampula,,,gleam_basin,,W-AF,,MZ,MOZ,,-15.106,39.282,389000,963
+G-APN,Alpena,,,gleam_basin,,W-NA,,US,USA,US-MI,45.078,-83.56,14000,2080
+G-APO,Apartado,,,gleam_basin,,W-SA,,CO,COL,,7.812,-76.716,86000,1363
+G-APW,Apia,,,gleam_basin,,W-OC,,WS,WSM,,-13.83,-172.008,62000,1739
+G-AQA,Araraquara,,,gleam_basin,,W-SA,,BR,BRA,,-21.812,-48.133,168000,2048
+G-AQG,Anqing,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,30.582,117.05,580000,471
+G-AQI,Qaisumah,,,gleam_basin,,W-AS,,SA,SAU,,28.335,46.125,21000,268
+G-AQJ,Aqaba,,,gleam_basin,,W-AS,,JO,JOR,,29.612,35.018,95000,152
+G-AQP,Arequipa,,,gleam_basin,,W-SA,,PE,PER,,-16.341,-71.583,815000,1231
 G-ARC,Arctic Village,,,gleam_basin,,W-NA,,US,USA,US-AK,68.115,-145.579,,2505
-G-ARH,Arkhangelsk,,,gleam_basin,,W-EU,,RU,RUS,,64.6,40.717,357000.0,1921
-G-ARI,Arica,,,gleam_basin,,W-SA,,CL,CHL,,-18.348,-70.339,186000.0,308
-G-ARK,Arusha,,,gleam_basin,,W-AF,,TZ,TZA,,-3.368,36.633,341000.0,215
-G-ARM,Armidale,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.528,151.617,23000.0,1680
-G-ARN,Stockholm,,,gleam_basin,,W-EU,,SE,SWE,,59.652,17.919,1264000.0,2571
+G-ARH,Arkhangelsk,,,gleam_basin,,W-EU,,RU,RUS,,64.6,40.717,357000,1921
+G-ARI,Arica,,,gleam_basin,,W-SA,,CL,CHL,,-18.348,-70.339,186000,308
+G-ARK,Arusha,,,gleam_basin,,W-AF,,TZ,TZA,,-3.368,36.633,341000,215
+G-ARM,Armidale,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.528,151.617,23000,1680
+G-ARN,Stockholm,,,gleam_basin,,W-EU,,SE,SWE,,59.652,17.919,1264000,2571
 G-ART,Watertown (US-NY),,,gleam_basin,,W-NA,,US,USA,US-NY,43.992,-76.022,,2504
-G-ARU,Aracatuba,,,gleam_basin,,W-SA,,BR,BRA,,-21.141,-50.425,170000.0,2037
-G-ASB,Ashgabat,,,gleam_basin,,W-AS,,TM,TKM,,37.987,58.361,728000.0,833
-G-ASE,Aspen,,,gleam_basin,,W-NA,,US,USA,US-CO,39.223,-106.869,9000.0,2447
-G-ASF,Astrakhan,,,gleam_basin,,W-EU,,RU,RUS,,46.283,48.006,503000.0,1911
+G-ARU,Aracatuba,,,gleam_basin,,W-SA,,BR,BRA,,-21.141,-50.425,170000,2037
+G-ASB,Ashgabat,,,gleam_basin,,W-AS,,TM,TKM,,37.987,58.361,728000,833
+G-ASE,Aspen,,,gleam_basin,,W-NA,,US,USA,US-CO,39.223,-106.869,9000,2447
+G-ASF,Astrakhan,,,gleam_basin,,W-EU,,RU,RUS,,46.283,48.006,503000,1911
 G-ASJ,Amami,,,gleam_basin,,W-AS,,JP,JPN,,28.431,129.713,,3149
-G-ASM,Asmara,,,gleam_basin,,W-AF,,ER,ERI,,15.292,38.911,621000.0,2848
-G-ASO,Asosa,,,gleam_basin,,W-AF,,ET,ETH,,10.019,34.586,31000.0,241
-G-ASP,Alice Springs,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-23.807,133.902,28000.0,1579
-G-ASR,Kayseri,,,gleam_basin,,W-AS,,TR,TUR,,38.77,35.495,593000.0,1779
-G-ASU,Asuncion,,,gleam_basin,,W-SA,,PY,PRY,,-25.24,-57.52,1870000.0,244
+G-ASM,Asmara,,,gleam_basin,,W-AF,,ER,ERI,,15.292,38.911,621000,2848
+G-ASO,Asosa,,,gleam_basin,,W-AF,,ET,ETH,,10.019,34.586,31000,241
+G-ASP,Alice Springs,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-23.807,133.902,28000,1579
+G-ASR,Kayseri,,,gleam_basin,,W-AS,,TR,TUR,,38.77,35.495,593000,1779
+G-ASU,Asuncion,,,gleam_basin,,W-SA,,PY,PRY,,-25.24,-57.52,1870000,244
 G-ASV,Amboseli,,,gleam_basin,,W-AF,,KE,KEN,,-2.645,37.253,,1734
-G-ASW,Aswan,,,gleam_basin,,W-AF,,EG,EGY,,23.964,32.82,313000.0,58
-G-ATA,Anta,,,gleam_basin,,W-SA,,PE,PER,,-9.347,-77.598,31000.0,1218
+G-ASW,Aswan,,,gleam_basin,,W-AF,,EG,EGY,,23.964,32.82,313000,58
+G-ATA,Anta,,,gleam_basin,,W-SA,,PE,PER,,-9.347,-77.598,31000,1218
 G-ATH,Athens (GR),,,gleam_basin,,W-EU,,GR,GRC,,37.936,23.944,,915
 G-ATK,Atqasuk,,,gleam_basin,,W-NA,,US,USA,US-AK,70.467,-157.436,,2205
-G-ATL,Atlanta,,,gleam_basin,,W-NA,,US,USA,US-GA,33.637,-84.428,5229000.0,2204
-G-ATM,Altamira,,,gleam_basin,,W-SA,,BR,BRA,,-3.254,-52.254,71000.0,1970
-G-ATQ,Amritsar,,,gleam_basin,,W-AS,,IN,IND,,31.71,74.797,1212000.0,1068
+G-ATL,Atlanta,,,gleam_basin,,W-NA,,US,USA,US-GA,33.637,-84.428,5229000,2204
+G-ATM,Altamira,,,gleam_basin,,W-SA,,BR,BRA,,-3.254,-52.254,71000,1970
+G-ATQ,Amritsar,,,gleam_basin,,W-AS,,IN,IND,,31.71,74.797,1212000,1068
 G-ATY,Watertown (US-SD),,,gleam_basin,,W-NA,,US,USA,US-SD,44.914,-97.155,,2208
-G-ATZ,Asyut,,,gleam_basin,,W-AF,,EG,EGY,,27.046,31.012,421000.0,54
+G-ATZ,Asyut,,,gleam_basin,,W-AF,,EG,EGY,,27.046,31.012,421000,54
 G-AUA,Aruba,,,gleam_basin,,W-NA,,AW,ABW,,,,,2973
-G-AUC,Arauca,,,gleam_basin,,W-SA,,CO,COL,,7.069,-70.737,69000.0,1371
+G-AUC,Arauca,,,gleam_basin,,W-SA,,CO,COL,,7.069,-70.737,69000,1371
 G-AUG,Augusta (US-ME),,,gleam_basin,,W-NA,,US,USA,US-ME,44.321,-69.797,,2180
-G-AUH,Abu Dhabi,,,gleam_basin,,W-AS,,AE,ARE,,24.433,54.651,603000.0,3179
+G-AUH,Abu Dhabi,,,gleam_basin,,W-AS,,AE,ARE,,24.433,54.651,603000,3179
 G-AUQ,Hiva Oa,,,gleam_basin,,W-OC,,PF,PYF,,-9.769,-139.011,,686
-G-AUR,Aurillac,,,gleam_basin,,W-EU,,FR,FRA,,44.891,2.422,35000.0,1502
-G-AUS,Austin,,,gleam_basin,,W-NA,,US,USA,US-TX,30.194,-97.67,1639000.0,2181
+G-AUR,Aurillac,,,gleam_basin,,W-EU,,FR,FRA,,44.891,2.422,35000,1502
+G-AUS,Austin,,,gleam_basin,,W-NA,,US,USA,US-TX,30.194,-97.67,1639000,2181
 G-AUU,Aurukun,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-13.354,141.721,,1601
-G-AUX,Araguaina,,,gleam_basin,,W-SA,,BR,BRA,,-7.228,-48.241,50000.0,1962
+G-AUX,Araguaina,,,gleam_basin,,W-SA,,BR,BRA,,-7.228,-48.241,50000,1962
 G-AUY,Aneityum,,,gleam_basin,,W-OC,,VU,VUT,,-20.249,169.771,,1317
-G-AVA,Anshun,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.261,105.873,849000.0,337
-G-AVL,Asheville,,,gleam_basin,,W-NA,,US,USA,US-NC,35.436,-82.542,309000.0,2144
-G-AVP,Wilkes-Barre,,,gleam_basin,,W-NA,,US,USA,US-PA,41.339,-75.723,41000.0,2143
+G-AVA,Anshun,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.261,105.873,849000,337
+G-AVL,Asheville,,,gleam_basin,,W-NA,,US,USA,US-NC,35.436,-82.542,309000,2144
+G-AVP,Wilkes-Barre,,,gleam_basin,,W-NA,,US,USA,US-PA,41.339,-75.723,41000,2143
 G-AVV,Avalon,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-38.039,144.469,,1594
-G-AWZ,Ahwaz,,,gleam_basin,,W-AS,,IR,IRN,,31.337,48.762,1112000.0,2931
+G-AWZ,Ahwaz,,,gleam_basin,,W-AS,,IR,IRN,,31.337,48.762,1112000,2931
 G-AXA,Anguilla,,,gleam_basin,,W-NA,,AI,AIA,,,,,2810
 G-AXD,Alexandroupolis,,,gleam_basin,,W-EU,,GR,GRC,,40.856,25.956,,925
-G-AXK,Ataq,,,gleam_basin,,W-AS,,YE,YEM,,14.551,46.826,37000.0,586
+G-AXK,Ataq,,,gleam_basin,,W-AS,,YE,YEM,,14.551,46.826,37000,586
 G-AXP,Spring Point,,,gleam_basin,,W-NA,,BS,BHS,,22.442,-73.971,,3230
 G-AXR,Arutua,,,gleam_basin,,W-OC,,PF,PYF,,-15.248,-146.617,,695
-G-AXT,Akita,,,gleam_basin,,W-AS,,JP,JPN,,39.616,140.219,320000.0,3132
-G-AXU,Axum,,,gleam_basin,,W-AF,,ET,ETH,,14.147,38.773,41000.0,235
-G-AYP,Ayacucho,,,gleam_basin,,W-SA,,PE,PER,,-13.155,-74.204,166000.0,1223
+G-AXT,Akita,,,gleam_basin,,W-AS,,JP,JPN,,39.616,140.219,320000,3132
+G-AXU,Axum,,,gleam_basin,,W-AF,,ET,ETH,,14.147,38.773,41000,235
+G-AYP,Ayacucho,,,gleam_basin,,W-SA,,PE,PER,,-13.155,-74.204,166000,1223
 G-AYQ,Ayers Rock,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-25.186,130.976,,1634
-G-AYT,Antalya,,,gleam_basin,,W-AS,,TR,TUR,,36.899,30.801,783000.0,1768
-G-AZD,Yazd,,,gleam_basin,,W-AS,,IR,IRN,,31.905,54.277,478000.0,2944
-G-AZN,Andizhan,,,gleam_basin,,W-AS,,UZ,UZB,,40.728,72.294,338000.0,2840
-G-AZO,Kalamazoo,,,gleam_basin,,W-NA,,US,USA,US-MI,42.235,-85.552,214000.0,2266
-G-AZR,Adrar,,,gleam_basin,,W-AF,,DZ,DZA,,27.838,-0.186,57000.0,30
-G-AZS,Samana,,,gleam_basin,,W-NA,,DO,DOM,,19.267,-69.742,11000.0,1200
+G-AYT,Antalya,,,gleam_basin,,W-AS,,TR,TUR,,36.899,30.801,783000,1768
+G-AZD,Yazd,,,gleam_basin,,W-AS,,IR,IRN,,31.905,54.277,478000,2944
+G-AZN,Andizhan,,,gleam_basin,,W-AS,,UZ,UZB,,40.728,72.294,338000,2840
+G-AZO,Kalamazoo,,,gleam_basin,,W-NA,,US,USA,US-MI,42.235,-85.552,214000,2266
+G-AZR,Adrar,,,gleam_basin,,W-AF,,DZ,DZA,,27.838,-0.186,57000,30
+G-AZS,Samana,,,gleam_basin,,W-NA,,DO,DOM,,19.267,-69.742,11000,1200
 G-BAH,Bahrain,,,gleam_basin,,W-AS,,BH,BHR,,,,,3232
-G-BAL,Batman,,,gleam_basin,,W-AS,,TR,TUR,,37.929,41.117,302000.0,1777
-G-BAQ,Barranquilla,,,gleam_basin,,W-SA,,CO,COL,,10.89,-74.781,1798000.0,1395
+G-BAL,Batman,,,gleam_basin,,W-AS,,TR,TUR,,37.929,41.117,302000,1777
+G-BAQ,Barranquilla,,,gleam_basin,,W-SA,,CO,COL,,10.89,-74.781,1798000,1395
 G-BAS,Balalae,,,gleam_basin,,W-OC,,SB,SLB,,-6.991,155.887,,3024
-G-BAV,Baotou,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,40.56,109.997,2036000.0,355
-G-BAX,Barnaul,,,gleam_basin,,W-EU,,RU,RUS,,53.364,83.538,600000.0,1898
-G-BAZ,Barcelos,,,gleam_basin,,W-SA,,BR,BRA,,-0.981,-62.92,13000.0,1963
+G-BAV,Baotou,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,40.56,109.997,2036000,355
+G-BAX,Barnaul,,,gleam_basin,,W-EU,,RU,RUS,,53.364,83.538,600000,1898
+G-BAZ,Barcelos,,,gleam_basin,,W-SA,,BR,BRA,,-0.981,-62.92,13000,1963
 G-BBA,Balmaceda,,,gleam_basin,,W-SA,,CL,CHL,,-45.916,-71.689,,292
-G-BBI,Bhubaneshwar,,,gleam_basin,,W-AS,,IN,IND,,20.244,85.818,844000.0,1058
-G-BBK,Kasane,,,gleam_basin,,W-AF,,BW,BWA,,-17.833,25.162,9000.0,218
+G-BBI,Bhubaneshwar,,,gleam_basin,,W-AS,,IN,IND,,20.244,85.818,844000,1058
+G-BBK,Kasane,,,gleam_basin,,W-AF,,BW,BWA,,-17.833,25.162,9000,218
 G-BBN,Bario,,,gleam_basin,,W-AS,,MY,MYS,,3.734,115.479,,168
-G-BBO,Berbera,,,gleam_basin,,W-AF,,SO,SOM,,10.389,44.941,242000.0,2829
-G-BCA,Baracoa,,,gleam_basin,,W-NA,,CU,CUB,,20.365,-74.506,48000.0,3241
-G-BCD,Bacolod,,,gleam_basin,,W-AS,,PH,PHL,,10.776,123.015,949000.0,622
-G-BCI,Barcaldine,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.565,145.307,1000.0,1686
-G-BCM,Bacau,,,gleam_basin,,W-EU,,RO,ROU,,46.522,26.91,200000.0,140
+G-BBO,Berbera,,,gleam_basin,,W-AF,,SO,SOM,,10.389,44.941,242000,2829
+G-BCA,Baracoa,,,gleam_basin,,W-NA,,CU,CUB,,20.365,-74.506,48000,3241
+G-BCD,Bacolod,,,gleam_basin,,W-AS,,PH,PHL,,10.776,123.015,949000,622
+G-BCI,Barcaldine,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.565,145.307,1000,1686
+G-BCM,Bacau,,,gleam_basin,,W-EU,,RO,ROU,,46.522,26.91,200000,140
 G-BCN,Barcelona (ES),,,gleam_basin,,W-EU,,ES,ESP,,41.297,2.078,,2884
-G-BCV,Belmopan,,,gleam_basin,,W-NA,,BZ,BLZ,,,,15000.0,864
+G-BCV,Belmopan,,,gleam_basin,,W-NA,,BZ,BLZ,,,,15000,864
 G-BDA,Bermuda,,,gleam_basin,,W-NA,,BM,BMU,,,,,839
-G-BDB,Bundaberg,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-24.904,152.319,52000.0,1687
+G-BDB,Bundaberg,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-24.904,152.319,52000,1687
 G-BDH,Bandar Lengeh,,,gleam_basin,,W-AS,,IR,IRN,,26.532,54.825,,2971
-G-BDJ,Banjarmasin,,,gleam_basin,,W-AS,,ID,IDN,,-3.442,114.763,604000.0,1313
-G-BDL,Hartford,,,gleam_basin,,W-NA,,US,USA,US-CT,41.939,-72.683,915000.0,2398
-G-BDO,Bandung,,,gleam_basin,,W-AS,,ID,IDN,,-6.901,107.576,2394000.0,1312
-G-BDP,Bhadrapur,,,gleam_basin,,W-AS,,NP,NPL,,26.571,88.08,20000.0,568
-G-BDQ,Vadodara,,,gleam_basin,,W-AS,,IN,IND,,22.336,73.226,1756000.0,1114
-G-BDS,Brindisi,,,gleam_basin,,W-EU,,IT,ITA,,40.658,17.947,104000.0,3096
+G-BDJ,Banjarmasin,,,gleam_basin,,W-AS,,ID,IDN,,-3.442,114.763,604000,1313
+G-BDL,Hartford,,,gleam_basin,,W-NA,,US,USA,US-CT,41.939,-72.683,915000,2398
+G-BDO,Bandung,,,gleam_basin,,W-AS,,ID,IDN,,-6.901,107.576,2394000,1312
+G-BDP,Bhadrapur,,,gleam_basin,,W-AS,,NP,NPL,,26.571,88.08,20000,568
+G-BDQ,Vadodara,,,gleam_basin,,W-AS,,IN,IND,,22.336,73.226,1756000,1114
+G-BDS,Brindisi,,,gleam_basin,,W-EU,,IT,ITA,,40.658,17.947,104000,3096
 G-BDU,Bardufoss,,,gleam_basin,,W-EU,,NO,NOR,,69.056,18.54,,1174
 G-BEB,Benbecula,,,gleam_basin,,W-EU,,GB,GBR,,57.481,-7.363,,760
-G-BEG,Belgrade,,,gleam_basin,,W-EU,,RS,SRB,,44.818,20.309,1099000.0,2051
+G-BEG,Belgrade,,,gleam_basin,,W-EU,,RS,SRB,,44.818,20.309,1099000,2051
 G-BEJ,Tanjung Redeb,,,gleam_basin,,W-AS,,ID,IDN,,2.155,117.432,,1233
-G-BEL,Belem,,,gleam_basin,,W-SA,,BR,BRA,,-1.379,-48.476,2167000.0,1937
-G-BEN,Benghazi,,,gleam_basin,,W-AF,,LY,LBY,,32.097,20.27,1180000.0,154
+G-BEL,Belem,,,gleam_basin,,W-SA,,BR,BRA,,-1.379,-48.476,2167000,1937
+G-BEN,Benghazi,,,gleam_basin,,W-AF,,LY,LBY,,32.097,20.27,1180000,154
 G-BES,Brest (FR),,,gleam_basin,,W-EU,,FR,FRA,,48.448,-4.419,,1491
-G-BET,Bethel,,,gleam_basin,,W-NA,,US,USA,US-CT,60.78,-161.838,20000.0,2457
-G-BEU,Bedourie,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-24.346,139.46,0.0,1570
-G-BEW,Beira,,,gleam_basin,,W-AF,,MZ,MOZ,,-19.796,34.908,531000.0,961
-G-BEY,Beirut,,,gleam_basin,,W-AS,,LB,LBN,,33.821,35.488,1846000.0,271
-G-BFD,Bradford,,,gleam_basin,,W-NA,,US,USA,US-PA,41.803,-78.64,502000.0,2428
-G-BFF,Scottsbluff,,,gleam_basin,,W-NA,,US,USA,US-NE,41.874,-103.596,26000.0,2427
-G-BFJ,Bijie,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.267,105.472,78000.0,452
-G-BFL,Bakersfield,,,gleam_basin,,W-NA,,US,USA,US-CA,35.434,-119.057,574000.0,2430
-G-BFN,Bloemfontein,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.093,26.302,463000.0,637
-G-BFS,Belfast,,,gleam_basin,,W-EU,,GB,GBR,,54.658,-6.216,450000.0,788
+G-BET,Bethel,,,gleam_basin,,W-NA,,US,USA,US-CT,60.78,-161.838,20000,2457
+G-BEU,Bedourie,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-24.346,139.46,0,1570
+G-BEW,Beira,,,gleam_basin,,W-AF,,MZ,MOZ,,-19.796,34.908,531000,961
+G-BEY,Beirut,,,gleam_basin,,W-AS,,LB,LBN,,33.821,35.488,1846000,271
+G-BFD,Bradford,,,gleam_basin,,W-NA,,US,USA,US-PA,41.803,-78.64,502000,2428
+G-BFF,Scottsbluff,,,gleam_basin,,W-NA,,US,USA,US-NE,41.874,-103.596,26000,2427
+G-BFJ,Bijie,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.267,105.472,78000,452
+G-BFL,Bakersfield,,,gleam_basin,,W-NA,,US,USA,US-CA,35.434,-119.057,574000,2430
+G-BFN,Bloemfontein,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.093,26.302,463000,637
+G-BFS,Belfast,,,gleam_basin,,W-EU,,GB,GBR,,54.658,-6.216,450000,788
 G-BFV,Buriram,,,gleam_basin,,W-AS,,TH,THA,,15.229,103.253,,544
-G-BGA,Bucaramanga,,,gleam_basin,,W-SA,,CO,COL,,7.127,-73.185,1008999.0,1399
-G-BGC,Braganca,,,gleam_basin,,W-EU,,PT,PRT,,41.858,-6.707,57000.0,1438
-G-BGF,Bangui,,,gleam_basin,,W-AF,,CF,CAF,,4.398,18.519,832000.0,2811
-G-BGG,Bingol,,,gleam_basin,,W-AS,,TR,TUR,,38.859,40.596,81000.0,1780
+G-BGA,Bucaramanga,,,gleam_basin,,W-SA,,CO,COL,,7.127,-73.185,1008999,1399
+G-BGC,Braganca,,,gleam_basin,,W-EU,,PT,PRT,,41.858,-6.707,57000,1438
+G-BGF,Bangui,,,gleam_basin,,W-AF,,CF,CAF,,4.398,18.519,832000,2811
+G-BGG,Bingol,,,gleam_basin,,W-AS,,TR,TUR,,38.859,40.596,81000,1780
 G-BGI,Barbados,,,gleam_basin,,W-NA,,BB,BRB,,,,,1933
-G-BGM,Binghamton,,,gleam_basin,,W-NA,,US,USA,US-NY,42.209,-75.98,151000.0,2470
+G-BGM,Binghamton,,,gleam_basin,,W-NA,,US,USA,US-NY,42.209,-75.98,151000,2470
 G-BGN,Belaya Gora,,,gleam_basin,,W-EU,,RU,RUS,,68.557,146.232,,1916
-G-BGO,Bergen,,,gleam_basin,,W-EU,,NO,NOR,,60.293,5.218,214000.0,1167
-G-BGR,Bangor,,,gleam_basin,,W-NA,,US,USA,US-ME,44.807,-68.828,59000.0,2471
-G-BGW,Baghdad,,,gleam_basin,,W-AS,,IQ,IRQ,,33.263,44.235,5054000.0,2915
-G-BHB,Bar Harbor,,,gleam_basin,,W-NA,,US,USA,US-ME,44.45,-68.362,5000.0,2421
-G-BHE,Blenheim,,,gleam_basin,,W-OC,,NZ,NZL,,-41.518,173.87,30000.0,3059
+G-BGO,Bergen,,,gleam_basin,,W-EU,,NO,NOR,,60.293,5.218,214000,1167
+G-BGR,Bangor,,,gleam_basin,,W-NA,,US,USA,US-ME,44.807,-68.828,59000,2471
+G-BGW,Baghdad,,,gleam_basin,,W-AS,,IQ,IRQ,,33.263,44.235,5054000,2915
+G-BHB,Bar Harbor,,,gleam_basin,,W-NA,,US,USA,US-ME,44.45,-68.362,5000,2421
+G-BHE,Blenheim,,,gleam_basin,,W-OC,,NZ,NZL,,-41.518,173.87,30000,3059
 G-BHH,Bisha,,,gleam_basin,,W-AS,,SA,SAU,,19.984,42.621,,264
-G-BHI,Bahia Blanca,,,gleam_basin,,W-SA,,AR,ARG,,-38.725,-62.169,282000.0,3212
-G-BHJ,Bhuj,,,gleam_basin,,W-AS,,IN,IND,,23.288,69.67,289000.0,1103
-G-BHK,Bukhara,,,gleam_basin,,W-AS,,UZ,UZB,,39.775,64.483,319000.0,2845
+G-BHI,Bahia Blanca,,,gleam_basin,,W-SA,,AR,ARG,,-38.725,-62.169,282000,3212
+G-BHJ,Bhuj,,,gleam_basin,,W-AS,,IN,IND,,23.288,69.67,289000,1103
+G-BHK,Bukhara,,,gleam_basin,,W-AS,,UZ,UZB,,39.775,64.483,319000,2845
 G-BHM,Birmingham (US),,,gleam_basin,,W-NA,,US,USA,US-AL,33.563,-86.754,,2420
-G-BHO,Bhopal,,,gleam_basin,,W-AS,,IN,IND,,23.288,77.337,1727000.0,1104
-G-BHQ,Broken Hill,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.001,141.472,17000.0,1662
-G-BHR,Bharatpur,,,gleam_basin,,W-AS,,NP,NPL,,27.678,84.429,229000.0,565
-G-BHU,Bhavnagar,,,gleam_basin,,W-AS,,IN,IND,,21.752,72.185,555000.0,1105
-G-BHV,Bahawalpur,,,gleam_basin,,W-AS,,PK,PAK,,29.348,71.718,10000000.0,130
+G-BHO,Bhopal,,,gleam_basin,,W-AS,,IN,IND,,23.288,77.337,1727000,1104
+G-BHQ,Broken Hill,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.001,141.472,17000,1662
+G-BHR,Bharatpur,,,gleam_basin,,W-AS,,NP,NPL,,27.678,84.429,229000,565
+G-BHU,Bhavnagar,,,gleam_basin,,W-AS,,IN,IND,,21.752,72.185,555000,1105
+G-BHV,Bahawalpur,,,gleam_basin,,W-AS,,PK,PAK,,29.348,71.718,10000000,130
 G-BHX,Birmingham (UK),,,gleam_basin,,W-EU,,GB,GBR,,52.454,-1.748,,786
-G-BHY,Beihai,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,21.539,109.294,729000.0,451
-G-BIA,Bastia,,,gleam_basin,,W-EU,,FR,FRA,,42.553,9.484,41000.0,1529
-G-BIB,Baidoa,,,gleam_basin,,W-AF,,SO,SOM,,3.102,43.629,130000.0,2834
+G-BHY,Beihai,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,21.539,109.294,729000,451
+G-BIA,Bastia,,,gleam_basin,,W-EU,,FR,FRA,,42.553,9.484,41000,1529
+G-BIB,Baidoa,,,gleam_basin,,W-AF,,SO,SOM,,3.102,43.629,130000,2834
 G-BID,Block Island,,,gleam_basin,,W-NA,,US,USA,US-RI,41.168,-71.578,,2456
-G-BIK,Biak,,,gleam_basin,,W-AS,,ID,IDN,,-1.19,136.108,104000.0,1304
-G-BIL,Billings,,,gleam_basin,,W-NA,,US,USA,US-MT,45.808,-108.543,121000.0,2455
+G-BIK,Biak,,,gleam_basin,,W-AS,,ID,IDN,,-1.19,136.108,104000,1304
+G-BIL,Billings,,,gleam_basin,,W-NA,,US,USA,US-MT,45.808,-108.543,121000,2455
 G-BIM,Bimini,,,gleam_basin,,W-NA,,BS,BHS,,25.7,-79.265,,3229
-G-BIN,Bamyan,,,gleam_basin,,W-AS,,AF,AFG,,34.817,67.817,62000.0,897
-G-BIO,Bilbao,,,gleam_basin,,W-EU,,ES,ESP,,43.301,-2.911,876000.0,2907
-G-BIQ,Biarritz,,,gleam_basin,,W-EU,,FR,FRA,,43.468,-1.531,145000.0,1530
-G-BIR,Biratnagar,,,gleam_basin,,W-AS,,NP,NPL,,26.482,87.264,182000.0,567
-G-BIS,Bismarck,,,gleam_basin,,W-NA,,US,USA,US-ND,46.773,-100.746,97000.0,2458
-G-BJA,Bejaia,,,gleam_basin,,W-AF,,DZ,DZA,,36.712,5.07,385000.0,40
-G-BJB,Bojnurd,,,gleam_basin,,W-AS,,IR,IRN,,37.493,57.308,209000.0,2956
+G-BIN,Bamyan,,,gleam_basin,,W-AS,,AF,AFG,,34.817,67.817,62000,897
+G-BIO,Bilbao,,,gleam_basin,,W-EU,,ES,ESP,,43.301,-2.911,876000,2907
+G-BIQ,Biarritz,,,gleam_basin,,W-EU,,FR,FRA,,43.468,-1.531,145000,1530
+G-BIR,Biratnagar,,,gleam_basin,,W-AS,,NP,NPL,,26.482,87.264,182000,567
+G-BIS,Bismarck,,,gleam_basin,,W-NA,,US,USA,US-ND,46.773,-100.746,97000,2458
+G-BJA,Bejaia,,,gleam_basin,,W-AF,,DZ,DZA,,36.712,5.07,385000,40
+G-BJB,Bojnurd,,,gleam_basin,,W-AS,,IR,IRN,,37.493,57.308,209000,2956
 G-BJF,Batsfjord,,,gleam_basin,,W-EU,,NO,NOR,,70.601,29.691,,1171
-G-BJI,Bemidji,,,gleam_basin,,W-NA,,US,USA,US-MN,47.509,-94.934,17000.0,2349
-G-BJL,Banjul,,,gleam_basin,,W-AF,,GM,GMB,,13.338,-16.652,43000.0,1554
-G-BJM,Bujumbura,,,gleam_basin,,W-AF,,BI,BDI,,-3.324,29.319,332000.0,900
+G-BJI,Bemidji,,,gleam_basin,,W-NA,,US,USA,US-MN,47.509,-94.934,17000,2349
+G-BJL,Banjul,,,gleam_basin,,W-AF,,GM,GMB,,13.338,-16.652,43000,1554
+G-BJM,Bujumbura,,,gleam_basin,,W-AF,,BI,BDI,,-3.324,29.319,332000,900
 G-BJR,Bahar Dar,,,gleam_basin,,W-AF,,ET,ETH,,11.608,37.322,,236
-G-BJV,Bodrum,,,gleam_basin,,W-AS,,TR,TUR,,37.251,27.664,39000.0,1774
+G-BJV,Bodrum,,,gleam_basin,,W-AS,,TR,TUR,,37.251,27.664,39000,1774
 G-BJX,Leon (MX),,,gleam_basin,,W-NA,,MX,MEX,,20.994,-101.481,,1018
-G-BJZ,Badajoz,,,gleam_basin,,W-EU,,ES,ESP,,38.891,-6.821,140000.0,2901
+G-BJZ,Badajoz,,,gleam_basin,,W-EU,,ES,ESP,,38.891,-6.821,140000,2901
 G-BKC,Buckland,,,gleam_basin,,W-NA,,US,USA,US-AK,65.982,-161.149,,2372
-G-BKG,Branson,,,gleam_basin,,W-NA,,US,USA,US-MO,36.532,-93.201,25000.0,2202
-G-BKI,Kota Kinabalu,,,gleam_basin,,W-AS,,MY,MYS,,5.937,116.051,528000.0,186
-G-BKK,Bangkok,,,gleam_basin,,W-AS,,TH,THA,,13.681,100.747,6704000.0,538
+G-BKG,Branson,,,gleam_basin,,W-NA,,US,USA,US-MO,36.532,-93.201,25000,2202
+G-BKI,Kota Kinabalu,,,gleam_basin,,W-AS,,MY,MYS,,5.937,116.051,528000,186
+G-BKK,Bangkok,,,gleam_basin,,W-AS,,TH,THA,,13.681,100.747,6704000,538
 G-BKM,Bakelalan,,,gleam_basin,,W-AS,,ID,IDN,,3.974,115.618,,1287
-G-BKO,Bamako,,,gleam_basin,,W-AF,,ML,MLI,,12.534,-7.95,1494000.0,2919
+G-BKO,Bamako,,,gleam_basin,,W-AF,,ML,MLI,,12.534,-7.95,1494000,2919
 G-BKQ,Blackall,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-24.428,145.429,,1647
-G-BKS,Bengkulu,,,gleam_basin,,W-AS,,ID,IDN,,-3.864,102.339,427000.0,1288
-G-BKW,Beckley,,,gleam_basin,,W-NA,,US,USA,US-WV,37.787,-81.124,60000.0,2373
-G-BKY,Bukavu,,,gleam_basin,,W-AF,,CD,COD,,-2.309,28.809,437000.0,1343
-G-BKZ,Bukoba,,,gleam_basin,,W-AF,,TZ,TZA,,-1.332,31.821,101000.0,212
+G-BKS,Bengkulu,,,gleam_basin,,W-AS,,ID,IDN,,-3.864,102.339,427000,1288
+G-BKW,Beckley,,,gleam_basin,,W-NA,,US,USA,US-WV,37.787,-81.124,60000,2373
+G-BKY,Bukavu,,,gleam_basin,,W-AF,,CD,COD,,-2.309,28.809,437000,1343
+G-BKZ,Bukoba,,,gleam_basin,,W-AF,,TZ,TZA,,-1.332,31.821,101000,212
 G-BLA,Barcelona (VE),,,gleam_basin,,W-SA,,VE,VEN,,10.111,-64.692,,1710
-G-BLE,Borlange,,,gleam_basin,,W-EU,,SE,SWE,,60.422,15.515,39000.0,2558
-G-BLI,Bellingham,,,gleam_basin,,W-NA,,US,USA,US-WA,48.793,-122.538,126000.0,2351
-G-BLJ,Batna,,,gleam_basin,,W-AF,,DZ,DZA,,35.752,6.309,281000.0,32
-G-BLK,Blackpool,,,gleam_basin,,W-EU,,GB,GBR,,53.772,-3.029,273000.0,779
+G-BLE,Borlange,,,gleam_basin,,W-EU,,SE,SWE,,60.422,15.515,39000,2558
+G-BLI,Bellingham,,,gleam_basin,,W-NA,,US,USA,US-WA,48.793,-122.538,126000,2351
+G-BLJ,Batna,,,gleam_basin,,W-AF,,DZ,DZA,,35.752,6.309,281000,32
+G-BLK,Blackpool,,,gleam_basin,,W-EU,,GB,GBR,,53.772,-3.029,273000,779
 G-BLL,Billund,,,gleam_basin,,W-EU,,DK,DNK,,55.74,9.152,,1562
-G-BLQ,Bologna,,,gleam_basin,,W-EU,,IT,ITA,,44.535,11.289,488000.0,3086
-G-BLR,Bengaluru,,,gleam_basin,,W-AS,,IN,IND,,13.198,77.706,6787000.0,1085
-G-BLV,Belleville,,,gleam_basin,,W-NA,,US,USA,US-IL,38.545,-89.835,44000.0,2284
-G-BLZ,Blantyre,,,gleam_basin,,W-AF,,MW,MWI,,-15.679,34.974,585000.0,2870
+G-BLQ,Bologna,,,gleam_basin,,W-EU,,IT,ITA,,44.535,11.289,488000,3086
+G-BLR,Bengaluru,,,gleam_basin,,W-AS,,IN,IND,,13.198,77.706,6787000,1085
+G-BLV,Belleville,,,gleam_basin,,W-NA,,US,USA,US-IL,38.545,-89.835,44000,2284
+G-BLZ,Blantyre,,,gleam_basin,,W-AF,,MW,MWI,,-15.679,34.974,585000,2870
 G-BMD,Belo Tsiribihina,,,gleam_basin,,W-AF,,MG,MDG,,-19.687,44.542,,1451
-G-BME,Broome,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-17.945,122.232,13000.0,1635
-G-BMI,Bloomington,,,gleam_basin,,W-NA,,US,USA,US-IL,40.477,-88.916,135000.0,2309
-G-BMO,Bhamo,,,gleam_basin,,W-AS,,MM,MMR,,24.269,97.246,48000.0,877
-G-BMU,Bima,,,gleam_basin,,W-AS,,ID,IDN,,-8.54,118.687,67000.0,1274
+G-BME,Broome,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-17.945,122.232,13000,1635
+G-BMI,Bloomington,,,gleam_basin,,W-NA,,US,USA,US-IL,40.477,-88.916,135000,2309
+G-BMO,Bhamo,,,gleam_basin,,W-AS,,MM,MMR,,24.269,97.246,48000,877
+G-BMU,Bima,,,gleam_basin,,W-AS,,ID,IDN,,-8.54,118.687,67000,1274
 G-BMV,Ban Me Thuot,,,gleam_basin,,W-AS,,VN,VNM,,12.668,108.12,,1132
 G-BMW,Bordj Mokhtar,,,gleam_basin,,W-AF,,DZ,DZA,,21.375,0.924,,34
 G-BMY,Ile Art,,,gleam_basin,,W-OC,,NC,NCL,,-19.721,163.661,,3172
-G-BNA,Nashville,,,gleam_basin,,W-NA,,US,USA,US-TN,36.125,-86.678,1077000.0,2224
-G-BNB,Boende,,,gleam_basin,,W-AF,,CD,COD,,-0.217,20.85,32000.0,1334
-G-BNC,Beni,,,gleam_basin,,W-AF,,CD,COD,,0.575,29.474,333000.0,1335
-G-BND,Bandar Abbas,,,gleam_basin,,W-AS,,IR,IRN,,27.218,56.378,352000.0,2938
-G-BNE,Brisbane,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.384,153.117,1860000.0,1603
-G-BNI,Benin City,,,gleam_basin,,W-AF,,NG,NGA,,6.317,5.6,1190000.0,1415
-G-BNK,Ballina,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-28.834,153.562,14000.0,1610
+G-BNA,Nashville,,,gleam_basin,,W-NA,,US,USA,US-TN,36.125,-86.678,1077000,2224
+G-BNB,Boende,,,gleam_basin,,W-AF,,CD,COD,,-0.217,20.85,32000,1334
+G-BNC,Beni,,,gleam_basin,,W-AF,,CD,COD,,0.575,29.474,333000,1335
+G-BND,Bandar Abbas,,,gleam_basin,,W-AS,,IR,IRN,,27.218,56.378,352000,2938
+G-BNE,Brisbane,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.384,153.117,1860000,1603
+G-BNI,Benin City,,,gleam_basin,,W-AF,,NG,NGA,,6.317,5.6,1190000,1415
+G-BNK,Ballina,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-28.834,153.562,14000,1610
 G-BNN,Bronnoysund,,,gleam_basin,,W-EU,,NO,NOR,,65.461,12.217,,1142
-G-BNS,Barinas,,,gleam_basin,,W-SA,,VE,VEN,,8.615,-70.214,284000.0,1708
-G-BNX,Banja Luka,,,gleam_basin,,W-EU,,BA,BIH,,44.941,17.298,222000.0,2818
+G-BNS,Barinas,,,gleam_basin,,W-SA,,VE,VEN,,8.615,-70.214,284000,1708
+G-BNX,Banja Luka,,,gleam_basin,,W-EU,,BA,BIH,,44.941,17.298,222000,2818
 G-BOB,Bora Bora,,,gleam_basin,,W-OC,,PF,PYF,,-16.444,-151.751,,692
-G-BOC,Bocas del Toro,,,gleam_basin,,W-NA,,PA,PAN,,9.341,-82.251,10000.0,3005
-G-BOD,Bordeaux,,,gleam_basin,,W-EU,,FR,FRA,,44.828,-0.716,803000.0,1511
-G-BOG,Bogota,,,gleam_basin,,W-SA,,CO,COL,,4.702,-74.147,7772000.0,1377
-G-BOI,Boise,,,gleam_basin,,W-NA,,US,USA,US-ID,43.564,-116.223,385000.0,2244
-G-BOJ,Burgas,,,gleam_basin,,W-EU,,BG,BGR,,42.57,27.515,196000.0,83
-G-BOM,Mumbai,,,gleam_basin,,W-AS,,IN,IND,,19.089,72.868,18978000.0,1090
+G-BOC,Bocas del Toro,,,gleam_basin,,W-NA,,PA,PAN,,9.341,-82.251,10000,3005
+G-BOD,Bordeaux,,,gleam_basin,,W-EU,,FR,FRA,,44.828,-0.716,803000,1511
+G-BOG,Bogota,,,gleam_basin,,W-SA,,CO,COL,,4.702,-74.147,7772000,1377
+G-BOI,Boise,,,gleam_basin,,W-NA,,US,USA,US-ID,43.564,-116.223,385000,2244
+G-BOJ,Burgas,,,gleam_basin,,W-EU,,BG,BGR,,42.57,27.515,196000,83
+G-BOM,Mumbai,,,gleam_basin,,W-AS,,IN,IND,,19.089,72.868,18978000,1090
 G-BON,Bonaire,,,gleam_basin,,W-NA,,BQ,BES,,12.131,-68.269,,796
-G-BOO,Bodo,,,gleam_basin,,W-EU,,NO,NOR,,67.269,14.365,34000.0,1146
-G-BOS,Boston,,,gleam_basin,,W-NA,,US,USA,US-MA,42.364,-71.005,4638000.0,2489
-G-BOY,Bobo Dioulasso,,,gleam_basin,,W-AF,,BF,BFA,,11.16,-4.331,360000.0,273
-G-BPL,Bole,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,44.895,82.3,225000.0,364
-G-BPN,Balikpapan,,,gleam_basin,,W-AS,,ID,IDN,,-1.268,116.894,446000.0,1262
-G-BPS,Porto Seguro,,,gleam_basin,,W-SA,,BR,BRA,,-16.439,-39.081,123000.0,1974
-G-BPT,Beaumont,,,gleam_basin,,W-NA,,US,USA,US-TX,29.951,-94.021,149000.0,2216
-G-BPX,Qamdo,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,30.554,97.108,100000.0,365
-G-BQB,Busselton,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.688,115.402,10000.0,1622
-G-BQG,Bogorodskoye,,,gleam_basin,,W-EU,,RU,RUS,,52.38,140.448,103000.0,1846
-G-BQK,Brunswick,,,gleam_basin,,W-NA,,US,USA,US-GA,31.259,-81.466,54000.0,2248
-G-BQL,Boulia,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.913,139.9,1000.0,1623
-G-BQN,Aguadilla,,,gleam_basin,,W-NA,,PR,PRI,,18.495,-67.129,12000.0,196
+G-BOO,Bodo,,,gleam_basin,,W-EU,,NO,NOR,,67.269,14.365,34000,1146
+G-BOS,Boston,,,gleam_basin,,W-NA,,US,USA,US-MA,42.364,-71.005,4638000,2489
+G-BOY,Bobo Dioulasso,,,gleam_basin,,W-AF,,BF,BFA,,11.16,-4.331,360000,273
+G-BPL,Bole,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,44.895,82.3,225000,364
+G-BPN,Balikpapan,,,gleam_basin,,W-AS,,ID,IDN,,-1.268,116.894,446000,1262
+G-BPS,Porto Seguro,,,gleam_basin,,W-SA,,BR,BRA,,-16.439,-39.081,123000,1974
+G-BPT,Beaumont,,,gleam_basin,,W-NA,,US,USA,US-TX,29.951,-94.021,149000,2216
+G-BPX,Qamdo,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,30.554,97.108,100000,365
+G-BQB,Busselton,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.688,115.402,10000,1622
+G-BQG,Bogorodskoye,,,gleam_basin,,W-EU,,RU,RUS,,52.38,140.448,103000,1846
+G-BQK,Brunswick,,,gleam_basin,,W-NA,,US,USA,US-GA,31.259,-81.466,54000,2248
+G-BQL,Boulia,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.913,139.9,1000,1623
+G-BQN,Aguadilla,,,gleam_basin,,W-NA,,PR,PRI,,18.495,-67.129,12000,196
 G-BQS,Blagoveschensk,,,gleam_basin,,W-EU,,RU,RUS,,50.425,127.412,,1848
 G-BQT,Brest (BY),,,gleam_basin,,W-EU,,BY,BLR,,52.108,23.898,,904
-G-BRA,Barreiras,,,gleam_basin,,W-SA,,BR,BRA,,-12.079,-45.009,158000.0,1956
-G-BRC,San Carlos de Bariloche,,,gleam_basin,,W-SA,,AR,ARG,,-41.151,-71.158,95000.0,3185
-G-BRD,Brainerd,,,gleam_basin,,W-NA,,US,USA,US-MN,46.398,-94.138,20000.0,2153
-G-BRE,Bremen,,,gleam_basin,,W-EU,,DE,DEU,,53.048,8.787,725000.0,728
-G-BRI,Bari,,,gleam_basin,,W-EU,,IT,ITA,,41.139,16.761,501000.0,3073
+G-BRA,Barreiras,,,gleam_basin,,W-SA,,BR,BRA,,-12.079,-45.009,158000,1956
+G-BRC,San Carlos de Bariloche,,,gleam_basin,,W-SA,,AR,ARG,,-41.151,-71.158,95000,3185
+G-BRD,Brainerd,,,gleam_basin,,W-NA,,US,USA,US-MN,46.398,-94.138,20000,2153
+G-BRE,Bremen,,,gleam_basin,,W-EU,,DE,DEU,,53.048,8.787,725000,728
+G-BRI,Bari,,,gleam_basin,,W-EU,,IT,ITA,,41.139,16.761,501000,3073
 G-BRL,Burlington (US-IA),,,gleam_basin,,W-NA,,US,USA,US-IA,40.783,-91.126,,2152
-G-BRM,Barquisimeto,,,gleam_basin,,W-SA,,VE,VEN,,10.043,-69.359,1116000.0,1705
-G-BRN,Berne,,,gleam_basin,,W-EU,,CH,CHE,,46.914,7.497,6000.0,275
-G-BRQ,Brno,,,gleam_basin,,W-EU,,CZ,CZE,,49.151,16.694,388000.0,1176
-G-BRR,Barra,,,gleam_basin,,W-EU,,GB,GBR,,57.023,-7.443,2000.0,765
-G-BRS,Bristol,,,gleam_basin,,W-EU,,GB,GBR,,51.383,-2.719,554000.0,764
-G-BRU,Brussels,,,gleam_basin,,W-EU,,BE,BEL,,50.901,4.484,1743000.0,720
+G-BRM,Barquisimeto,,,gleam_basin,,W-SA,,VE,VEN,,10.043,-69.359,1116000,1705
+G-BRN,Berne,,,gleam_basin,,W-EU,,CH,CHE,,46.914,7.497,6000,275
+G-BRQ,Brno,,,gleam_basin,,W-EU,,CZ,CZE,,49.151,16.694,388000,1176
+G-BRR,Barra,,,gleam_basin,,W-EU,,GB,GBR,,57.023,-7.443,2000,765
+G-BRS,Bristol,,,gleam_basin,,W-EU,,GB,GBR,,51.383,-2.719,554000,764
+G-BRU,Brussels,,,gleam_basin,,W-EU,,BE,BEL,,50.901,4.484,1743000,720
 G-BRW,Barrow,,,gleam_basin,,W-NA,,US,USA,US-AK,71.285,-156.766,,2151
-G-BSA,Bosaso,,,gleam_basin,,W-AF,,SO,SOM,,11.275,49.149,74000.0,2830
-G-BSB,Brasilia,,,gleam_basin,,W-SA,,BR,BRA,,-15.869,-47.921,3717000.0,1961
+G-BSA,Bosaso,,,gleam_basin,,W-AF,,SO,SOM,,11.275,49.149,74000,2830
+G-BSB,Brasilia,,,gleam_basin,,W-SA,,BR,BRA,,-15.869,-47.921,3717000,1961
 G-BSC,Bahia Solano,,,gleam_basin,,W-SA,,CO,COL,,6.203,-77.395,,1370
-G-BSD,Baoshan,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.053,99.168,1000000.0,354
-G-BSG,Bata,,,gleam_basin,,W-AF,,GQ,GNQ,,1.905,9.806,173000.0,2054
-G-BSK,Biskra,,,gleam_basin,,W-AF,,DZ,DZA,,34.793,5.738,202000.0,23
-G-BSL,Basel,,,gleam_basin,,W-EU,,FR,FRA,,47.59,7.529,830000.0,1501
+G-BSD,Baoshan,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.053,99.168,1000000,354
+G-BSG,Bata,,,gleam_basin,,W-AF,,GQ,GNQ,,1.905,9.806,173000,2054
+G-BSK,Biskra,,,gleam_basin,,W-AF,,DZ,DZA,,34.793,5.738,202000,23
+G-BSL,Basel,,,gleam_basin,,W-EU,,FR,FRA,,47.59,7.529,830000,1501
 G-BSO,Basco,,,gleam_basin,,W-AS,,PH,PHL,,20.451,121.98,,599
-G-BSR,Basrah,,,gleam_basin,,W-AS,,IQ,IRQ,,30.549,47.662,2600000.0,2913
-G-BTC,Batticaloa,,,gleam_basin,,W-AS,,LK,LKA,,7.706,81.679,129000.0,754
-G-BTH,Batam,,,gleam_basin,,W-AS,,ID,IDN,,1.121,104.119,944000.0,1240
+G-BSR,Basrah,,,gleam_basin,,W-AS,,IQ,IRQ,,30.549,47.662,2600000,2913
+G-BTC,Batticaloa,,,gleam_basin,,W-AS,,LK,LKA,,7.706,81.679,129000,754
+G-BTH,Batam,,,gleam_basin,,W-AS,,ID,IDN,,1.121,104.119,944000,1240
 G-BTI,Barter Island,,,gleam_basin,,W-NA,,US,USA,US-AK,70.134,-143.582,,2090
-G-BTJ,Banda Aceh,,,gleam_basin,,W-AS,,ID,IDN,,5.523,95.421,514000.0,1241
-G-BTK,Bratsk,,,gleam_basin,,W-EU,,RU,RUS,,56.371,101.698,246000.0,1809
-G-BTM,Butte,,,gleam_basin,,W-NA,,US,USA,US-MT,45.955,-112.497,31000.0,2089
-G-BTR,Baton Rouge,,,gleam_basin,,W-NA,,US,USA,US-LA,30.533,-91.15,584000.0,2088
-G-BTS,Bratislava,,,gleam_basin,,W-EU,,SK,SVK,,48.17,17.213,424000.0,2812
+G-BTJ,Banda Aceh,,,gleam_basin,,W-AS,,ID,IDN,,5.523,95.421,514000,1241
+G-BTK,Bratsk,,,gleam_basin,,W-EU,,RU,RUS,,56.371,101.698,246000,1809
+G-BTM,Butte,,,gleam_basin,,W-NA,,US,USA,US-MT,45.955,-112.497,31000,2089
+G-BTR,Baton Rouge,,,gleam_basin,,W-NA,,US,USA,US-LA,30.533,-91.15,584000,2088
+G-BTS,Bratislava,,,gleam_basin,,W-EU,,SK,SVK,,48.17,17.213,424000,2812
 G-BTT,Bettles,,,gleam_basin,,W-NA,,US,USA,US-AK,66.914,-151.529,,2087
-G-BTU,Bintulu,,,gleam_basin,,W-AS,,MY,MYS,,3.124,113.02,152000.0,167
+G-BTU,Bintulu,,,gleam_basin,,W-AS,,MY,MYS,,3.124,113.02,152000,167
 G-BTV,Burlington (US-VT),,,gleam_basin,,W-NA,,US,USA,US-VT,44.472,-73.153,,2139
 G-BUA,Buka,,,gleam_basin,,W-OC,,PG,PNG,,-5.422,154.673,,2981
-G-BUC,Burketown,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-17.749,139.534,0.0,1586
-G-BUD,Budapest,,,gleam_basin,,W-EU,,HU,HUN,,47.43,19.261,1679000.0,830
-G-BUF,Buffalo,,,gleam_basin,,W-NA,,US,USA,US-NY,42.94,-78.732,926000.0,2336
-G-BUL,Bulolo,,,gleam_basin,,W-OC,,PG,PNG,,-7.216,146.65,16000.0,2980
-G-BUN,Buenaventura,,,gleam_basin,,W-SA,,CO,COL,,3.82,-76.99,253000.0,1365
-G-BUQ,Bulawayo,,,gleam_basin,,W-AF,,ZW,ZWE,,-20.017,28.618,699000.0,958
-G-BUS,Batumi,,,gleam_basin,,W-AS,,GE,GEO,,41.61,41.6,156000.0,842
-G-BUW,Baubau,,,gleam_basin,,W-AS,,ID,IDN,,-5.487,122.569,24000.0,1245
-G-BUX,Bunia,,,gleam_basin,,W-AF,,CD,COD,,1.566,30.221,97000.0,1329
-G-BUZ,Bushehr,,,gleam_basin,,W-AS,,IR,IRN,,28.945,50.835,165000.0,2933
-G-BVB,Boa Vista,,,gleam_basin,,W-SA,,BR,BRA,,2.841,-60.692,235000.0,2039
+G-BUC,Burketown,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-17.749,139.534,0,1586
+G-BUD,Budapest,,,gleam_basin,,W-EU,,HU,HUN,,47.43,19.261,1679000,830
+G-BUF,Buffalo,,,gleam_basin,,W-NA,,US,USA,US-NY,42.94,-78.732,926000,2336
+G-BUL,Bulolo,,,gleam_basin,,W-OC,,PG,PNG,,-7.216,146.65,16000,2980
+G-BUN,Buenaventura,,,gleam_basin,,W-SA,,CO,COL,,3.82,-76.99,253000,1365
+G-BUQ,Bulawayo,,,gleam_basin,,W-AF,,ZW,ZWE,,-20.017,28.618,699000,958
+G-BUS,Batumi,,,gleam_basin,,W-AS,,GE,GEO,,41.61,41.6,156000,842
+G-BUW,Baubau,,,gleam_basin,,W-AS,,ID,IDN,,-5.487,122.569,24000,1245
+G-BUX,Bunia,,,gleam_basin,,W-AF,,CD,COD,,1.566,30.221,97000,1329
+G-BUZ,Bushehr,,,gleam_basin,,W-AS,,IR,IRN,,28.945,50.835,165000,2933
+G-BVB,Boa Vista,,,gleam_basin,,W-SA,,BR,BRA,,2.841,-60.692,235000,2039
 G-BVC,Boa Vista Island,,,gleam_basin,,W-AF,,CV,CPV,,16.136,-22.889,,138
-G-BVE,Brive-La-Gaillarde,,,gleam_basin,,W-EU,,FR,FRA,,45.04,1.486,55000.0,1536
-G-BVH,Vilhena,,,gleam_basin,,W-SA,,BR,BRA,,-12.694,-60.098,63000.0,2040
-G-BVI,Birdsville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.897,139.348,0.0,1683
+G-BVE,Brive-La-Gaillarde,,,gleam_basin,,W-EU,,FR,FRA,,45.04,1.486,55000,1536
+G-BVH,Vilhena,,,gleam_basin,,W-SA,,BR,BRA,,-12.694,-60.098,63000,2040
+G-BVI,Birdsville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.897,139.348,0,1683
 G-BVV,Iturup Island,,,gleam_basin,,W-EU,,RU,RUS,,,,,1922
 G-BWA,Bhairawa,,,gleam_basin,,W-AS,,NP,NPL,,27.506,83.416,,553
-G-BWI,Baltimore,,,gleam_basin,,W-NA,,US,USA,US-MD,39.175,-76.668,2171000.0,2335
-G-BWN,Bandar Seri Begawan,,,gleam_basin,,W-AS,,BN,BRN,,4.944,114.928,296000.0,1789
-G-BWT,Burnie,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-40.999,145.731,20000.0,1569
+G-BWI,Baltimore,,,gleam_basin,,W-NA,,US,USA,US-MD,39.175,-76.668,2171000,2335
+G-BWN,Bandar Seri Begawan,,,gleam_basin,,W-AS,,BN,BRN,,4.944,114.928,296000,1789
+G-BWT,Burnie,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-40.999,145.731,20000,1569
 G-BWW,Cayo Las Brujas,,,gleam_basin,,W-NA,,CU,CUB,,22.621,-79.147,,3236
 G-BXB,Irarutu,,,gleam_basin,,W-AS,,ID,IDN,,-2.532,133.439,,1307
-G-BXR,Bam,,,gleam_basin,,W-AS,,IR,IRN,,29.084,58.45,99000.0,2967
-G-BXU,Butuan,,,gleam_basin,,W-AS,,PH,PHL,,8.951,125.479,191000.0,620
-G-BYC,Yacuiba,,,gleam_basin,,W-SA,,BO,BOL,,-21.961,-63.652,83000.0,85
+G-BXR,Bam,,,gleam_basin,,W-AS,,IR,IRN,,29.084,58.45,99000,2967
+G-BXU,Butuan,,,gleam_basin,,W-AS,,PH,PHL,,8.951,125.479,191000,620
+G-BYC,Yacuiba,,,gleam_basin,,W-SA,,BO,BOL,,-21.961,-63.652,83000,85
 G-BYF,Albert,,,gleam_basin,,W-EU,,FR,FRA,,49.972,2.698,,1490
-G-BYJ,Beja,,,gleam_basin,,W-EU,,PT,PRT,,38.079,-7.932,60000.0,1428
-G-BYM,Bayamo,,,gleam_basin,,W-NA,,CU,CUB,,20.396,-76.621,193000.0,3237
+G-BYJ,Beja,,,gleam_basin,,W-EU,,PT,PRT,,38.079,-7.932,60000,1428
+G-BYM,Bayamo,,,gleam_basin,,W-NA,,CU,CUB,,20.396,-76.621,193000,3237
 G-BYN,Bayankhongor,,,gleam_basin,,W-AS,,MN,MNG,,46.163,100.704,,845
 G-BYO,Bonito,,,gleam_basin,,W-SA,,BR,BRA,,-21.247,-56.452,,1934
-G-BZE,Belize City,,,gleam_basin,,W-NA,,BZ,BLZ,,17.539,-88.308,63000.0,862
-G-BZG,Bydgoszcz,,,gleam_basin,,W-EU,,PL,POL,,53.097,17.978,366000.0,2859
-G-BZL,Barisal,,,gleam_basin,,W-AS,,BD,BGD,,22.801,90.301,202000.0,66
-G-BZN,Bozeman,,,gleam_basin,,W-NA,,US,USA,US-MT,45.778,-111.153,54000.0,2403
-G-BZO,Bolzano,,,gleam_basin,,W-EU,,IT,ITA,,46.46,11.326,96000.0,3091
-G-BZR,Beziers,,,gleam_basin,,W-EU,,FR,FRA,,43.324,3.354,81000.0,1524
-G-BZV,Brazzaville,,,gleam_basin,,W-AF,,CG,COG,,-4.252,15.253,1355000.0,1346
-G-CAB,Cabinda,,,gleam_basin,,W-AF,,AO,AGO,,-5.597,12.188,92000.0,6
-G-CAC,Cascavel,,,gleam_basin,,W-SA,,BR,BRA,,-25,-53.501,257000.0,2018
+G-BZE,Belize City,,,gleam_basin,,W-NA,,BZ,BLZ,,17.539,-88.308,63000,862
+G-BZG,Bydgoszcz,,,gleam_basin,,W-EU,,PL,POL,,53.097,17.978,366000,2859
+G-BZL,Barisal,,,gleam_basin,,W-AS,,BD,BGD,,22.801,90.301,202000,66
+G-BZN,Bozeman,,,gleam_basin,,W-NA,,US,USA,US-MT,45.778,-111.153,54000,2403
+G-BZO,Bolzano,,,gleam_basin,,W-EU,,IT,ITA,,46.46,11.326,96000,3091
+G-BZR,Beziers,,,gleam_basin,,W-EU,,FR,FRA,,43.324,3.354,81000,1524
+G-BZV,Brazzaville,,,gleam_basin,,W-AF,,CG,COG,,-4.252,15.253,1355000,1346
+G-CAB,Cabinda,,,gleam_basin,,W-AF,,AO,AGO,,-5.597,12.188,92000,6
+G-CAC,Cascavel,,,gleam_basin,,W-SA,,BR,BRA,,-25,-53.501,257000,2018
 G-CAE,Columbia (US-SC),,,gleam_basin,,W-NA,,US,USA,US-SC,33.939,-81.119,,2295
-G-CAG,Cagliari,,,gleam_basin,,W-EU,,IT,ITA,,39.251,9.054,292000.0,3088
-G-CAH,Ca Mau,,,gleam_basin,,W-AS,,VN,VNM,,9.178,105.178,357000.0,1131
-G-CAI,Cairo,,,gleam_basin,,W-AF,,EG,EGY,,30.122,31.406,11893000.0,52
+G-CAG,Cagliari,,,gleam_basin,,W-EU,,IT,ITA,,39.251,9.054,292000,3088
+G-CAH,Ca Mau,,,gleam_basin,,W-AS,,VN,VNM,,9.178,105.178,357000,1131
+G-CAI,Cairo,,,gleam_basin,,W-AF,,EG,EGY,,30.122,31.406,11893000,52
 G-CAJ,Canaima,,,gleam_basin,,W-SA,,VE,VEN,,6.232,-62.854,,1711
-G-CAK,Akron,,,gleam_basin,,W-NA,,US,USA,US-OH,40.916,-81.442,566000.0,2294
-G-CAN,Guangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,23.392,113.299,8829000.0,455
-G-CAP,Cap Haitien,,,gleam_basin,,W-NA,,HT,HTI,,19.733,-72.195,281000.0,979
-G-CAW,Campos,,,gleam_basin,,W-SA,,BR,BRA,,-21.698,-41.302,387000.0,1993
-G-CAY,Cayenne,,,gleam_basin,,W-SA,,GF,GUF,,4.82,-52.36,62000.0,718
+G-CAK,Akron,,,gleam_basin,,W-NA,,US,USA,US-OH,40.916,-81.442,566000,2294
+G-CAN,Guangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,23.392,113.299,8829000,455
+G-CAP,Cap Haitien,,,gleam_basin,,W-NA,,HT,HTI,,19.733,-72.195,281000,979
+G-CAW,Campos,,,gleam_basin,,W-SA,,BR,BRA,,-21.698,-41.302,387000,1993
+G-CAY,Cayenne,,,gleam_basin,,W-SA,,GF,GUF,,4.82,-52.36,62000,718
 G-CAZ,Cobar,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.538,145.794,,1628
-G-CBB,Cochabamba,,,gleam_basin,,W-SA,,BO,BOL,,-17.421,-66.177,1000000.0,95
-G-CBH,Bechar,,,gleam_basin,,W-AF,,DZ,DZA,,31.646,-2.27,143000.0,42
-G-CBO,Cotabato,,,gleam_basin,,W-AS,,PH,PHL,,7.165,124.21,280000.0,613
-G-CBQ,Calabar,,,gleam_basin,,W-AF,,NG,NGA,,4.976,8.347,462000.0,1424
-G-CBR,Canberra,,,gleam_basin,,W-OC,,AU,AUS,AU-ACT,-35.307,149.195,328000.0,1655
-G-CBS,Cabimas,,,gleam_basin,,W-SA,,VE,VEN,,,,441000.0,1715
-G-CBT,Catumbela,,,gleam_basin,,W-AF,,AO,AGO,,-12.479,13.487,17000.0,12
+G-CBB,Cochabamba,,,gleam_basin,,W-SA,,BO,BOL,,-17.421,-66.177,1000000,95
+G-CBH,Bechar,,,gleam_basin,,W-AF,,DZ,DZA,,31.646,-2.27,143000,42
+G-CBO,Cotabato,,,gleam_basin,,W-AS,,PH,PHL,,7.165,124.21,280000,613
+G-CBQ,Calabar,,,gleam_basin,,W-AF,,NG,NGA,,4.976,8.347,462000,1424
+G-CBR,Canberra,,,gleam_basin,,W-OC,,AU,AUS,AU-ACT,-35.307,149.195,328000,1655
+G-CBS,Cabimas,,,gleam_basin,,W-SA,,VE,VEN,,,,441000,1715
+G-CBT,Catumbela,,,gleam_basin,,W-AF,,AO,AGO,,-12.479,13.487,17000,12
 G-CCC,Cayo Coco,,,gleam_basin,,W-NA,,CU,CUB,,22.461,-78.328,,3249
-G-CCF,Carcassonne,,,gleam_basin,,W-EU,,FR,FRA,,43.216,2.306,50000.0,1521
-G-CCJ,Kozhikode,,,gleam_basin,,W-AS,,IN,IND,,11.137,75.955,440000.0,1096
+G-CCF,Carcassonne,,,gleam_basin,,W-EU,,FR,FRA,,43.216,2.306,50000,1521
+G-CCJ,Kozhikode,,,gleam_basin,,W-AS,,IN,IND,,11.137,75.955,440000,1096
 G-CCK,Cocos Islands,,,gleam_basin,,W-AS,,CC,CCK,,-12.188,96.834,,104
-G-CCM,Criciuma,,,gleam_basin,,W-SA,,BR,BRA,,-28.724,-49.421,204000.0,2005
+G-CCM,Criciuma,,,gleam_basin,,W-SA,,BR,BRA,,-28.724,-49.421,204000,2005
 G-CCN,Chaghcharan,,,gleam_basin,,W-AS,,AF,AFG,,34.533,65.267,,887
-G-CCP,Concepcion,,,gleam_basin,,W-SA,,CL,CHL,,-36.773,-73.063,890000.0,303
-G-CCS,Caracas,,,gleam_basin,,W-SA,,VE,VEN,,10.601,-66.991,2985000.0,1714
-G-CCU,Kolkata,,,gleam_basin,,W-AS,,IN,IND,,22.655,88.447,14787000.0,1095
+G-CCP,Concepcion,,,gleam_basin,,W-SA,,CL,CHL,,-36.773,-73.063,890000,303
+G-CCS,Caracas,,,gleam_basin,,W-SA,,VE,VEN,,10.601,-66.991,2985000,1714
+G-CCU,Kolkata,,,gleam_basin,,W-AS,,IN,IND,,22.655,88.447,14787000,1095
 G-CDB,Cold Bay,,,gleam_basin,,W-NA,,US,USA,US-AK,55.206,-162.725,,2487
-G-CDC,Cedar City,,,gleam_basin,,W-NA,,US,USA,US-UT,37.701,-113.099,37000.0,2488
-G-CDG,Paris,,,gleam_basin,,W-EU,,FR,FRA,,49.013,2.55,9904000.0,1535
-G-CDR,Chadron,,,gleam_basin,,W-NA,,US,USA,US-NE,42.838,-103.095,5000.0,2492
-G-CDV,Cordova,,,gleam_basin,,W-NA,,US,USA,US-AK,60.492,-145.478,29000.0,2490
-G-CEB,Cebu,,,gleam_basin,,W-AS,,PH,PHL,,10.307,123.979,866000.0,615
-G-CEC,Crescent City,,,gleam_basin,,W-NA,,US,USA,US-CA,41.78,-124.237,16000.0,2438
-G-CED,Ceduna,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-32.131,133.71,2000.0,1664
-G-CEE,Cherepovets,,,gleam_basin,,W-EU,,RU,RUS,,59.274,38.016,312000.0,1905
+G-CDC,Cedar City,,,gleam_basin,,W-NA,,US,USA,US-UT,37.701,-113.099,37000,2488
+G-CDG,Paris,,,gleam_basin,,W-EU,,FR,FRA,,49.013,2.55,9904000,1535
+G-CDR,Chadron,,,gleam_basin,,W-NA,,US,USA,US-NE,42.838,-103.095,5000,2492
+G-CDV,Cordova,,,gleam_basin,,W-NA,,US,USA,US-AK,60.492,-145.478,29000,2490
+G-CEB,Cebu,,,gleam_basin,,W-AS,,PH,PHL,,10.307,123.979,866000,615
+G-CEC,Crescent City,,,gleam_basin,,W-NA,,US,USA,US-CA,41.78,-124.237,16000,2438
+G-CED,Ceduna,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-32.131,133.71,2000,1664
+G-CEE,Cherepovets,,,gleam_basin,,W-EU,,RU,RUS,,59.274,38.016,312000,1905
 G-CEH,Chelinda,,,gleam_basin,,W-AF,,MW,MWI,,,,,2871
-G-CEI,Chiang Rai,,,gleam_basin,,W-AS,,TH,THA,,19.952,99.883,117000.0,545
-G-CEK,Chelyabinsk,,,gleam_basin,,W-EU,,RU,RUS,,55.306,61.503,1091000.0,1906
-G-CEM,Central,,,gleam_basin,,W-NA,,US,USA,US-LA,65.574,-144.783,29000.0,2439
-G-CEN,Ciudad Obregon,,,gleam_basin,,W-NA,,MX,MEX,,27.393,-109.833,288000.0,1028
-G-CER,Cherbourg,,,gleam_basin,,W-EU,,FR,FRA,,49.65,-1.47,61000.0,1528
-G-CEZ,Cortez,,,gleam_basin,,W-NA,,US,USA,US-CO,37.303,-108.628,9000.0,2442
-G-CFB,Cabo Frio,,,gleam_basin,,W-SA,,BR,BRA,,-22.922,-42.074,262000.0,1939
-G-CFC,Cacador,,,gleam_basin,,W-SA,,BR,BRA,,-26.788,-50.94,64000.0,1940
-G-CFE,Clermont-Ferrand,,,gleam_basin,,W-EU,,FR,FRA,,45.787,3.169,233000.0,1492
-G-CFG,Cienfuegos,,,gleam_basin,,W-NA,,CU,CUB,,22.15,-80.414,187000.0,3238
-G-CFK,Chlef,,,gleam_basin,,W-AF,,DZ,DZA,,36.213,1.332,449000.0,14
-G-CFN,Donegal,,,gleam_basin,,W-EU,,IE,IRL,,55.044,-8.341,3000.0,2922
-G-CFR,Caen,,,gleam_basin,,W-EU,,FR,FRA,,49.173,-0.45,190000.0,1515
-G-CFS,Coffs Harbour,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.321,153.116,63000.0,1577
-G-CFU,Kerkyra,,,gleam_basin,,W-EU,,GR,GRC,,39.602,19.912,39000.0,909
-G-CGB,Cuiaba,,,gleam_basin,,W-SA,,BR,BRA,,-15.653,-56.117,806000.0,2044
-G-CGD,Changde,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,28.919,111.64,1469000.0,482
-G-CGI,Cape Girardeau,,,gleam_basin,,W-NA,,US,USA,US-MO,37.225,-89.571,55000.0,2521
-G-CGK,Jakarta,,,gleam_basin,,W-AS,,ID,IDN,,-6.126,106.656,9125000.0,1314
+G-CEI,Chiang Rai,,,gleam_basin,,W-AS,,TH,THA,,19.952,99.883,117000,545
+G-CEK,Chelyabinsk,,,gleam_basin,,W-EU,,RU,RUS,,55.306,61.503,1091000,1906
+G-CEM,Central,,,gleam_basin,,W-NA,,US,USA,US-LA,65.574,-144.783,29000,2439
+G-CEN,Ciudad Obregon,,,gleam_basin,,W-NA,,MX,MEX,,27.393,-109.833,288000,1028
+G-CER,Cherbourg,,,gleam_basin,,W-EU,,FR,FRA,,49.65,-1.47,61000,1528
+G-CEZ,Cortez,,,gleam_basin,,W-NA,,US,USA,US-CO,37.303,-108.628,9000,2442
+G-CFB,Cabo Frio,,,gleam_basin,,W-SA,,BR,BRA,,-22.922,-42.074,262000,1939
+G-CFC,Cacador,,,gleam_basin,,W-SA,,BR,BRA,,-26.788,-50.94,64000,1940
+G-CFE,Clermont-Ferrand,,,gleam_basin,,W-EU,,FR,FRA,,45.787,3.169,233000,1492
+G-CFG,Cienfuegos,,,gleam_basin,,W-NA,,CU,CUB,,22.15,-80.414,187000,3238
+G-CFK,Chlef,,,gleam_basin,,W-AF,,DZ,DZA,,36.213,1.332,449000,14
+G-CFN,Donegal,,,gleam_basin,,W-EU,,IE,IRL,,55.044,-8.341,3000,2922
+G-CFR,Caen,,,gleam_basin,,W-EU,,FR,FRA,,49.173,-0.45,190000,1515
+G-CFS,Coffs Harbour,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.321,153.116,63000,1577
+G-CFU,Kerkyra,,,gleam_basin,,W-EU,,GR,GRC,,39.602,19.912,39000,909
+G-CGB,Cuiaba,,,gleam_basin,,W-SA,,BR,BRA,,-15.653,-56.117,806000,2044
+G-CGD,Changde,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,28.919,111.64,1469000,482
+G-CGI,Cape Girardeau,,,gleam_basin,,W-NA,,US,USA,US-MO,37.225,-89.571,55000,2521
+G-CGK,Jakarta,,,gleam_basin,,W-AS,,ID,IDN,,-6.126,106.656,9125000,1314
 G-CGM,Camiguin,,,gleam_basin,,W-AS,,PH,PHL,,9.254,124.707,,623
-G-CGN,Cologne,,,gleam_basin,,W-EU,,DE,DEU,,50.866,7.143,1004000.0,752
-G-CGO,Zhengzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,34.52,113.841,2636000.0,481
-G-CGP,Chittagong,,,gleam_basin,,W-AS,,BD,BGD,,22.25,91.813,4529000.0,68
-G-CGQ,Changchun,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,43.996,125.685,3183000.0,483
-G-CGR,Campo Grande,,,gleam_basin,,W-SA,,BR,BRA,,-20.469,-54.673,778000.0,2045
-G-CGY,Cagayan de Oro,,,gleam_basin,,W-AS,,PH,PHL,,8.612,124.456,1122000.0,624
-G-CHA,Chattanooga,,,gleam_basin,,W-NA,,US,USA,US-TN,35.035,-85.204,407000.0,2074
-G-CHC,Christchurch,,,gleam_basin,,W-OC,,NZ,NZL,,-43.489,172.532,363000.0,3041
-G-CHG,Chaoyang,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.538,120.435,470000.0,319
-G-CHO,Charlottesville,,,gleam_basin,,W-NA,,US,USA,US-VA,38.139,-78.453,102000.0,2313
-G-CHQ,Chania,,,gleam_basin,,W-EU,,GR,GRC,,35.532,24.15,79000.0,910
-G-CHR,Chateauroux,,,gleam_basin,,W-EU,,FR,FRA,,46.86,1.721,53000.0,1493
+G-CGN,Cologne,,,gleam_basin,,W-EU,,DE,DEU,,50.866,7.143,1004000,752
+G-CGO,Zhengzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,34.52,113.841,2636000,481
+G-CGP,Chittagong,,,gleam_basin,,W-AS,,BD,BGD,,22.25,91.813,4529000,68
+G-CGQ,Changchun,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,43.996,125.685,3183000,483
+G-CGR,Campo Grande,,,gleam_basin,,W-SA,,BR,BRA,,-20.469,-54.673,778000,2045
+G-CGY,Cagayan de Oro,,,gleam_basin,,W-AS,,PH,PHL,,8.612,124.456,1122000,624
+G-CHA,Chattanooga,,,gleam_basin,,W-NA,,US,USA,US-TN,35.035,-85.204,407000,2074
+G-CHC,Christchurch,,,gleam_basin,,W-OC,,NZ,NZL,,-43.489,172.532,363000,3041
+G-CHG,Chaoyang,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.538,120.435,470000,319
+G-CHO,Charlottesville,,,gleam_basin,,W-NA,,US,USA,US-VA,38.139,-78.453,102000,2313
+G-CHQ,Chania,,,gleam_basin,,W-EU,,GR,GRC,,35.532,24.15,79000,910
+G-CHR,Chateauroux,,,gleam_basin,,W-EU,,FR,FRA,,46.86,1.721,53000,1493
 G-CHS,Charleston (US-SC),,,gleam_basin,,W-NA,,US,USA,US-SC,32.899,-80.04,,2078
 G-CHT,Chatham Island,,,gleam_basin,,W-OC,,NZ,NZL,,-43.81,-176.457,,3042
 G-CHY,Choiseul Bay,,,gleam_basin,,W-OC,,SB,SLB,,-6.712,156.396,,3020
-G-CIC,Chico,,,gleam_basin,,W-NA,,US,USA,US-CA,39.795,-121.858,106000.0,2523
-G-CID,Cedar Rapids,,,gleam_basin,,W-NA,,US,USA,US-IA,41.885,-91.711,186000.0,2525
-G-CIF,Chifeng,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,42.235,118.908,1277000.0,484
-G-CIH,Changzhi,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,36.248,113.126,706000.0,485
-G-CIJ,Cobija,,,gleam_basin,,W-SA,,BO,BOL,,-11.04,-68.783,44000.0,97
+G-CIC,Chico,,,gleam_basin,,W-NA,,US,USA,US-CA,39.795,-121.858,106000,2523
+G-CID,Cedar Rapids,,,gleam_basin,,W-NA,,US,USA,US-IA,41.885,-91.711,186000,2525
+G-CIF,Chifeng,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,42.235,118.908,1277000,484
+G-CIH,Changzhi,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,36.248,113.126,706000,485
+G-CIJ,Cobija,,,gleam_basin,,W-SA,,BO,BOL,,-11.04,-68.783,44000,97
 G-CIK,Chalkyitsik,,,gleam_basin,,W-NA,,US,USA,US-AK,66.645,-143.74,,2526
-G-CIP,Chipata,,,gleam_basin,,W-AF,,ZM,ZMB,,-13.558,32.587,86000.0,1553
-G-CIT,Shymkent,,,gleam_basin,,W-AS,,KZ,KAZ,,42.364,69.479,465000.0,673
+G-CIP,Chipata,,,gleam_basin,,W-AF,,ZM,ZMB,,-13.558,32.587,86000,1553
+G-CIT,Shymkent,,,gleam_basin,,W-AS,,KZ,KAZ,,42.364,69.479,465000,673
 G-CIU,Sault Ste Marie (US),,,gleam_basin,,W-NA,,US,USA,US-MI,46.251,-84.472,,2531
 G-CIW,Canouan Island,,,gleam_basin,,W-NA,,VC,VCT,,12.699,-61.342,,1119
-G-CIX,Chiclayo,,,gleam_basin,,W-SA,,PE,PER,,-6.787,-79.828,597000.0,1230
-G-CIY,Comiso,,,gleam_basin,,W-EU,,IT,ITA,,36.995,14.607,26000.0,3100
-G-CIZ,Coari,,,gleam_basin,,W-SA,,BR,BRA,,-4.134,-63.133,53000.0,2047
-G-CJA,Cajamarca,,,gleam_basin,,W-SA,,PE,PER,,-7.139,-78.489,143000.0,1214
-G-CJB,Coimbatore,,,gleam_basin,,W-AS,,IN,IND,,11.03,77.043,1696000.0,1063
-G-CJC,Calama,,,gleam_basin,,W-SA,,CL,CHL,,-22.498,-68.904,143000.0,294
-G-CJJ,Cheongju,,,gleam_basin,,W-AS,,KR,KOR,,36.717,127.499,775000.0,2800
-G-CJL,Chitral,,,gleam_basin,,W-AS,,PK,PAK,,35.887,71.801,2000000.0,111
-G-CJM,Chumphon,,,gleam_basin,,W-AS,,TH,THA,,10.711,99.362,86000.0,526
-G-CJS,Ciudad Juarez,,,gleam_basin,,W-NA,,MX,MEX,,31.636,-106.429,1512000.0,990
-G-CJU,Jeju,,,gleam_basin,,W-AS,,KR,KOR,,33.511,126.493,408000.0,2801
-G-CKD,Crooked Creek,,,gleam_basin,,W-NA,,US,USA,US-IN,,,100.0,2459
-G-CKG,Chongqing,,,gleam_basin,,W-AS,,CN,CHN,CN-CQ,29.719,106.642,6461000.0,325
-G-CKH,Chokurdakh,,,gleam_basin,,W-EU,,RU,RUS,,70.623,147.902,3000.0,1810
+G-CIX,Chiclayo,,,gleam_basin,,W-SA,,PE,PER,,-6.787,-79.828,597000,1230
+G-CIY,Comiso,,,gleam_basin,,W-EU,,IT,ITA,,36.995,14.607,26000,3100
+G-CIZ,Coari,,,gleam_basin,,W-SA,,BR,BRA,,-4.134,-63.133,53000,2047
+G-CJA,Cajamarca,,,gleam_basin,,W-SA,,PE,PER,,-7.139,-78.489,143000,1214
+G-CJB,Coimbatore,,,gleam_basin,,W-AS,,IN,IND,,11.03,77.043,1696000,1063
+G-CJC,Calama,,,gleam_basin,,W-SA,,CL,CHL,,-22.498,-68.904,143000,294
+G-CJJ,Cheongju,,,gleam_basin,,W-AS,,KR,KOR,,36.717,127.499,775000,2800
+G-CJL,Chitral,,,gleam_basin,,W-AS,,PK,PAK,,35.887,71.801,2000000,111
+G-CJM,Chumphon,,,gleam_basin,,W-AS,,TH,THA,,10.711,99.362,86000,526
+G-CJS,Ciudad Juarez,,,gleam_basin,,W-NA,,MX,MEX,,31.636,-106.429,1512000,990
+G-CJU,Jeju,,,gleam_basin,,W-AS,,KR,KOR,,33.511,126.493,408000,2801
+G-CKD,Crooked Creek,,,gleam_basin,,W-NA,,US,USA,US-IN,,,100,2459
+G-CKG,Chongqing,,,gleam_basin,,W-AS,,CN,CHN,CN-CQ,29.719,106.642,6461000,325
+G-CKH,Chokurdakh,,,gleam_basin,,W-EU,,RU,RUS,,70.623,147.902,3000,1810
 G-CKS,Carajas,,,gleam_basin,,W-SA,,BR,BRA,,-6.115,-50.001,,1949
 G-CKX,Chicken,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2107
-G-CKY,Conakry,,,gleam_basin,,W-AF,,GN,GIN,,9.577,-13.612,1494000.0,495
-G-CLE,Cleveland,,,gleam_basin,,W-NA,,US,USA,US-OH,41.412,-81.85,1730000.0,2212
-G-CLJ,Cluj-Napoca,,,gleam_basin,,W-EU,,RO,ROU,,46.785,23.686,317000.0,139
-G-CLL,Bryan,,,gleam_basin,,W-NA,,US,USA,US-TX,30.589,-96.364,84000.0,2210
-G-CLM,Port Angeles,,,gleam_basin,,W-NA,,US,USA,US-WA,48.12,-123.5,24000.0,2211
-G-CLO,Cali,,,gleam_basin,,W-SA,,CO,COL,,3.543,-76.382,2254000.0,1374
-G-CLQ,Colima,,,gleam_basin,,W-NA,,MX,MEX,,19.277,-103.577,223000.0,998
-G-CLT,Charlotte,,,gleam_basin,,W-NA,,US,USA,US-NC,35.214,-80.943,1467000.0,2214
-G-CLV,Caldas Novas,,,gleam_basin,,W-SA,,BR,BRA,,-17.725,-48.607,64000.0,1973
+G-CKY,Conakry,,,gleam_basin,,W-AF,,GN,GIN,,9.577,-13.612,1494000,495
+G-CLE,Cleveland,,,gleam_basin,,W-NA,,US,USA,US-OH,41.412,-81.85,1730000,2212
+G-CLJ,Cluj-Napoca,,,gleam_basin,,W-EU,,RO,ROU,,46.785,23.686,317000,139
+G-CLL,Bryan,,,gleam_basin,,W-NA,,US,USA,US-TX,30.589,-96.364,84000,2210
+G-CLM,Port Angeles,,,gleam_basin,,W-NA,,US,USA,US-WA,48.12,-123.5,24000,2211
+G-CLO,Cali,,,gleam_basin,,W-SA,,CO,COL,,3.543,-76.382,2254000,1374
+G-CLQ,Colima,,,gleam_basin,,W-NA,,MX,MEX,,19.277,-103.577,223000,998
+G-CLT,Charlotte,,,gleam_basin,,W-NA,,US,USA,US-NC,35.214,-80.943,1467000,2214
+G-CLV,Caldas Novas,,,gleam_basin,,W-SA,,BR,BRA,,-17.725,-48.607,64000,1973
 G-CLY,Calvi,,,gleam_basin,,W-EU,,FR,FRA,,42.524,8.793,,1507
 G-CMA,Cunnamulla,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-28.03,145.622,,1599
-G-CMB,Colombo,,,gleam_basin,,W-AS,,LK,LKA,,7.181,79.884,217000.0,758
-G-CME,Ciudad del Carmen,,,gleam_basin,,W-NA,,MX,MEX,,18.654,-91.799,156000.0,992
-G-CMF,Chambery,,,gleam_basin,,W-EU,,FR,FRA,,45.638,5.88,62000.0,1504
-G-CMG,Corumba,,,gleam_basin,,W-SA,,BR,BRA,,-19.012,-57.671,97000.0,1959
+G-CMB,Colombo,,,gleam_basin,,W-AS,,LK,LKA,,7.181,79.884,217000,758
+G-CME,Ciudad del Carmen,,,gleam_basin,,W-NA,,MX,MEX,,18.654,-91.799,156000,992
+G-CMF,Chambery,,,gleam_basin,,W-EU,,FR,FRA,,45.638,5.88,62000,1504
+G-CMG,Corumba,,,gleam_basin,,W-SA,,BR,BRA,,-19.012,-57.671,97000,1959
 G-CMH,Columbus (US-OH),,,gleam_basin,,W-NA,,US,USA,US-OH,39.998,-82.892,,2479
-G-CMI,Champaign,,,gleam_basin,,W-NA,,US,USA,US-IL,40.039,-88.278,157000.0,2170
-G-CMN,Casablanca,,,gleam_basin,,W-AF,,MA,MAR,,33.368,-7.59,3181000.0,814
-G-CMW,Camaguey,,,gleam_basin,,W-NA,,CU,CUB,,21.42,-77.848,348000.0,3245
+G-CMI,Champaign,,,gleam_basin,,W-NA,,US,USA,US-IL,40.039,-88.278,157000,2170
+G-CMN,Casablanca,,,gleam_basin,,W-AF,,MA,MAR,,33.368,-7.59,3181000,814
+G-CMW,Camaguey,,,gleam_basin,,W-NA,,CU,CUB,,21.42,-77.848,348000,3245
 G-CMX,Hancock,,,gleam_basin,,W-NA,,US,USA,US-MI,47.168,-88.489,,2171
-G-CND,Constanta,,,gleam_basin,,W-EU,,RO,ROU,,44.362,28.488,303000.0,144
-G-CNF,Belo Horizonte,,,gleam_basin,,W-SA,,BR,BRA,,-19.624,-43.972,5575000.0,2034
-G-CNJ,Cloncurry,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.669,140.504,1000.0,1626
-G-CNM,Carlsbad,,,gleam_basin,,W-NA,,US,USA,US-CA,32.338,-104.263,115000.0,2273
+G-CND,Constanta,,,gleam_basin,,W-EU,,RO,ROU,,44.362,28.488,303000,144
+G-CNF,Belo Horizonte,,,gleam_basin,,W-SA,,BR,BRA,,-19.624,-43.972,5575000,2034
+G-CNJ,Cloncurry,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.669,140.504,1000,1626
+G-CNM,Carlsbad,,,gleam_basin,,W-NA,,US,USA,US-CA,32.338,-104.263,115000,2273
 G-CNP,Neerlerit Inaat,,,gleam_basin,,W-NA,,GL,GRL,,70.743,-22.65,,954
-G-CNS,Cairns,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-16.886,145.755,154000.0,1684
-G-CNX,Chiang Mai,,,gleam_basin,,W-AS,,TH,THA,,18.767,98.963,397000.0,531
-G-CNY,Moab,,,gleam_basin,,W-NA,,US,USA,US-UT,38.755,-109.755,7000.0,2271
-G-COD,Cody,,,gleam_basin,,W-NA,,US,USA,US-WY,44.52,-109.024,10000.0,2231
+G-CNS,Cairns,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-16.886,145.755,154000,1684
+G-CNX,Chiang Mai,,,gleam_basin,,W-AS,,TH,THA,,18.767,98.963,397000,531
+G-CNY,Moab,,,gleam_basin,,W-NA,,US,USA,US-UT,38.755,-109.755,7000,2271
+G-COD,Cody,,,gleam_basin,,W-NA,,US,USA,US-WY,44.52,-109.024,10000,2231
 G-COK,Kochi (IN),,,gleam_basin,,W-AS,,IN,IND,,10.152,76.402,,1083
-G-COO,Cotonou,,,gleam_basin,,W-AF,,BJ,BEN,,6.357,2.384,762000.0,717
+G-COO,Cotonou,,,gleam_basin,,W-AF,,BJ,BEN,,6.357,2.384,762000,717
 G-COQ,Choibalsan,,,gleam_basin,,W-AS,,MN,MNG,,48.136,114.646,,847
-G-COR,Cordoba,,,gleam_basin,,W-SA,,AR,ARG,,-31.324,-64.208,1452000.0,3192
-G-COS,Colorado Springs,,,gleam_basin,,W-NA,,US,USA,US-CO,38.806,-104.701,624000.0,2243
+G-COR,Cordoba,,,gleam_basin,,W-SA,,AR,ARG,,-31.324,-64.208,1452000,3192
+G-COS,Colorado Springs,,,gleam_basin,,W-NA,,US,USA,US-CO,38.806,-104.701,624000,2243
 G-COU,Columbia (US-MO),,,gleam_basin,,W-NA,,US,USA,US-MO,38.818,-92.22,,2227
-G-CPC,San Martin de Los Andes,,,gleam_basin,,W-SA,,AR,ARG,,-40.075,-71.137,24000.0,3206
+G-CPC,San Martin de Los Andes,,,gleam_basin,,W-SA,,AR,ARG,,-40.075,-71.137,24000,3206
 G-CPD,Coober Pedy,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-29.04,134.721,,1651
-G-CPE,Campeche,,,gleam_basin,,W-NA,,MX,MEX,,19.817,-90.5,205000.0,1025
-G-CPH,Copenhagen,,,gleam_basin,,W-EU,,DK,DNK,,55.618,12.656,1085000.0,1564
-G-CPO,Copiapo,,,gleam_basin,,W-SA,,CL,CHL,,-27.261,-70.779,129000.0,305
-G-CPR,Casper,,,gleam_basin,,W-NA,,US,USA,US-WY,42.908,-106.464,67000.0,2389
-G-CPT,Cape Town,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.965,18.602,3215000.0,635
-G-CPV,Campina Grande,,,gleam_basin,,W-SA,,BR,BRA,,-7.27,-35.896,417000.0,2015
+G-CPE,Campeche,,,gleam_basin,,W-NA,,MX,MEX,,19.817,-90.5,205000,1025
+G-CPH,Copenhagen,,,gleam_basin,,W-EU,,DK,DNK,,55.618,12.656,1085000,1564
+G-CPO,Copiapo,,,gleam_basin,,W-SA,,CL,CHL,,-27.261,-70.779,129000,305
+G-CPR,Casper,,,gleam_basin,,W-NA,,US,USA,US-WY,42.908,-106.464,67000,2389
+G-CPT,Cape Town,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.965,18.602,3215000,635
+G-CPV,Campina Grande,,,gleam_basin,,W-SA,,BR,BRA,,-7.27,-35.896,417000,2015
 G-CQD,Shahre Kord,,,gleam_basin,,W-AS,,IR,IRN,,32.297,50.842,,2957
-G-CRA,Craiova,,,gleam_basin,,W-EU,,RO,ROU,,44.318,23.889,304000.0,149
-G-CRD,Comodoro Rivadavia,,,gleam_basin,,W-SA,,AR,ARG,,-45.785,-67.466,141000.0,3215
-G-CRK,Angeles,,,gleam_basin,,W-AS,,PH,PHL,,15.186,120.56,326000.0,616
-G-CRM,Catarman,,,gleam_basin,,W-AS,,PH,PHL,,12.502,124.636,47000.0,617
-G-CRP,Corpus Christi,,,gleam_basin,,W-NA,,US,USA,US-TX,27.77,-97.501,341000.0,2477
-G-CRV,Crotone,,,gleam_basin,,W-EU,,IT,ITA,,38.997,17.08,60000.0,3075
+G-CRA,Craiova,,,gleam_basin,,W-EU,,RO,ROU,,44.318,23.889,304000,149
+G-CRD,Comodoro Rivadavia,,,gleam_basin,,W-SA,,AR,ARG,,-45.785,-67.466,141000,3215
+G-CRK,Angeles,,,gleam_basin,,W-AS,,PH,PHL,,15.186,120.56,326000,616
+G-CRM,Catarman,,,gleam_basin,,W-AS,,PH,PHL,,12.502,124.636,47000,617
+G-CRP,Corpus Christi,,,gleam_basin,,W-NA,,US,USA,US-TX,27.77,-97.501,341000,2477
+G-CRV,Crotone,,,gleam_basin,,W-EU,,IT,ITA,,38.997,17.08,60000,3075
 G-CRW,Charleston (US-WV),,,gleam_basin,,W-NA,,US,USA,US-WV,38.373,-81.593,,2478
 G-CSG,Columbus (US-GA),,,gleam_basin,,W-NA,,US,USA,US-GA,32.516,-84.939,,2444
 G-CSH,Solovetsky,,,gleam_basin,,W-EU,,RU,RUS,,65.03,35.733,,1908
 G-CSK,Cap Skiring,,,gleam_basin,,W-AF,,SN,SEN,,12.395,-16.748,,1476
-G-CSO,Magdeburg,,,gleam_basin,,W-EU,,DE,DEU,,51.856,11.42,230000.0,747
-G-CSX,Changsha,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,28.189,113.22,2604000.0,456
-G-CSY,Cheboksary,,,gleam_basin,,W-EU,,RU,RUS,,56.09,47.347,447000.0,1909
-G-CTA,Catania,,,gleam_basin,,W-EU,,IT,ITA,,37.467,15.066,675000.0,3065
-G-CTC,Catamarca,,,gleam_basin,,W-SA,,AR,ARG,,-28.596,-65.752,216000.0,3182
-G-CTG,Cartagena,,,gleam_basin,,W-SA,,CO,COL,,10.442,-75.513,887000.0,1361
-G-CTL,Charleville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.413,146.262,2000.0,1573
-G-CTM,Chetumal,,,gleam_basin,,W-NA,,MX,MEX,,18.505,-88.327,155000.0,989
-G-CTS,Sapporo,,,gleam_basin,,W-AS,,JP,JPN,,42.775,141.692,2544000.0,3158
-G-CTU,Chengdu,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.579,103.947,4123000.0,315
-G-CUC,Cucuta,,,gleam_basin,,W-SA,,CO,COL,,7.928,-72.511,722000.0,1407
-G-CUE,Cuenca,,,gleam_basin,,W-SA,,EC,ECU,,-2.889,-78.984,287000.0,1473
-G-CUF,Cuneo,,,gleam_basin,,W-EU,,IT,ITA,,44.547,7.623,46000.0,3098
-G-CUL,Culiacan,,,gleam_basin,,W-NA,,MX,MEX,,24.764,-107.475,809000.0,1037
-G-CUM,Cumana,,,gleam_basin,,W-SA,,VE,VEN,,10.45,-64.13,318000.0,1721
-G-CUN,Cancun,,,gleam_basin,,W-NA,,MX,MEX,,21.037,-86.877,542000.0,1036
+G-CSO,Magdeburg,,,gleam_basin,,W-EU,,DE,DEU,,51.856,11.42,230000,747
+G-CSX,Changsha,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,28.189,113.22,2604000,456
+G-CSY,Cheboksary,,,gleam_basin,,W-EU,,RU,RUS,,56.09,47.347,447000,1909
+G-CTA,Catania,,,gleam_basin,,W-EU,,IT,ITA,,37.467,15.066,675000,3065
+G-CTC,Catamarca,,,gleam_basin,,W-SA,,AR,ARG,,-28.596,-65.752,216000,3182
+G-CTG,Cartagena,,,gleam_basin,,W-SA,,CO,COL,,10.442,-75.513,887000,1361
+G-CTL,Charleville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.413,146.262,2000,1573
+G-CTM,Chetumal,,,gleam_basin,,W-NA,,MX,MEX,,18.505,-88.327,155000,989
+G-CTS,Sapporo,,,gleam_basin,,W-AS,,JP,JPN,,42.775,141.692,2544000,3158
+G-CTU,Chengdu,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.579,103.947,4123000,315
+G-CUC,Cucuta,,,gleam_basin,,W-SA,,CO,COL,,7.928,-72.511,722000,1407
+G-CUE,Cuenca,,,gleam_basin,,W-SA,,EC,ECU,,-2.889,-78.984,287000,1473
+G-CUF,Cuneo,,,gleam_basin,,W-EU,,IT,ITA,,44.547,7.623,46000,3098
+G-CUL,Culiacan,,,gleam_basin,,W-NA,,MX,MEX,,24.764,-107.475,809000,1037
+G-CUM,Cumana,,,gleam_basin,,W-SA,,VE,VEN,,10.45,-64.13,318000,1721
+G-CUN,Cancun,,,gleam_basin,,W-NA,,MX,MEX,,21.037,-86.877,542000,1036
 G-CUQ,Coen,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-13.761,143.113,,1689
 G-CUR,Curacao,,,gleam_basin,,W-NA,,CW,CUW,,,,,1488
-G-CUU,Chihuahua,,,gleam_basin,,W-NA,,MX,MEX,,28.703,-105.965,793000.0,1035
-G-CUZ,Cuzco,,,gleam_basin,,W-SA,,PE,PER,,-13.536,-71.939,349000.0,1229
-G-CVG,Cincinnati,,,gleam_basin,,W-NA,,US,USA,US-OH,39.049,-84.668,1648000.0,2320
-G-CVJ,Cuernavaca,,,gleam_basin,,W-NA,,MX,MEX,,18.835,-99.261,834000.0,987
-G-CVM,Ciudad Victoria,,,gleam_basin,,W-NA,,MX,MEX,,23.703,-98.956,275000.0,986
-G-CVN,Clovis,,,gleam_basin,,W-NA,,US,USA,US-CA,34.425,-103.079,110000.0,2126
-G-CWA,Wausau,,,gleam_basin,,W-NA,,US,USA,US-WI,44.778,-89.667,74000.0,2103
+G-CUU,Chihuahua,,,gleam_basin,,W-NA,,MX,MEX,,28.703,-105.965,793000,1035
+G-CUZ,Cuzco,,,gleam_basin,,W-SA,,PE,PER,,-13.536,-71.939,349000,1229
+G-CVG,Cincinnati,,,gleam_basin,,W-NA,,US,USA,US-OH,39.049,-84.668,1648000,2320
+G-CVJ,Cuernavaca,,,gleam_basin,,W-NA,,MX,MEX,,18.835,-99.261,834000,987
+G-CVM,Ciudad Victoria,,,gleam_basin,,W-NA,,MX,MEX,,23.703,-98.956,275000,986
+G-CVN,Clovis,,,gleam_basin,,W-NA,,US,USA,US-CA,34.425,-103.079,110000,2126
+G-CWA,Wausau,,,gleam_basin,,W-NA,,US,USA,US-WI,44.778,-89.667,74000,2103
 G-CWB,Curitiba,,,gleam_basin,,W-SA,,BR,BRA,,-25.528,-49.176,,1947
-G-CWC,Chernivtsi,,,gleam_basin,,W-EU,,UA,UKR,,48.259,25.981,298000.0,2782
-G-CXB,Cox's Bazar,,,gleam_basin,,W-AS,,BD,BGD,,21.452,91.964,254000.0,64
+G-CWC,Chernivtsi,,,gleam_basin,,W-EU,,UA,UKR,,48.259,25.981,298000,2782
+G-CXB,Cox's Bazar,,,gleam_basin,,W-AS,,BD,BGD,,21.452,91.964,254000,64
 G-CXF,Coldfoot,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2132
 G-CXI,Kiritimati,,,gleam_basin,,W-OC,,KI,KIR,,1.986,-157.35,,643
-G-CXJ,Caxias do Sul,,,gleam_basin,,W-SA,,BR,BRA,,-29.197,-51.188,381000.0,1955
-G-CXR,Nha Trang,,,gleam_basin,,W-AS,,VN,VNM,,11.998,109.219,412000.0,1137
+G-CXJ,Caxias do Sul,,,gleam_basin,,W-SA,,BR,BRA,,-29.197,-51.188,381000,1955
+G-CXR,Nha Trang,,,gleam_basin,,W-AS,,VN,VNM,,11.998,109.219,412000,1137
 G-CYB,Cayman Brac,,,gleam_basin,,W-NA,,KY,CYM,,19.687,-79.883,,2864
 G-CYO,Cayo Largo del Sur,,,gleam_basin,,W-NA,,CU,CUB,,21.617,-81.546,,3239
-G-CYS,Cheyenne,,,gleam_basin,,W-NA,,US,USA,US-WY,41.156,-104.812,79000.0,2100
+G-CYS,Cheyenne,,,gleam_basin,,W-NA,,US,USA,US-WY,41.156,-104.812,79000,2100
 G-CYX,Chersky,,,gleam_basin,,W-EU,,RU,RUS,,68.741,161.338,,1886
-G-CYZ,Cauayan,,,gleam_basin,,W-AS,,PH,PHL,,16.93,121.753,122000.0,593
-G-CZE,Coro,,,gleam_basin,,W-SA,,VE,VEN,,11.415,-69.681,195000.0,1707
+G-CYZ,Cauayan,,,gleam_basin,,W-AS,,PH,PHL,,16.93,121.753,122000,593
+G-CZE,Coro,,,gleam_basin,,W-SA,,VE,VEN,,11.415,-69.681,195000,1707
 G-CZH,Corozal (BZ),,,gleam_basin,,W-NA,,BZ,BLZ,,,,,860
-G-CZL,Constantine,,,gleam_basin,,W-AF,,DZ,DZA,,36.276,6.62,605000.0,24
-G-CZM,Cozumel,,,gleam_basin,,W-NA,,MX,MEX,,20.522,-86.926,74000.0,996
-G-CZS,Cruzeiro do Sul,,,gleam_basin,,W-SA,,BR,BRA,,-7.6,-72.77,57000.0,1969
+G-CZL,Constantine,,,gleam_basin,,W-AF,,DZ,DZA,,36.276,6.62,605000,24
+G-CZM,Cozumel,,,gleam_basin,,W-NA,,MX,MEX,,20.522,-86.926,74000,996
+G-CZS,Cruzeiro do Sul,,,gleam_basin,,W-SA,,BR,BRA,,-7.6,-72.77,57000,1969
 G-CZU,Corozal (CO),,,gleam_basin,,W-SA,,CO,COL,,9.333,-75.286,,1373
-G-CZX,Changzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.92,119.779,1327000.0,362
-G-DAC,Dhaka,,,gleam_basin,,W-AS,,BD,BGD,,23.843,90.398,12797000.0,69
-G-DAD,Da Nang,,,gleam_basin,,W-AS,,VN,VNM,,16.044,108.199,752000.0,1139
-G-DAM,Damascus,,,gleam_basin,,W-AS,,SY,SYR,,33.411,36.516,2466000.0,653
-G-DAR,Dar Es Salaam,,,gleam_basin,,W-AF,,TZ,TZA,,-6.878,39.203,2930000.0,216
-G-DAT,Datong,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,40.06,113.482,61000.0,486
-G-DAU,Daru,,,gleam_basin,,W-OC,,PG,PNG,,-9.087,143.208,15000.0,3003
-G-DAV,David,,,gleam_basin,,W-NA,,PA,PAN,,8.391,-82.435,110000.0,3009
-G-DAX,Dazhou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,31.13,107.43,131000.0,487
-G-DAY,Dayton,,,gleam_basin,,W-NA,,US,USA,US-OH,39.902,-84.219,718000.0,2534
-G-DBA,Dalbandin,,,gleam_basin,,W-AS,,PK,PAK,,28.878,64.4,465000.0,107
-G-DBO,Dubbo,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.217,148.575,32000.0,1578
-G-DBQ,Dubuque,,,gleam_basin,,W-NA,,US,USA,US-IA,42.402,-90.71,69000.0,2082
-G-DBV,Dubrovnik,,,gleam_basin,,W-EU,,HR,HRV,,42.561,18.268,37000.0,285
-G-DCN,Derby,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-17.581,123.828,24000.0,1582
+G-CZX,Changzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.92,119.779,1327000,362
+G-DAC,Dhaka,,,gleam_basin,,W-AS,,BD,BGD,,23.843,90.398,12797000,69
+G-DAD,Da Nang,,,gleam_basin,,W-AS,,VN,VNM,,16.044,108.199,752000,1139
+G-DAM,Damascus,,,gleam_basin,,W-AS,,SY,SYR,,33.411,36.516,2466000,653
+G-DAR,Dar Es Salaam,,,gleam_basin,,W-AF,,TZ,TZA,,-6.878,39.203,2930000,216
+G-DAT,Datong,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,40.06,113.482,61000,486
+G-DAU,Daru,,,gleam_basin,,W-OC,,PG,PNG,,-9.087,143.208,15000,3003
+G-DAV,David,,,gleam_basin,,W-NA,,PA,PAN,,8.391,-82.435,110000,3009
+G-DAX,Dazhou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,31.13,107.43,131000,487
+G-DAY,Dayton,,,gleam_basin,,W-NA,,US,USA,US-OH,39.902,-84.219,718000,2534
+G-DBA,Dalbandin,,,gleam_basin,,W-AS,,PK,PAK,,28.878,64.4,465000,107
+G-DBO,Dubbo,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.217,148.575,32000,1578
+G-DBQ,Dubuque,,,gleam_basin,,W-NA,,US,USA,US-IA,42.402,-90.71,69000,2082
+G-DBV,Dubrovnik,,,gleam_basin,,W-EU,,HR,HRV,,42.561,18.268,37000,285
+G-DCN,Derby,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-17.581,123.828,24000,1582
 G-DCY,Daocheng,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,29.323,100.053,,326
-G-DDC,Dodge City,,,gleam_basin,,W-NA,,US,USA,US-KS,37.763,-99.966,28000.0,2345
-G-DDG,Dandong,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,40.025,124.286,870000.0,428
-G-DDU,Dadu,,,gleam_basin,,W-AS,,PK,PAK,,,,2900000.0,126
-G-DEA,Dera Ghazi Khan,,,gleam_basin,,W-AS,,PK,PAK,,29.961,70.486,4100000.0,129
-G-DEB,Debrecen,,,gleam_basin,,W-EU,,HU,HUN,,47.489,21.615,231000.0,831
-G-DEC,Decatur,,,gleam_basin,,W-NA,,US,USA,US-IL,39.835,-88.866,89000.0,2367
-G-DED,Dehra Dun,,,gleam_basin,,W-AS,,IN,IND,,30.19,78.18,714000.0,1100
+G-DDC,Dodge City,,,gleam_basin,,W-NA,,US,USA,US-KS,37.763,-99.966,28000,2345
+G-DDG,Dandong,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,40.025,124.286,870000,428
+G-DDU,Dadu,,,gleam_basin,,W-AS,,PK,PAK,,,,2900000,126
+G-DEA,Dera Ghazi Khan,,,gleam_basin,,W-AS,,PK,PAK,,29.961,70.486,4100000,129
+G-DEB,Debrecen,,,gleam_basin,,W-EU,,HU,HUN,,47.489,21.615,231000,831
+G-DEC,Decatur,,,gleam_basin,,W-NA,,US,USA,US-IL,39.835,-88.866,89000,2367
+G-DED,Dehra Dun,,,gleam_basin,,W-AS,,IN,IND,,30.19,78.18,714000,1100
 G-DEE,Yuzhno-Kurilsk,,,gleam_basin,,W-EU,,RU,RUS,,43.958,145.683,,1888
-G-DEF,Dezful,,,gleam_basin,,W-AS,,IR,IRN,,32.434,48.398,315000.0,2958
-G-DEL,Delhi,,,gleam_basin,,W-AS,,IN,IND,,28.567,77.103,15926000.0,1099
-G-DEN,Denver,,,gleam_basin,,W-NA,,US,USA,US-CO,39.862,-104.673,2787000.0,2366
-G-DFW,Dallas,,,gleam_basin,,W-NA,,US,USA,US-TX,32.897,-97.038,5733000.0,2533
-G-DGA,Dangriga,,,gleam_basin,,W-NA,,BZ,BLZ,,,,11000.0,863
-G-DGE,Mudgee,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.562,149.611,5000.0,1667
+G-DEF,Dezful,,,gleam_basin,,W-AS,,IR,IRN,,32.434,48.398,315000,2958
+G-DEL,Delhi,,,gleam_basin,,W-AS,,IN,IND,,28.567,77.103,15926000,1099
+G-DEN,Denver,,,gleam_basin,,W-NA,,US,USA,US-CO,39.862,-104.673,2787000,2366
+G-DFW,Dallas,,,gleam_basin,,W-NA,,US,USA,US-TX,32.897,-97.038,5733000,2533
+G-DGA,Dangriga,,,gleam_basin,,W-NA,,BZ,BLZ,,,,11000,863
+G-DGE,Mudgee,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.562,149.611,5000,1667
 G-DGO,Durango (MX),,,gleam_basin,,W-NA,,MX,MEX,,24.124,-104.528,,1029
-G-DGT,Dumaguete,,,gleam_basin,,W-AS,,PH,PHL,,9.334,123.3,114000.0,591
-G-DHI,Dhangarhi,,,gleam_basin,,W-AS,,NP,NPL,,28.753,80.582,92000.0,558
-G-DHM,Dharamsala,,,gleam_basin,,W-AS,,IN,IND,,32.165,76.263,20000.0,1070
-G-DHN,Dothan,,,gleam_basin,,W-NA,,US,USA,US-AL,31.321,-85.45,72000.0,2134
-G-DIB,Dibrugarh,,,gleam_basin,,W-AS,,IN,IND,,27.484,95.017,166000.0,1077
-G-DIE,Antsiranana,,,gleam_basin,,W-AF,,MG,MDG,,-12.349,49.292,83000.0,1446
-G-DIG,Deqen,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,27.794,99.677,62000.0,377
-G-DIK,Dickinson,,,gleam_basin,,W-NA,,US,USA,US-ND,46.797,-102.802,22000.0,2289
-G-DIL,Dili,,,gleam_basin,,W-AS,,TL,TLS,,-8.546,125.526,234000.0,1427
-G-DIN,Dien Bien Phu,,,gleam_basin,,W-AS,,VN,VNM,,21.397,103.008,40000.0,1126
-G-DIR,Dire Dawa,,,gleam_basin,,W-AF,,ET,ETH,,9.625,41.854,252000.0,229
-G-DIU,Diu,,,gleam_basin,,W-AS,,IN,IND,,20.713,70.921,24000.0,1078
+G-DGT,Dumaguete,,,gleam_basin,,W-AS,,PH,PHL,,9.334,123.3,114000,591
+G-DHI,Dhangarhi,,,gleam_basin,,W-AS,,NP,NPL,,28.753,80.582,92000,558
+G-DHM,Dharamsala,,,gleam_basin,,W-AS,,IN,IND,,32.165,76.263,20000,1070
+G-DHN,Dothan,,,gleam_basin,,W-NA,,US,USA,US-AL,31.321,-85.45,72000,2134
+G-DIB,Dibrugarh,,,gleam_basin,,W-AS,,IN,IND,,27.484,95.017,166000,1077
+G-DIE,Antsiranana,,,gleam_basin,,W-AF,,MG,MDG,,-12.349,49.292,83000,1446
+G-DIG,Deqen,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,27.794,99.677,62000,377
+G-DIK,Dickinson,,,gleam_basin,,W-NA,,US,USA,US-ND,46.797,-102.802,22000,2289
+G-DIL,Dili,,,gleam_basin,,W-AS,,TL,TLS,,-8.546,125.526,234000,1427
+G-DIN,Dien Bien Phu,,,gleam_basin,,W-AS,,VN,VNM,,21.397,103.008,40000,1126
+G-DIR,Dire Dawa,,,gleam_basin,,W-AF,,ET,ETH,,9.625,41.854,252000,229
+G-DIU,Diu,,,gleam_basin,,W-AS,,IN,IND,,20.713,70.921,24000,1078
 G-DIW,Dickwella,,,gleam_basin,,W-AS,,LK,LKA,,,,,755
-G-DIY,Diyarbakir,,,gleam_basin,,W-AS,,TR,TUR,,37.894,40.201,645000.0,1761
-G-DJB,Jambi,,,gleam_basin,,W-AS,,ID,IDN,,-1.638,103.644,457000.0,1268
+G-DIY,Diyarbakir,,,gleam_basin,,W-AS,,TR,TUR,,37.894,40.201,645000,1761
+G-DJB,Jambi,,,gleam_basin,,W-AS,,ID,IDN,,-1.638,103.644,457000,1268
 G-DJE,Djerba,,,gleam_basin,,W-AF,,TN,TUN,,33.875,10.776,,1791
-G-DJG,Djanet,,,gleam_basin,,W-AF,,DZ,DZA,,24.293,9.452,1000.0,31
-G-DJJ,Jayapura,,,gleam_basin,,W-AS,,ID,IDN,,-2.577,140.516,169000.0,1269
-G-DKA,Katsina,,,gleam_basin,,W-AF,,NG,NGA,,,,432000.0,1418
+G-DJG,Djanet,,,gleam_basin,,W-AF,,DZ,DZA,,24.293,9.452,1000,31
+G-DJJ,Jayapura,,,gleam_basin,,W-AS,,ID,IDN,,-2.577,140.516,169000,1269
+G-DKA,Katsina,,,gleam_basin,,W-AF,,NG,NGA,,,,432000,1418
 G-DKI,Dunk Island,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-17.942,146.14,,1632
-G-DKR,Dakar,,,gleam_basin,,W-AF,,SN,SEN,,14.74,-17.49,2604000.0,1475
-G-DKS,Dikson,,,gleam_basin,,W-EU,,RU,RUS,,73.518,80.38,1000.0,1864
-G-DLA,Douala,,,gleam_basin,,W-AF,,CM,CMR,,4.006,9.719,1906000.0,805
-G-DLC,Dalian,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,38.966,121.539,3167000.0,394
-G-DLE,Dole,,,gleam_basin,,W-EU,,FR,FRA,,47.043,5.435,26000.0,1509
+G-DKR,Dakar,,,gleam_basin,,W-AF,,SN,SEN,,14.74,-17.49,2604000,1475
+G-DKS,Dikson,,,gleam_basin,,W-EU,,RU,RUS,,73.518,80.38,1000,1864
+G-DLA,Douala,,,gleam_basin,,W-AF,,CM,CMR,,4.006,9.719,1906000,805
+G-DLC,Dalian,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,38.966,121.539,3167000,394
+G-DLE,Dole,,,gleam_basin,,W-EU,,FR,FRA,,47.043,5.435,26000,1509
 G-DLG,Dillingham,,,gleam_basin,,W-NA,,US,USA,US-AK,59.045,-158.505,,2472
-G-DLH,Duluth,,,gleam_basin,,W-NA,,US,USA,US-MN,46.842,-92.194,120000.0,2085
+G-DLH,Duluth,,,gleam_basin,,W-NA,,US,USA,US-MN,46.842,-92.194,120000,2085
 G-DLI,Dalat,,,gleam_basin,,W-AS,,VN,VNM,,11.75,108.367,,1120
-G-DLM,Dalaman,,,gleam_basin,,W-AS,,TR,TUR,,36.713,28.792,19000.0,1743
-G-DLU,Dali,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.649,100.319,157000.0,388
-G-DLZ,Dalanzadgad,,,gleam_basin,,W-AS,,MN,MNG,,43.592,104.43,15000.0,846
-G-DMB,Taraz,,,gleam_basin,,W-AS,,KZ,KAZ,,42.854,71.304,358000.0,670
+G-DLM,Dalaman,,,gleam_basin,,W-AS,,TR,TUR,,36.713,28.792,19000,1743
+G-DLU,Dali,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.649,100.319,157000,388
+G-DLZ,Dalanzadgad,,,gleam_basin,,W-AS,,MN,MNG,,43.592,104.43,15000,846
+G-DMB,Taraz,,,gleam_basin,,W-AS,,KZ,KAZ,,42.854,71.304,358000,670
 G-DMD,Doomadgee Mission,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-17.94,138.822,,1584
-G-DME,Moscow,,,gleam_basin,,W-EU,,RU,RUS,,55.409,37.906,10452000.0,1890
-G-DMM,Dammam,,,gleam_basin,,W-AS,,SA,SAU,,26.471,49.798,769000.0,247
-G-DMU,Dimapur,,,gleam_basin,,W-AS,,IN,IND,,25.884,93.771,136000.0,1060
-G-DND,Dundee,,,gleam_basin,,W-EU,,GB,GBR,,56.452,-3.026,152000.0,763
-G-DNH,Dunhuang,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,40.161,94.809,140000.0,340
+G-DME,Moscow,,,gleam_basin,,W-EU,,RU,RUS,,55.409,37.906,10452000,1890
+G-DMM,Dammam,,,gleam_basin,,W-AS,,SA,SAU,,26.471,49.798,769000,247
+G-DMU,Dimapur,,,gleam_basin,,W-AS,,IN,IND,,25.884,93.771,136000,1060
+G-DND,Dundee,,,gleam_basin,,W-EU,,GB,GBR,,56.452,-3.026,152000,763
+G-DNH,Dunhuang,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,40.161,94.809,140000,340
 G-DNK,Dnipropetrovsk,,,gleam_basin,,W-EU,,UA,UKR,,48.357,35.101,,2785
 G-DNR,St-Malo,,,gleam_basin,,W-EU,,FR,FRA,,48.588,-2.08,,1500
-G-DNZ,Denizli,,,gleam_basin,,W-AS,,TR,TUR,,37.786,29.701,372000.0,1747
+G-DNZ,Denizli,,,gleam_basin,,W-AS,,TR,TUR,,37.786,29.701,372000,1747
 G-DOB,Dobo,,,gleam_basin,,W-AS,,ID,IDN,,-5.772,134.212,,1282
-G-DOG,Dongola,,,gleam_basin,,W-AF,,SD,SDN,,19.154,30.43,26000.0,3018
-G-DOH,Doha,,,gleam_basin,,W-AS,,QA,QAT,,25.273,51.608,1450000.0,73
-G-DOK,Donetsk,,,gleam_basin,,W-EU,,UA,UKR,,48.074,37.74,51000.0,2783
+G-DOG,Dongola,,,gleam_basin,,W-AF,,SD,SDN,,19.154,30.43,26000,3018
+G-DOH,Doha,,,gleam_basin,,W-AS,,QA,QAT,,25.273,51.608,1450000,73
+G-DOK,Donetsk,,,gleam_basin,,W-EU,,UA,UKR,,48.074,37.74,51000,2783
 G-DOM,Dominica,,,gleam_basin,,W-NA,,DM,DMA,,,,,716
 G-DOP,Dolpa,,,gleam_basin,,W-AS,,NP,NPL,,28.986,82.819,,555
-G-DOU,Dourados,,,gleam_basin,,W-SA,,BR,BRA,,-22.202,-54.927,162000.0,1960
-G-DOV,Dover,,,gleam_basin,,W-NA,,US,USA,US-DE,39.13,-75.466,115000.0,2179
-G-DOY,Dongying,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.509,118.788,789000.0,352
-G-DPL,Dipolog,,,gleam_basin,,W-AS,,PH,PHL,,8.602,123.342,94000.0,588
-G-DPO,Devonport,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-41.17,146.43,19000.0,1575
-G-DPS,Denpasar,,,gleam_basin,,W-AS,,ID,IDN,,-8.748,115.167,732000.0,1238
-G-DQA,Daqing,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,46.746,125.141,1693000.0,329
+G-DOU,Dourados,,,gleam_basin,,W-SA,,BR,BRA,,-22.202,-54.927,162000,1960
+G-DOV,Dover,,,gleam_basin,,W-NA,,US,USA,US-DE,39.13,-75.466,115000,2179
+G-DOY,Dongying,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.509,118.788,789000,352
+G-DPL,Dipolog,,,gleam_basin,,W-AS,,PH,PHL,,8.602,123.342,94000,588
+G-DPO,Devonport,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-41.17,146.43,19000,1575
+G-DPS,Denpasar,,,gleam_basin,,W-AS,,ID,IDN,,-8.748,115.167,732000,1238
+G-DQA,Daqing,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,46.746,125.141,1693000,329
 G-DRG,Deering,,,gleam_basin,,W-NA,,US,USA,US-AK,66.07,-162.766,,2130
 G-DRO,Durango (US),,,gleam_basin,,W-NA,,US,USA,US-CO,37.152,-107.754,,2128
-G-DRS,Dresden,,,gleam_basin,,W-EU,,DE,DEU,,51.133,13.767,618000.0,727
-G-DRT,Del Rio,,,gleam_basin,,W-NA,,US,USA,US-TX,29.374,-100.927,44000.0,2127
+G-DRS,Dresden,,,gleam_basin,,W-EU,,DE,DEU,,51.133,13.767,618000,727
+G-DRT,Del Rio,,,gleam_basin,,W-NA,,US,USA,US-TX,29.374,-100.927,44000,2127
 G-DRV,Dharavandhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,5.156,73.13,,1478
-G-DRW,Darwin,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.415,130.877,93000.0,1589
-G-DSA,Doncaster,,,gleam_basin,,W-EU,,GB,GBR,,53.481,-1.011,18000.0,778
-G-DSK,Dera Ismail Khan,,,gleam_basin,,W-AS,,PK,PAK,,31.909,70.897,9100000.0,116
-G-DSM,Des Moines,,,gleam_basin,,W-NA,,US,USA,US-IA,41.534,-93.663,481000.0,2173
-G-DSN,Ordos,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,39.49,109.861,1941000.0,349
+G-DRW,Darwin,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.415,130.877,93000,1589
+G-DSA,Doncaster,,,gleam_basin,,W-EU,,GB,GBR,,53.481,-1.011,18000,778
+G-DSK,Dera Ismail Khan,,,gleam_basin,,W-AS,,PK,PAK,,31.909,70.897,9100000,116
+G-DSM,Des Moines,,,gleam_basin,,W-NA,,US,USA,US-IA,41.534,-93.663,481000,2173
+G-DSN,Ordos,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,39.49,109.861,1941000,349
 G-DTD,Datadawai,,,gleam_basin,,W-AS,,ID,IDN,,0.811,114.531,,1293
-G-DTM,Dortmund,,,gleam_basin,,W-EU,,DE,DEU,,51.518,7.612,588000.0,745
-G-DTW,Detroit,,,gleam_basin,,W-NA,,US,USA,US-MI,42.212,-83.353,3522000.0,2397
-G-DUB,Dublin,,,gleam_basin,,W-EU,,IE,IRL,,53.421,-6.27,1059000.0,2925
-G-DUD,Dunedin,,,gleam_basin,,W-OC,,NZ,NZL,,-45.928,170.198,118000.0,3061
-G-DUJ,Dubois,,,gleam_basin,,W-NA,,US,USA,US-PA,41.178,-78.899,11000.0,2449
-G-DUR,Durban,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.614,31.12,2729000.0,639
-G-DUS,Duesseldorf,,,gleam_basin,,W-EU,,DE,DEU,,51.29,6.767,573000.0,750
+G-DTM,Dortmund,,,gleam_basin,,W-EU,,DE,DEU,,51.518,7.612,588000,745
+G-DTW,Detroit,,,gleam_basin,,W-NA,,US,USA,US-MI,42.212,-83.353,3522000,2397
+G-DUB,Dublin,,,gleam_basin,,W-EU,,IE,IRL,,53.421,-6.27,1059000,2925
+G-DUD,Dunedin,,,gleam_basin,,W-OC,,NZ,NZL,,-45.928,170.198,118000,3061
+G-DUJ,Dubois,,,gleam_basin,,W-NA,,US,USA,US-PA,41.178,-78.899,11000,2449
+G-DUR,Durban,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.614,31.12,2729000,639
+G-DUS,Duesseldorf,,,gleam_basin,,W-EU,,DE,DEU,,51.29,6.767,573000,750
 G-DUT,Dutch Harbor,,,gleam_basin,,W-NA,,US,USA,US-AK,53.9,-166.544,,2451
 G-DVD,Andavadoaka,,,gleam_basin,,W-AF,,MG,MDG,,,,,1458
-G-DVL,Devils Lake,,,gleam_basin,,W-NA,,US,USA,US-ND,48.114,-98.909,8000.0,2481
-G-DVO,Davao,,,gleam_basin,,W-AS,,PH,PHL,,7.126,125.646,1402000.0,619
+G-DVL,Devils Lake,,,gleam_basin,,W-NA,,US,USA,US-ND,48.114,-98.909,8000,2481
+G-DVO,Davao,,,gleam_basin,,W-AS,,PH,PHL,,7.126,125.646,1402000,619
 G-DWD,Dawadmi,,,gleam_basin,,W-AS,,SA,SAU,,24.45,44.121,,270
-G-DXB,Dubai,,,gleam_basin,,W-AS,,AE,ARE,,25.253,55.364,1379000.0,3181
-G-DYG,Zhangjiajie,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,29.103,110.443,86000.0,404
+G-DXB,Dubai,,,gleam_basin,,W-AS,,AE,ARE,,25.253,55.364,1379000,3181
+G-DYG,Zhangjiajie,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,29.103,110.443,86000,404
 G-DYR,Anadyr,,,gleam_basin,,W-EU,,RU,RUS,,64.735,177.741,,1862
-G-DYU,Dushanbe,,,gleam_basin,,W-AS,,TJ,TJK,,38.543,68.825,1086000.0,975
-G-DZA,Dzaoudzi,,,gleam_basin,,W-AF,,YT,MYT,,-12.805,45.281,15000.0,199
+G-DYU,Dushanbe,,,gleam_basin,,W-AS,,TJ,TJK,,38.543,68.825,1086000,975
+G-DZA,Dzaoudzi,,,gleam_basin,,W-AF,,YT,MYT,,-12.805,45.281,15000,199
 G-DZN,Zhezkazgan,,,gleam_basin,,W-AS,,KZ,KAZ,,47.708,67.733,,666
-G-EAA,Eagle,,,gleam_basin,,W-NA,,US,USA,US-ID,64.776,-141.151,1000.0,2157
+G-EAA,Eagle,,,gleam_basin,,W-NA,,US,USA,US-ID,64.776,-141.151,1000,2157
 G-EAM,Nejran,,,gleam_basin,,W-AS,,SA,SAU,,17.611,44.419,,248
-G-EAR,Kearney,,,gleam_basin,,W-NA,,US,USA,US-NE,,,34000.0,2159
-G-EAT,Wenatchee,,,gleam_basin,,W-NA,,US,USA,US-WA,47.399,-120.207,72000.0,2161
-G-EAU,Eau Claire,,,gleam_basin,,W-NA,,US,USA,US-WI,44.866,-91.484,107000.0,2160
+G-EAR,Kearney,,,gleam_basin,,W-NA,,US,USA,US-NE,,,34000,2159
+G-EAT,Wenatchee,,,gleam_basin,,W-NA,,US,USA,US-WA,47.399,-120.207,72000,2161
+G-EAU,Eau Claire,,,gleam_basin,,W-NA,,US,USA,US-WI,44.866,-91.484,107000,2160
 G-EBA,Elba Island,,,gleam_basin,,W-EU,,IT,ITA,,42.76,10.239,,3070
-G-EBB,Entebbe,,,gleam_basin,,W-AF,,UG,UGA,,0.042,32.444,175000.0,3163
-G-EBD,El Obeid,,,gleam_basin,,W-AF,,SD,SDN,,13.153,30.233,393000.0,3011
-G-EBH,El Bayadh,,,gleam_basin,,W-AF,,DZ,DZA,,33.722,1.093,67000.0,18
-G-EBL,Erbil,,,gleam_basin,,W-AS,,IQ,IRQ,,36.238,43.963,926000.0,2912
+G-EBB,Entebbe,,,gleam_basin,,W-AF,,UG,UGA,,0.042,32.444,175000,3163
+G-EBD,El Obeid,,,gleam_basin,,W-AF,,SD,SDN,,13.153,30.233,393000,3011
+G-EBH,El Bayadh,,,gleam_basin,,W-AF,,DZ,DZA,,33.722,1.093,67000,18
+G-EBL,Erbil,,,gleam_basin,,W-AS,,IQ,IRQ,,36.238,43.963,926000,2912
 G-EBU,St-etienne,,,gleam_basin,,W-EU,,FR,FRA,,45.541,4.296,,1497
 G-ECP,Panama City (US),,,gleam_basin,,W-NA,,US,USA,US-FL,30.357,-85.795,,2094
-G-EDI,Edinburgh,,,gleam_basin,,W-EU,,GB,GBR,,55.95,-3.372,505000.0,762
-G-EDL,Eldoret,,,gleam_basin,,W-AF,,KE,KEN,,0.404,35.239,353000.0,1724
-G-EDO,Edremit,,,gleam_basin,,W-AS,,TR,TUR,,39.555,27.014,41000.0,1742
+G-EDI,Edinburgh,,,gleam_basin,,W-EU,,GB,GBR,,55.95,-3.372,505000,762
+G-EDL,Eldoret,,,gleam_basin,,W-AF,,KE,KEN,,0.404,35.239,353000,1724
+G-EDO,Edremit,,,gleam_basin,,W-AS,,TR,TUR,,39.555,27.014,41000,1742
 G-EDR,Pormpuraaw,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-14.896,141.609,,1574
 G-EFL,Kefallinia,,,gleam_basin,,W-EU,,GR,GRC,,38.12,20.5,,935
-G-EGC,Bergerac,,,gleam_basin,,W-EU,,FR,FRA,,44.825,0.519,28000.0,1526
+G-EGC,Bergerac,,,gleam_basin,,W-EU,,FR,FRA,,44.825,0.519,28000,1526
 G-EGM,Seghe,,,gleam_basin,,W-OC,,SB,SLB,,-8.579,157.876,,3034
-G-EGN,Geneina,,,gleam_basin,,W-AF,,SD,SDN,,13.482,22.467,163000.0,3019
-G-EGO,Belgorod,,,gleam_basin,,W-EU,,RU,RUS,,50.644,36.59,345000.0,1902
+G-EGN,Geneina,,,gleam_basin,,W-AF,,SD,SDN,,13.482,22.467,163000,3019
+G-EGO,Belgorod,,,gleam_basin,,W-EU,,RU,RUS,,50.644,36.59,345000,1902
 G-EGS,Egilsstadir,,,gleam_basin,,W-EU,,IS,ISL,,65.283,-14.401,,1351
 G-EGX,Egegik,,,gleam_basin,,W-NA,,US,USA,US-AK,58.186,-157.375,,2422
-G-EIN,Eindhoven,,,gleam_basin,,W-EU,,NL,NLD,,51.45,5.375,398000.0,836
+G-EIN,Eindhoven,,,gleam_basin,,W-EU,,NL,NLD,,51.45,5.375,398000,836
 G-EIS,Beef Island,,,gleam_basin,,W-NA,,VG,VGB,,18.445,-64.543,,901
-G-EJA,Barrancabermeja,,,gleam_basin,,W-SA,,CO,COL,,7.024,-73.807,191000.0,1384
+G-EJA,Barrancabermeja,,,gleam_basin,,W-SA,,CO,COL,,7.024,-73.807,191000,1384
 G-EJH,Wedjh,,,gleam_basin,,W-AS,,SA,SAU,,26.199,36.476,,261
-G-EKO,Elko,,,gleam_basin,,W-NA,,US,USA,US-NV,40.825,-115.792,21000.0,2285
+G-EKO,Elko,,,gleam_basin,,W-NA,,US,USA,US-NV,40.825,-115.792,21000,2285
 G-EKS,Shakhtersk,,,gleam_basin,,W-EU,,RU,RUS,,49.19,142.083,,1860
 G-ELC,Elcho Island,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.019,135.571,,1625
-G-ELD,El Dorado,,,gleam_basin,,W-NA,,US,USA,US-AR,33.221,-92.813,18000.0,2259
-G-ELF,El Fasher,,,gleam_basin,,W-AF,,SD,SDN,,13.615,25.325,253000.0,3014
-G-ELG,El Golea,,,gleam_basin,,W-AF,,DZ,DZA,,30.571,2.86,32000.0,28
+G-ELD,El Dorado,,,gleam_basin,,W-NA,,US,USA,US-AR,33.221,-92.813,18000,2259
+G-ELF,El Fasher,,,gleam_basin,,W-AF,,SD,SDN,,13.615,25.325,253000,3014
+G-ELG,El Golea,,,gleam_basin,,W-AF,,DZ,DZA,,30.571,2.86,32000,28
 G-ELH,North Eleuthera,,,gleam_basin,,W-NA,,BS,BHS,,25.475,-76.684,,3222
 G-ELI,Elim,,,gleam_basin,,W-NA,,US,USA,US-AK,64.615,-162.272,,2364
-G-ELM,Elmira,,,gleam_basin,,W-NA,,US,USA,US-NY,42.16,-76.892,65000.0,2258
-G-ELP,El Paso,,,gleam_basin,,W-NA,,US,USA,US-TX,31.807,-106.378,846000.0,2263
+G-ELM,Elmira,,,gleam_basin,,W-NA,,US,USA,US-NY,42.16,-76.892,65000,2258
+G-ELP,El Paso,,,gleam_basin,,W-NA,,US,USA,US-TX,31.807,-106.378,846000,2263
 G-ELQ,Gassim,,,gleam_basin,,W-AS,,SA,SAU,,26.303,43.774,,257
-G-ELS,East London,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.036,27.826,339000.0,632
-G-ELU,El Oued,,,gleam_basin,,W-AF,,DZ,DZA,,33.511,6.777,177000.0,29
+G-ELS,East London,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.036,27.826,339000,632
+G-ELU,El Oued,,,gleam_basin,,W-AF,,DZ,DZA,,33.511,6.777,177000,29
 G-ELY,Ely,,,gleam_basin,,W-NA,,US,USA,US-NV,39.3,-114.842,,2261
-G-EMA,Nottingham,,,gleam_basin,,W-EU,,GB,GBR,,52.831,-1.328,826000.0,773
-G-EMD,Emerald,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.567,148.179,9000.0,1613
+G-EMA,Nottingham,,,gleam_basin,,W-EU,,GB,GBR,,52.831,-1.328,826000,773
+G-EMD,Emerald,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.567,148.179,9000,1613
 G-EMK,Emmonak,,,gleam_basin,,W-NA,,US,USA,US-AK,62.786,-164.491,,2246
-G-EMN,Nema,,,gleam_basin,,W-AF,,MR,MRT,,16.622,-7.317,200000.0,281
-G-ENA,Kenai,,,gleam_basin,,W-NA,,US,USA,US-AK,60.573,-151.245,5000.0,2201
-G-ENE,Ende,,,gleam_basin,,W-AS,,ID,IDN,,-8.849,121.661,77000.0,1260
+G-EMN,Nema,,,gleam_basin,,W-AF,,MR,MRT,,16.622,-7.317,200000,281
+G-ENA,Kenai,,,gleam_basin,,W-NA,,US,USA,US-AK,60.573,-151.245,5000,2201
+G-ENE,Ende,,,gleam_basin,,W-AS,,ID,IDN,,-8.849,121.661,77000,1260
 G-ENF,Enontekio,,,gleam_basin,,W-EU,,FI,FIN,,68.363,23.424,,504
-G-ENH,Enshi,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.32,109.485,95000.0,360
-G-ENU,Enugu,,,gleam_basin,,W-AF,,NG,NGA,,6.474,7.562,689000.0,1414
-G-ENY,Yan'an,,,gleam_basin,,W-AS,,CN,CHN,CN-SN,36.637,109.554,404000.0,361
-G-EPL,Epinal,,,gleam_basin,,W-EU,,FR,FRA,,48.325,6.07,40000.0,1510
-G-EPR,Esperance,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.684,121.823,8000.0,1621
-G-EQS,Esquel,,,gleam_basin,,W-SA,,AR,ARG,,-42.908,-71.14,20000.0,3187
-G-ERC,Erzincan,,,gleam_basin,,W-AS,,TR,TUR,,39.71,39.527,129000.0,1753
-G-ERF,Erfurt,,,gleam_basin,,W-EU,,DE,DEU,,50.98,10.958,203000.0,731
+G-ENH,Enshi,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.32,109.485,95000,360
+G-ENU,Enugu,,,gleam_basin,,W-AF,,NG,NGA,,6.474,7.562,689000,1414
+G-ENY,Yan'an,,,gleam_basin,,W-AS,,CN,CHN,CN-SN,36.637,109.554,404000,361
+G-EPL,Epinal,,,gleam_basin,,W-EU,,FR,FRA,,48.325,6.07,40000,1510
+G-EPR,Esperance,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.684,121.823,8000,1621
+G-EQS,Esquel,,,gleam_basin,,W-SA,,AR,ARG,,-42.908,-71.14,20000,3187
+G-ERC,Erzincan,,,gleam_basin,,W-AS,,TR,TUR,,39.71,39.527,129000,1753
+G-ERF,Erfurt,,,gleam_basin,,W-EU,,DE,DEU,,50.98,10.958,203000,731
 G-ERG,Yerbogachen,,,gleam_basin,,W-EU,,RU,RUS,,61.275,108.03,,1823
-G-ERH,Errachidia,,,gleam_basin,,W-AF,,MA,MAR,,31.948,-4.398,228000.0,815
-G-ERI,Erie,,,gleam_basin,,W-NA,,US,USA,US-PA,42.083,-80.174,188000.0,2186
-G-ERL,Erenhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,43.422,112.097,16000.0,356
-G-ERM,Erechim,,,gleam_basin,,W-SA,,BR,BRA,,-27.662,-52.268,96000.0,1965
-G-ERN,Eirunepe,,,gleam_basin,,W-SA,,BR,BRA,,-6.64,-69.88,22000.0,1966
-G-ERZ,Erzurum,,,gleam_basin,,W-AS,,TR,TUR,,39.957,41.17,421000.0,1752
-G-ESB,Ankara,,,gleam_basin,,W-AS,,TR,TUR,,40.128,32.995,3716000.0,1749
-G-ESC,Escanaba,,,gleam_basin,,W-NA,,US,USA,US-MI,45.723,-87.094,20000.0,2256
-G-ESL,Elista,,,gleam_basin,,W-EU,,RU,RUS,,46.374,44.331,107000.0,1820
-G-ESM,Esmeraldas,,,gleam_basin,,W-SA,,EC,ECU,,0.979,-79.627,173000.0,1463
+G-ERH,Errachidia,,,gleam_basin,,W-AF,,MA,MAR,,31.948,-4.398,228000,815
+G-ERI,Erie,,,gleam_basin,,W-NA,,US,USA,US-PA,42.083,-80.174,188000,2186
+G-ERL,Erenhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,43.422,112.097,16000,356
+G-ERM,Erechim,,,gleam_basin,,W-SA,,BR,BRA,,-27.662,-52.268,96000,1965
+G-ERN,Eirunepe,,,gleam_basin,,W-SA,,BR,BRA,,-6.64,-69.88,22000,1966
+G-ERZ,Erzurum,,,gleam_basin,,W-AS,,TR,TUR,,39.957,41.17,421000,1752
+G-ESB,Ankara,,,gleam_basin,,W-AS,,TR,TUR,,40.128,32.995,3716000,1749
+G-ESC,Escanaba,,,gleam_basin,,W-NA,,US,USA,US-MI,45.723,-87.094,20000,2256
+G-ESL,Elista,,,gleam_basin,,W-EU,,RU,RUS,,46.374,44.331,107000,1820
+G-ESM,Esmeraldas,,,gleam_basin,,W-SA,,EC,ECU,,0.979,-79.627,173000,1463
 G-ESR,El Salvador,,,gleam_basin,,W-SA,,CL,CHL,,-26.311,-69.765,,295
-G-ESU,Essaouira,,,gleam_basin,,W-AF,,MA,MAR,,31.397,-9.682,71000.0,816
-G-ETH,Eilat,,,gleam_basin,,W-AS,,IL,ISR,,29.561,34.96,46000.0,1207
+G-ESU,Essaouira,,,gleam_basin,,W-AF,,MA,MAR,,31.397,-9.682,71000,816
+G-ETH,Eilat,,,gleam_basin,,W-AS,,IL,ISR,,29.561,34.96,46000,1207
 G-ETR,Santa Rosa (EC),,,gleam_basin,,W-SA,,EC,ECU,,-3.442,-79.997,,1459
-G-ETZ,Metz,,,gleam_basin,,W-EU,,FR,FRA,,48.982,6.251,409000.0,1496
-G-EUG,Eugene,,,gleam_basin,,W-NA,,US,USA,US-OR,44.125,-123.212,268000.0,2096
-G-EUN,Laayoune,,,gleam_basin,,W-AF,,MA,MAR,,27.152,-13.219,196000.0,812
+G-ETZ,Metz,,,gleam_basin,,W-EU,,FR,FRA,,48.982,6.251,409000,1496
+G-EUG,Eugene,,,gleam_basin,,W-NA,,US,USA,US-OR,44.125,-123.212,268000,2096
+G-EUN,Laayoune,,,gleam_basin,,W-AF,,MA,MAR,,27.152,-13.219,196000,812
 G-EUX,St Eustatius,,,gleam_basin,,W-NA,,BQ,BES,,17.497,-62.979,,795
-G-EVE,Harstad,,,gleam_basin,,W-EU,,NO,NOR,,68.491,16.678,19000.0,1170
+G-EVE,Harstad,,,gleam_basin,,W-EU,,NO,NOR,,68.491,16.678,19000,1170
 G-EVG,Sveg,,,gleam_basin,,W-EU,,SE,SWE,,62.048,14.423,,2541
-G-EVN,Yerevan,,,gleam_basin,,W-AS,,AM,ARM,,40.147,44.396,1102000.0,3233
-G-EVV,Evansville,,,gleam_basin,,W-NA,,US,USA,US-IN,38.037,-87.532,232000.0,2356
-G-EWN,New Bern,,,gleam_basin,,W-NA,,US,USA,US-NC,35.073,-77.043,51000.0,2516
-G-EXT,Exeter,,,gleam_basin,,W-EU,,GB,GBR,,50.734,-3.414,113000.0,766
+G-EVN,Yerevan,,,gleam_basin,,W-AS,,AM,ARM,,40.147,44.396,1102000,3233
+G-EVV,Evansville,,,gleam_basin,,W-NA,,US,USA,US-IN,38.037,-87.532,232000,2356
+G-EWN,New Bern,,,gleam_basin,,W-NA,,US,USA,US-NC,35.073,-77.043,51000,2516
+G-EXT,Exeter,,,gleam_basin,,W-EU,,GB,GBR,,50.734,-3.414,113000,766
 G-EYK,Beloyarsky,,,gleam_basin,,W-EU,,RU,RUS,,63.687,66.699,,1919
 G-EYP,El Yopal,,,gleam_basin,,W-SA,,CO,COL,,5.319,-72.384,,1397
-G-EYW,Key West,,,gleam_basin,,W-NA,,US,USA,US-FL,24.556,-81.76,33000.0,2431
-G-EZE,Buenos Aires,,,gleam_basin,,W-SA,,AR,ARG,,-34.822,-58.536,12795000.0,3205
-G-EZS,Elazig,,,gleam_basin,,W-AS,,TR,TUR,,38.607,39.291,271000.0,1775
+G-EYW,Key West,,,gleam_basin,,W-NA,,US,USA,US-FL,24.556,-81.76,33000,2431
+G-EZE,Buenos Aires,,,gleam_basin,,W-SA,,AR,ARG,,-34.822,-58.536,12795000,3205
+G-EZS,Elazig,,,gleam_basin,,W-AS,,TR,TUR,,38.607,39.291,271000,1775
 G-EZV,Berezovo,,,gleam_basin,,W-EU,,RU,RUS,,63.921,65.031,,1894
 G-FAC,Faaite,,,gleam_basin,,W-OC,,PF,PYF,,-16.687,-145.329,,700
 G-FAE,Faroe Islands,,,gleam_basin,,W-EU,,FO,FRO,,62.064,-7.277,,1558
-G-FAH,Farah,,,gleam_basin,,W-AS,,AF,AFG,,32.367,62.183,74000.0,894
-G-FAI,Fairbanks,,,gleam_basin,,W-NA,,US,USA,US-AK,64.815,-147.856,65000.0,2357
-G-FAO,Faro,,,gleam_basin,,W-EU,,PT,PRT,,37.014,-7.966,41000.0,1435
-G-FAR,Fargo,,,gleam_basin,,W-NA,,US,USA,US-ND,46.921,-96.816,205000.0,2353
-G-FAT,Fresno,,,gleam_basin,,W-NA,,US,USA,US-CA,36.776,-119.718,698000.0,2355
+G-FAH,Farah,,,gleam_basin,,W-AS,,AF,AFG,,32.367,62.183,74000,894
+G-FAI,Fairbanks,,,gleam_basin,,W-NA,,US,USA,US-AK,64.815,-147.856,65000,2357
+G-FAO,Faro,,,gleam_basin,,W-EU,,PT,PRT,,37.014,-7.966,41000,1435
+G-FAR,Fargo,,,gleam_basin,,W-NA,,US,USA,US-ND,46.921,-96.816,205000,2353
+G-FAT,Fresno,,,gleam_basin,,W-NA,,US,USA,US-CA,36.776,-119.718,698000,2355
 G-FAV,Fakarava,,,gleam_basin,,W-OC,,PF,PYF,,-16.054,-145.657,,699
 G-FAY,Fayetteville (US-NC),,,gleam_basin,,W-NA,,US,USA,US-NC,34.991,-78.88,,2352
-G-FBA,Fonte Boa,,,gleam_basin,,W-SA,,BR,BRA,,-2.533,-66.083,16000.0,1987
-G-FBD,Faizabad,,,gleam_basin,,W-AS,,AF,AFG,,37.121,70.518,65000.0,890
-G-FBE,Francisco Beltrao,,,gleam_basin,,W-SA,,BR,BRA,,-26.059,-53.063,58000.0,1988
-G-FBM,Lubumbashi,,,gleam_basin,,W-AF,,CD,COD,,-11.591,27.531,1352000.0,1338
-G-FCA,Kalispell,,,gleam_basin,,W-NA,,US,USA,US-MT,48.311,-114.256,37000.0,2290
-G-FCO,Rome,,,gleam_basin,,W-EU,,IT,ITA,,41.8,12.239,3339000.0,3099
-G-FDF,Fort de France,,,gleam_basin,,W-NA,,MQ,MTQ,,14.591,-61.003,254000.0,859
-G-FDH,Friedrichshafen,,,gleam_basin,,W-EU,,DE,DEU,,47.671,9.511,58000.0,751
-G-FEG,Fergana,,,gleam_basin,,W-AS,,UZ,UZB,,40.359,71.745,164000.0,2846
+G-FBA,Fonte Boa,,,gleam_basin,,W-SA,,BR,BRA,,-2.533,-66.083,16000,1987
+G-FBD,Faizabad,,,gleam_basin,,W-AS,,AF,AFG,,37.121,70.518,65000,890
+G-FBE,Francisco Beltrao,,,gleam_basin,,W-SA,,BR,BRA,,-26.059,-53.063,58000,1988
+G-FBM,Lubumbashi,,,gleam_basin,,W-AF,,CD,COD,,-11.591,27.531,1352000,1338
+G-FCA,Kalispell,,,gleam_basin,,W-NA,,US,USA,US-MT,48.311,-114.256,37000,2290
+G-FCO,Rome,,,gleam_basin,,W-EU,,IT,ITA,,41.8,12.239,3339000,3099
+G-FDF,Fort de France,,,gleam_basin,,W-NA,,MQ,MTQ,,14.591,-61.003,254000,859
+G-FDH,Friedrichshafen,,,gleam_basin,,W-EU,,DE,DEU,,47.671,9.511,58000,751
+G-FEG,Fergana,,,gleam_basin,,W-AS,,UZ,UZB,,40.359,71.745,164000,2846
 G-FEN,Fernando de Noronha,,,gleam_basin,,W-SA,,BR,BRA,,-3.855,-32.423,,2046
-G-FEZ,Fes,,,gleam_basin,,W-AF,,MA,MAR,,33.927,-4.978,1002000.0,826
+G-FEZ,Fes,,,gleam_basin,,W-AF,,MA,MAR,,33.927,-4.978,1002000,826
 G-FGU,Fangatau,,,gleam_basin,,W-OC,,PF,PYF,,-15.82,-140.887,,709
 G-FHZ,Fakahina,,,gleam_basin,,W-OC,,PF,PYF,,,,,679
-G-FIH,Kinshasa,,,gleam_basin,,W-AF,,CD,COD,,-4.386,15.445,7843000.0,1331
+G-FIH,Kinshasa,,,gleam_basin,,W-AF,,CD,COD,,-4.386,15.445,7843000,1331
 G-FJR,Fujairah,,,gleam_basin,,W-AS,,AE,ARE,,25.112,56.324,,3176
-G-FKB,Karlsruhe,,,gleam_basin,,W-EU,,DE,DEU,,48.779,8.08,377000.0,725
-G-FKI,Kisangani,,,gleam_basin,,W-AF,,CD,COD,,0.482,25.338,578000.0,1328
-G-FKL,Franklin,,,gleam_basin,,W-NA,,US,USA,US-TN,41.378,-79.86,78000.0,2101
+G-FKB,Karlsruhe,,,gleam_basin,,W-EU,,DE,DEU,,48.779,8.08,377000,725
+G-FKI,Kisangani,,,gleam_basin,,W-AF,,CD,COD,,0.482,25.338,578000,1328
+G-FKL,Franklin,,,gleam_basin,,W-NA,,US,USA,US-TN,41.378,-79.86,78000,2101
 G-FKQ,Fak Fak,,,gleam_basin,,W-AS,,ID,IDN,,-2.92,132.267,,1242
-G-FKS,Fukushima,,,gleam_basin,,W-AS,,JP,JPN,,37.227,140.431,294000.0,3140
-G-FLA,Florencia,,,gleam_basin,,W-SA,,CO,COL,,1.589,-75.564,130000.0,1378
-G-FLG,Flagstaff,,,gleam_basin,,W-NA,,US,USA,US-AZ,35.139,-111.671,79000.0,2252
-G-FLN,Florianopolis,,,gleam_basin,,W-SA,,BR,BRA,,-27.67,-48.553,1022999.0,1984
+G-FKS,Fukushima,,,gleam_basin,,W-AS,,JP,JPN,,37.227,140.431,294000,3140
+G-FLA,Florencia,,,gleam_basin,,W-SA,,CO,COL,,1.589,-75.564,130000,1378
+G-FLG,Flagstaff,,,gleam_basin,,W-NA,,US,USA,US-AZ,35.139,-111.671,79000,2252
+G-FLN,Florianopolis,,,gleam_basin,,W-SA,,BR,BRA,,-27.67,-48.553,1022999,1984
 G-FLO,Florence (US),,,gleam_basin,,W-NA,,US,USA,US-SC,34.185,-79.724,,2251
 G-FLR,Florence (IT),,,gleam_basin,,W-EU,,IT,ITA,,43.81,11.205,,3081
 G-FLS,Flinders Island,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-40.092,147.993,,1654
 G-FLW,Flores Island,,,gleam_basin,,W-EU,,PT,PRT,,39.455,-31.131,,1433
-G-FMA,Formosa,,,gleam_basin,,W-SA,,AR,ARG,,-26.213,-58.228,221000.0,3198
-G-FMI,Kalemie,,,gleam_basin,,W-AF,,CD,COD,,-5.876,29.25,206000.0,1341
-G-FMM,Memmingen,,,gleam_basin,,W-EU,,DE,DEU,,47.989,10.24,41000.0,739
-G-FMN,Farmington,,,gleam_basin,,W-NA,,US,USA,US-NM,36.741,-108.23,53000.0,2291
-G-FMO,Muenster,,,gleam_basin,,W-EU,,DE,DEU,,52.135,7.685,270000.0,738
-G-FNA,Freetown,,,gleam_basin,,W-AF,,SL,SLE,,8.616,-13.195,827000.0,490
-G-FNC,Funchal,,,gleam_basin,,W-EU,,PT,PRT,,32.698,-16.774,205000.0,1431
-G-FNJ,Pyongyang,,,gleam_basin,,W-AS,,KP,PRK,,39.224,125.67,3300000.0,200
-G-FNT,Flint,,,gleam_basin,,W-NA,,US,USA,US-MI,42.965,-83.744,335000.0,2192
-G-FOC,Fuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,25.935,119.663,2606000.0,376
-G-FOD,Fort Dodge,,,gleam_basin,,W-NA,,US,USA,US-IA,42.551,-94.193,24000.0,2225
-G-FOG,Foggia,,,gleam_basin,,W-EU,,IT,ITA,,41.433,15.535,155000.0,3079
-G-FON,Fortuna,,,gleam_basin,,W-NA,,CR,CRI,,10.478,-84.634,13000.0,800
-G-FOR,Fortaleza,,,gleam_basin,,W-SA,,BR,BRA,,-3.776,-38.533,3602000.0,1980
-G-FPO,Freeport,,,gleam_basin,,W-NA,,BS,BHS,,26.559,-78.696,44000.0,3220
-G-FRA,Frankfurt,,,gleam_basin,,W-EU,,DE,DEU,,50.033,8.571,2895000.0,733
+G-FMA,Formosa,,,gleam_basin,,W-SA,,AR,ARG,,-26.213,-58.228,221000,3198
+G-FMI,Kalemie,,,gleam_basin,,W-AF,,CD,COD,,-5.876,29.25,206000,1341
+G-FMM,Memmingen,,,gleam_basin,,W-EU,,DE,DEU,,47.989,10.24,41000,739
+G-FMN,Farmington,,,gleam_basin,,W-NA,,US,USA,US-NM,36.741,-108.23,53000,2291
+G-FMO,Muenster,,,gleam_basin,,W-EU,,DE,DEU,,52.135,7.685,270000,738
+G-FNA,Freetown,,,gleam_basin,,W-AF,,SL,SLE,,8.616,-13.195,827000,490
+G-FNC,Funchal,,,gleam_basin,,W-EU,,PT,PRT,,32.698,-16.774,205000,1431
+G-FNJ,Pyongyang,,,gleam_basin,,W-AS,,KP,PRK,,39.224,125.67,3300000,200
+G-FNT,Flint,,,gleam_basin,,W-NA,,US,USA,US-MI,42.965,-83.744,335000,2192
+G-FOC,Fuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,25.935,119.663,2606000,376
+G-FOD,Fort Dodge,,,gleam_basin,,W-NA,,US,USA,US-IA,42.551,-94.193,24000,2225
+G-FOG,Foggia,,,gleam_basin,,W-EU,,IT,ITA,,41.433,15.535,155000,3079
+G-FON,Fortuna,,,gleam_basin,,W-NA,,CR,CRI,,10.478,-84.634,13000,800
+G-FOR,Fortaleza,,,gleam_basin,,W-SA,,BR,BRA,,-3.776,-38.533,3602000,1980
+G-FPO,Freeport,,,gleam_basin,,W-NA,,BS,BHS,,26.559,-78.696,44000,3220
+G-FRA,Frankfurt,,,gleam_basin,,W-EU,,DE,DEU,,50.033,8.571,2895000,733
 G-FRE,Fera Island,,,gleam_basin,,W-OC,,SB,SLB,,-8.107,159.577,,3026
 G-FRO,Floro,,,gleam_basin,,W-EU,,NO,NOR,,61.584,5.025,,1168
-G-FRS,Flores,,,gleam_basin,,W-NA,,GT,GTM,,16.914,-89.866,38000.0,1559
-G-FRU,Bishkek,,,gleam_basin,,W-AS,,KG,KGZ,,43.061,74.478,837000.0,3161
-G-FRW,Francistown,,,gleam_basin,,W-AF,,BW,BWA,,-21.16,27.475,90000.0,220
+G-FRS,Flores,,,gleam_basin,,W-NA,,GT,GTM,,16.914,-89.866,38000,1559
+G-FRU,Bishkek,,,gleam_basin,,W-AS,,KG,KGZ,,43.061,74.478,837000,3161
+G-FRW,Francistown,,,gleam_basin,,W-AF,,BW,BWA,,-21.16,27.475,90000,220
 G-FSC,Figari,,,gleam_basin,,W-EU,,FR,FRA,,41.501,9.098,,1508
-G-FSD,Sioux Falls,,,gleam_basin,,W-NA,,US,USA,US-SD,43.582,-96.742,180000.0,2245
+G-FSD,Sioux Falls,,,gleam_basin,,W-NA,,US,USA,US-SD,43.582,-96.742,180000,2245
 G-FSM,Fort Smith (US),,,gleam_basin,,W-NA,,US,USA,US-AR,35.337,-94.367,,2230
 G-FSP,St Pierre,,,gleam_basin,,W-NA,,PM,SPM,,46.763,-56.173,,1487
-G-FSZ,Shizuoka,,,gleam_basin,,W-AS,,JP,JPN,,,,702000.0,3121
+G-FSZ,Shizuoka,,,gleam_basin,,W-AS,,JP,JPN,,,,702000,3121
 G-FTA,Futuna Island,,,gleam_basin,,W-OC,,VU,VUT,,-19.516,170.232,,1319
-G-FTE,El Calafate,,,gleam_basin,,W-SA,,AR,ARG,,-50.28,-72.053,8000.0,3209
-G-FTU,Tolanaro,,,gleam_basin,,W-AF,,MG,MDG,,-25.038,46.956,17000.0,1456
+G-FTE,El Calafate,,,gleam_basin,,W-SA,,AR,ARG,,-50.28,-72.053,8000,3209
+G-FTU,Tolanaro,,,gleam_basin,,W-AF,,MG,MDG,,-25.038,46.956,17000,1456
 G-FUE,Fuerteventura,,,gleam_basin,,W-EU,,ES,ESP,,28.453,-13.864,,2906
-G-FUG,Fuyang,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,32.882,115.734,771000.0,454
+G-FUG,Fuyang,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,32.882,115.734,771000,454
 G-FUJ,Fukue,,,gleam_basin,,W-AS,,JP,JPN,,32.666,128.833,,3146
-G-FUK,Fukuoka,,,gleam_basin,,W-AS,,JP,JPN,,33.586,130.451,2792000.0,3147
-G-FUN,Funafuti,,,gleam_basin,,W-OC,,TV,TUV,,-8.525,179.196,5000.0,1787
+G-FUK,Fukuoka,,,gleam_basin,,W-AS,,JP,JPN,,33.586,130.451,2792000,3147
+G-FUN,Funafuti,,,gleam_basin,,W-OC,,TV,TUV,,-8.525,179.196,5000,1787
 G-FUT,Futuna,,,gleam_basin,,W-OC,,WF,WLF,,-14.311,-178.066,,1556
 G-FVM,Fuvahmulak Island,,,gleam_basin,,W-AS,,MV,MDV,,,,,1481
-G-FWA,Fort Wayne,,,gleam_basin,,W-NA,,US,USA,US-IN,40.979,-85.195,329000.0,2111
-G-FXO,Cuamba,,,gleam_basin,,W-AF,,MZ,MOZ,,-14.815,36.53,73000.0,962
+G-FWA,Fort Wayne,,,gleam_basin,,W-NA,,US,USA,US-IN,40.979,-85.195,329000,2111
+G-FXO,Cuamba,,,gleam_basin,,W-AF,,MZ,MOZ,,-14.815,36.53,73000,962
 G-FYU,Fort Yukon,,,gleam_basin,,W-NA,,US,USA,US-AK,66.572,-145.25,,2281
-G-GAE,Gabes,,,gleam_basin,,W-AF,,TN,TUN,,33.877,10.103,220000.0,1795
-G-GAJ,Yamagata,,,gleam_basin,,W-AS,,JP,JPN,,38.412,140.371,272000.0,3157
+G-GAE,Gabes,,,gleam_basin,,W-AF,,TN,TUN,,33.877,10.103,220000,1795
+G-GAJ,Yamagata,,,gleam_basin,,W-AS,,JP,JPN,,38.412,140.371,272000,3157
 G-GAL,Galena,,,gleam_basin,,W-NA,,US,USA,US-AK,64.736,-156.937,,2499
 G-GAM,Gambell,,,gleam_basin,,W-NA,,US,USA,US-AK,63.767,-171.733,,2498
 G-GAN,Gan Island,,,gleam_basin,,W-AS,,MV,MDV,,-0.693,73.156,,1485
-G-GAO,Guantanamo,,,gleam_basin,,W-NA,,CU,CUB,,20.085,-75.158,273000.0,3252
-G-GAU,Guwahati,,,gleam_basin,,W-AS,,IN,IND,,26.106,91.586,983000.0,1112
-G-GAY,Gaya,,,gleam_basin,,W-AS,,IN,IND,,24.744,84.951,424000.0,1111
+G-GAO,Guantanamo,,,gleam_basin,,W-NA,,CU,CUB,,20.085,-75.158,273000,3252
+G-GAU,Guwahati,,,gleam_basin,,W-AS,,IN,IND,,26.106,91.586,983000,1112
+G-GAY,Gaya,,,gleam_basin,,W-AS,,IN,IND,,24.744,84.951,424000,1111
 G-GBB,Gabala,,,gleam_basin,,W-AS,,AZ,AZE,,40.827,47.712,,2576
-G-GBD,Great Bend,,,gleam_basin,,W-NA,,US,USA,US-KS,38.344,-98.859,16000.0,2113
-G-GBE,Gaborone,,,gleam_basin,,W-AF,,BW,BWA,,-24.555,25.918,208000.0,219
-G-GBT,Gorgan,,,gleam_basin,,W-AS,,IR,IRN,,36.909,54.401,281000.0,2932
-G-GCC,Gillette,,,gleam_basin,,W-NA,,US,USA,US-WY,44.349,-105.539,34000.0,2280
+G-GBD,Great Bend,,,gleam_basin,,W-NA,,US,USA,US-KS,38.344,-98.859,16000,2113
+G-GBE,Gaborone,,,gleam_basin,,W-AF,,BW,BWA,,-24.555,25.918,208000,219
+G-GBT,Gorgan,,,gleam_basin,,W-AS,,IR,IRN,,36.909,54.401,281000,2932
+G-GCC,Gillette,,,gleam_basin,,W-NA,,US,USA,US-WY,44.349,-105.539,34000,2280
 G-GCI,Guernsey,,,gleam_basin,,W-EU,,GG,GGY,,,,,1442
-G-GCK,Garden City,,,gleam_basin,,W-NA,,US,USA,US-KS,37.928,-100.724,30000.0,2312
+G-GCK,Garden City,,,gleam_basin,,W-NA,,US,USA,US-KS,37.928,-100.724,30000,2312
 G-GCM,Grand Cayman Island,,,gleam_basin,,W-NA,,KY,CYM,,19.293,-81.358,,2863
 G-GCN,Grand Canyon,,,gleam_basin,,W-NA,,US,USA,US-AZ,35.952,-112.147,,2086
 G-GCW,Grand Canyon West,,,gleam_basin,,W-NA,,US,USA,US-AZ,,,,2287
-G-GDE,Gode,,,gleam_basin,,W-AF,,ET,ETH,,5.935,43.579,75000.0,239
-G-GDL,Guadalajara,,,gleam_basin,,W-NA,,MX,MEX,,20.522,-103.311,4198000.0,1023
-G-GDN,Gdansk,,,gleam_basin,,W-EU,,PL,POL,,54.378,18.466,740000.0,2857
-G-GDQ,Gonder,,,gleam_basin,,W-AF,,ET,ETH,,12.52,37.434,156000.0,238
-G-GDT,Grand Turk,,,gleam_basin,,W-NA,,TC,TCA,,21.444,-71.142,6000.0,674
-G-GDV,Glendive,,,gleam_basin,,W-NA,,US,USA,US-MT,47.139,-104.807,7000.0,2376
-G-GDX,Magadan,,,gleam_basin,,W-EU,,RU,RUS,,59.911,150.72,95000.0,1891
-G-GDZ,Gelendzhik,,,gleam_basin,,W-EU,,RU,RUS,,44.582,38.012,56000.0,1892
-G-GEG,Spokane,,,gleam_basin,,W-NA,,US,USA,US-WA,47.62,-117.534,403000.0,2343
-G-GEL,Santo Angelo,,,gleam_basin,,W-SA,,BR,BRA,,-28.282,-54.169,65000.0,2003
-G-GEO,Georgetown,,,gleam_basin,,W-SA,,GY,GUY,,6.499,-58.254,264000.0,797
-G-GER,Nueva Gerona,,,gleam_basin,,W-NA,,CU,CUB,,21.835,-82.784,26000.0,3248
-G-GES,General Santos,,,gleam_basin,,W-AS,,PH,PHL,,6.058,125.096,951000.0,610
+G-GDE,Gode,,,gleam_basin,,W-AF,,ET,ETH,,5.935,43.579,75000,239
+G-GDL,Guadalajara,,,gleam_basin,,W-NA,,MX,MEX,,20.522,-103.311,4198000,1023
+G-GDN,Gdansk,,,gleam_basin,,W-EU,,PL,POL,,54.378,18.466,740000,2857
+G-GDQ,Gonder,,,gleam_basin,,W-AF,,ET,ETH,,12.52,37.434,156000,238
+G-GDT,Grand Turk,,,gleam_basin,,W-NA,,TC,TCA,,21.444,-71.142,6000,674
+G-GDV,Glendive,,,gleam_basin,,W-NA,,US,USA,US-MT,47.139,-104.807,7000,2376
+G-GDX,Magadan,,,gleam_basin,,W-EU,,RU,RUS,,59.911,150.72,95000,1891
+G-GDZ,Gelendzhik,,,gleam_basin,,W-EU,,RU,RUS,,44.582,38.012,56000,1892
+G-GEG,Spokane,,,gleam_basin,,W-NA,,US,USA,US-WA,47.62,-117.534,403000,2343
+G-GEL,Santo Angelo,,,gleam_basin,,W-SA,,BR,BRA,,-28.282,-54.169,65000,2003
+G-GEO,Georgetown,,,gleam_basin,,W-SA,,GY,GUY,,6.499,-58.254,264000,797
+G-GER,Nueva Gerona,,,gleam_basin,,W-NA,,CU,CUB,,21.835,-82.784,26000,3248
+G-GES,General Santos,,,gleam_basin,,W-AS,,PH,PHL,,6.058,125.096,951000,610
 G-GET,Geraldton (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-28.796,114.707,,1641
 G-GEV,Gallivare,,,gleam_basin,,W-EU,,SE,SWE,,67.132,20.815,,2559
-G-GFF,Griffith,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-34.251,146.067,16000.0,1673
-G-GFK,Grand Forks,,,gleam_basin,,W-NA,,US,USA,US-ND,47.949,-97.176,66000.0,2467
-G-GFN,Grafton,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-29.759,153.03,19000.0,1670
-G-GGG,Longview,,,gleam_basin,,W-NA,,US,USA,US-TX,32.384,-94.712,100000.0,2405
-G-GGT,George Town,,,gleam_basin,,W-NA,,BS,BHS,,23.563,-75.878,2000.0,3228
+G-GFF,Griffith,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-34.251,146.067,16000,1673
+G-GFK,Grand Forks,,,gleam_basin,,W-NA,,US,USA,US-ND,47.949,-97.176,66000,2467
+G-GFN,Grafton,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-29.759,153.03,19000,1670
+G-GGG,Longview,,,gleam_basin,,W-NA,,US,USA,US-TX,32.384,-94.712,100000,2405
+G-GGT,George Town,,,gleam_basin,,W-NA,,BS,BHS,,23.563,-75.878,2000,3228
 G-GGW,Glasgow (US),,,gleam_basin,,W-NA,,US,USA,US-MT,48.213,-106.615,,2404
-G-GHA,Ghardaia,,,gleam_basin,,W-AF,,DZ,DZA,,32.384,3.794,125000.0,33
-G-GHT,Ghat,,,gleam_basin,,W-AF,,LY,LBY,,25.146,10.143,24000.0,161
+G-GHA,Ghardaia,,,gleam_basin,,W-AF,,DZ,DZA,,32.384,3.794,125000,33
+G-GHT,Ghat,,,gleam_basin,,W-AF,,LY,LBY,,25.146,10.143,24000,161
 G-GIB,Gibraltar,,,gleam_basin,,W-EU,,GI,GIB,,,,,493
-G-GIG,Rio de Janeiro,,,gleam_basin,,W-SA,,BR,BRA,,-22.81,-43.251,11748000.0,1990
-G-GIL,Gilgit,,,gleam_basin,,W-AS,,PK,PAK,,35.919,74.334,3500000.0,106
-G-GIS,Gisborne,,,gleam_basin,,W-OC,,NZ,NZL,,-38.663,177.978,34000.0,3051
-G-GIZ,Jazan,,,gleam_basin,,W-AS,,SA,SAU,,16.901,42.586,105000.0,258
+G-GIG,Rio de Janeiro,,,gleam_basin,,W-SA,,BR,BRA,,-22.81,-43.251,11748000,1990
+G-GIL,Gilgit,,,gleam_basin,,W-AS,,PK,PAK,,35.919,74.334,3500000,106
+G-GIS,Gisborne,,,gleam_basin,,W-OC,,NZ,NZL,,-38.663,177.978,34000,3051
+G-GIZ,Jazan,,,gleam_basin,,W-AS,,SA,SAU,,16.901,42.586,105000,258
 G-GJA,Guanaja,,,gleam_basin,,W-NA,,HN,HND,,16.445,-85.907,,1194
-G-GJL,Jijel,,,gleam_basin,,W-AF,,DZ,DZA,,36.795,5.874,148000.0,41
-G-GJT,Grand Junction,,,gleam_basin,,W-NA,,US,USA,US-CO,39.122,-108.527,137000.0,2365
-G-GKA,Goroka,,,gleam_basin,,W-OC,,PG,PNG,,,,40000.0,2999
+G-GJL,Jijel,,,gleam_basin,,W-AF,,DZ,DZA,,36.795,5.874,148000,41
+G-GJT,Grand Junction,,,gleam_basin,,W-NA,,US,USA,US-CO,39.122,-108.527,137000,2365
+G-GKA,Goroka,,,gleam_basin,,W-OC,,PG,PNG,,,,40000,2999
 G-GKK,Kooddoo Island,,,gleam_basin,,W-AS,,MV,MDV,,0.732,73.434,,1482
 G-GLA,Glasgow (UK),,,gleam_basin,,W-EU,,GB,GBR,,55.872,-4.433,,782
 G-GLH,Greenville (US-MS),,,gleam_basin,,W-NA,,US,USA,US-MS,33.483,-90.986,,2176
 G-GLK,Galcaio,,,gleam_basin,,W-AF,,SO,SOM,,6.781,47.455,,2832
 G-GLN,Guelmime,,,gleam_basin,,W-AF,,MA,MAR,,,,,822
-G-GLO,Gloucester,,,gleam_basin,,W-EU,,GB,GBR,,51.894,-2.167,64000.0,783
-G-GLT,Gladstone,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.87,151.223,30000.0,1645
-G-GMA,Gemena,,,gleam_basin,,W-AF,,CD,COD,,3.235,19.771,198000.0,1330
-G-GMB,Gambela,,,gleam_basin,,W-AF,,ET,ETH,,8.129,34.563,42000.0,227
-G-GME,Gomel,,,gleam_basin,,W-EU,,BY,BLR,,52.527,31.017,481000.0,902
-G-GMO,Gombe,,,gleam_basin,,W-AF,,NG,NGA,,10.298,10.896,270000.0,1411
+G-GLO,Gloucester,,,gleam_basin,,W-EU,,GB,GBR,,51.894,-2.167,64000,783
+G-GLT,Gladstone,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.87,151.223,30000,1645
+G-GMA,Gemena,,,gleam_basin,,W-AF,,CD,COD,,3.235,19.771,198000,1330
+G-GMB,Gambela,,,gleam_basin,,W-AF,,ET,ETH,,8.129,34.563,42000,227
+G-GME,Gomel,,,gleam_basin,,W-EU,,BY,BLR,,52.527,31.017,481000,902
+G-GMO,Gombe,,,gleam_basin,,W-AF,,NG,NGA,,10.298,10.896,270000,1411
 G-GMR,Totegegie,,,gleam_basin,,W-OC,,PF,PYF,,-23.08,-134.89,,682
 G-GMZ,San Sebastian La Gomera,,,gleam_basin,,W-EU,,ES,ESP,,28.03,-17.215,,2885
-G-GNA,Grodno,,,gleam_basin,,W-EU,,BY,BLR,,53.602,24.054,350000.0,903
+G-GNA,Grodno,,,gleam_basin,,W-EU,,BY,BLR,,53.602,24.054,350000,903
 G-GND,Grenada,,,gleam_basin,,W-NA,,GD,GRD,,,,,907
 G-GNS,Gunung Sitoli,,,gleam_basin,,W-AS,,ID,IDN,,1.166,97.705,,1263
 G-GNU,Goodnews Bay,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2237
-G-GNV,Gainesville,,,gleam_basin,,W-NA,,US,USA,US-FL,29.69,-82.272,200000.0,2236
-G-GNY,Sanliurfa,,,gleam_basin,,W-AS,,TR,TUR,,37.446,38.896,450000.0,1766
-G-GOA,Genoa,,,gleam_basin,,W-EU,,IT,ITA,,44.413,8.838,647000.0,3077
-G-GOH,Nuuk,,,gleam_basin,,W-NA,,GL,GRL,,64.191,-51.678,15000.0,941
-G-GOI,Goa,,,gleam_basin,,W-AS,,IN,IND,,15.381,73.831,21000.0,1071
-G-GOJ,Nizhny Novgorod,,,gleam_basin,,W-EU,,RU,RUS,,56.23,43.784,1266000.0,1836
-G-GOM,Goma,,,gleam_basin,,W-AF,,CD,COD,,-1.671,29.239,144000.0,1542
-G-GOP,Gorakhpur,,,gleam_basin,,W-AS,,IN,IND,,26.74,83.45,674000.0,1073
-G-GOQ,Golmud,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,36.401,94.786,107000.0,369
-G-GOT,Goteborg,,,gleam_basin,,W-EU,,SE,SWE,,57.663,12.28,538000.0,2572
-G-GOU,Garoua,,,gleam_basin,,W-AF,,CM,CMR,,9.336,13.37,437000.0,806
+G-GNV,Gainesville,,,gleam_basin,,W-NA,,US,USA,US-FL,29.69,-82.272,200000,2236
+G-GNY,Sanliurfa,,,gleam_basin,,W-AS,,TR,TUR,,37.446,38.896,450000,1766
+G-GOA,Genoa,,,gleam_basin,,W-EU,,IT,ITA,,44.413,8.838,647000,3077
+G-GOH,Nuuk,,,gleam_basin,,W-NA,,GL,GRL,,64.191,-51.678,15000,941
+G-GOI,Goa,,,gleam_basin,,W-AS,,IN,IND,,15.381,73.831,21000,1071
+G-GOJ,Nizhny Novgorod,,,gleam_basin,,W-EU,,RU,RUS,,56.23,43.784,1266000,1836
+G-GOM,Goma,,,gleam_basin,,W-AF,,CD,COD,,-1.671,29.239,144000,1542
+G-GOP,Gorakhpur,,,gleam_basin,,W-AS,,IN,IND,,26.74,83.45,674000,1073
+G-GOQ,Golmud,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,36.401,94.786,107000,369
+G-GOT,Goteborg,,,gleam_basin,,W-EU,,SE,SWE,,57.663,12.28,538000,2572
+G-GOU,Garoua,,,gleam_basin,,W-AF,,CM,CMR,,9.336,13.37,437000,806
 G-GOV,Nhulunbuy,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.269,136.818,,1607
-G-GPA,Patrai,,,gleam_basin,,W-EU,,GR,GRC,,38.151,21.426,167000.0,933
-G-GPI,Guapi,,,gleam_basin,,W-SA,,CO,COL,,2.57,-77.899,14000.0,1401
+G-GPA,Patrai,,,gleam_basin,,W-EU,,GR,GRC,,38.151,21.426,167000,933
+G-GPI,Guapi,,,gleam_basin,,W-SA,,CO,COL,,2.57,-77.899,14000,1401
 G-GPS,Baltra Island,,,gleam_basin,,W-SA,,EC,ECU,,-0.454,-90.266,,1472
-G-GPT,Gulfport,,,gleam_basin,,W-NA,,US,USA,US-MS,30.407,-89.07,221000.0,2475
+G-GPT,Gulfport,,,gleam_basin,,W-NA,,US,USA,US-MS,30.407,-89.07,221000,2475
 G-GPZ,Grand Rapids (US-MN),,,gleam_basin,,W-NA,,US,USA,US-MN,47.211,-93.51,,2474
-G-GRB,Green Bay,,,gleam_basin,,W-NA,,US,USA,US-WI,44.485,-88.13,209000.0,2206
-G-GRI,Grand Island,,,gleam_basin,,W-NA,,US,USA,US-NE,40.967,-98.31,53000.0,2063
-G-GRJ,George,,,gleam_basin,,W-AF,,ZA,ZAF,,-34.006,22.379,175000.0,625
-G-GRK,Killeen,,,gleam_basin,,W-NA,,US,USA,US-TX,31.067,-97.829,247000.0,2062
-G-GRO,Girona,,,gleam_basin,,W-EU,,ES,ESP,,41.901,2.761,96000.0,2877
-G-GRQ,Groningen,,,gleam_basin,,W-EU,,NL,NLD,,53.12,6.579,217000.0,835
+G-GRB,Green Bay,,,gleam_basin,,W-NA,,US,USA,US-WI,44.485,-88.13,209000,2206
+G-GRI,Grand Island,,,gleam_basin,,W-NA,,US,USA,US-NE,40.967,-98.31,53000,2063
+G-GRJ,George,,,gleam_basin,,W-AF,,ZA,ZAF,,-34.006,22.379,175000,625
+G-GRK,Killeen,,,gleam_basin,,W-NA,,US,USA,US-TX,31.067,-97.829,247000,2062
+G-GRO,Girona,,,gleam_basin,,W-EU,,ES,ESP,,41.901,2.761,96000,2877
+G-GRQ,Groningen,,,gleam_basin,,W-EU,,NL,NLD,,53.12,6.579,217000,835
 G-GRR,Grand Rapids (US-MI),,,gleam_basin,,W-NA,,US,USA,US-MI,42.881,-85.523,,2061
-G-GRU,Sao Paulo,,,gleam_basin,,W-SA,,BR,BRA,,-23.436,-46.473,18845000.0,2042
+G-GRU,Sao Paulo,,,gleam_basin,,W-SA,,BR,BRA,,-23.436,-46.473,18845000,2042
 G-GRV,Grozny,,,gleam_basin,,W-EU,,RU,RUS,,,,,1797
-G-GRX,Granada,,,gleam_basin,,W-EU,,ES,ESP,,37.189,-3.777,388000.0,2876
-G-GRY,Grimsey,,,gleam_basin,,W-EU,,IS,ISL,,66.546,-18.017,3300.0,1347
-G-GRZ,Graz,,,gleam_basin,,W-EU,,AT,AUT,,46.991,15.44,263000.0,1694
+G-GRX,Granada,,,gleam_basin,,W-EU,,ES,ESP,,37.189,-3.777,388000,2876
+G-GRY,Grimsey,,,gleam_basin,,W-EU,,IS,ISL,,66.546,-18.017,3300,1347
+G-GRZ,Graz,,,gleam_basin,,W-EU,,AT,AUT,,46.991,15.44,263000,1694
 G-GSM,Gheshm Island,,,gleam_basin,,W-AS,,IR,IRN,,,,,2968
 G-GSN,Mount Gunson,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,,,,1681
-G-GSO,Greensboro,,,gleam_basin,,W-NA,,US,USA,US-NC,36.098,-79.937,336000.0,2508
+G-GSO,Greensboro,,,gleam_basin,,W-NA,,US,USA,US-NC,36.098,-79.937,336000,2508
 G-GSP,Greenville (US-SC),,,gleam_basin,,W-NA,,US,USA,US-SC,34.896,-82.219,,2506
 G-GST,Gustavus,,,gleam_basin,,W-NA,,US,USA,US-AK,58.425,-135.707,,2507
 G-GTE,Groote Eylandt,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-13.975,136.46,,1637
-G-GTF,Great Falls,,,gleam_basin,,W-NA,,US,USA,US-MT,47.482,-111.371,66000.0,2321
-G-GTO,Gorontalo,,,gleam_basin,,W-AS,,ID,IDN,,0.637,122.85,365000.0,1277
+G-GTF,Great Falls,,,gleam_basin,,W-NA,,US,USA,US-MT,47.482,-111.371,66000,2321
+G-GTO,Gorontalo,,,gleam_basin,,W-AS,,ID,IDN,,0.637,122.85,365000,1277
 G-GTR,Golden Triangle,,,gleam_basin,,W-NA,,US,USA,US-MS,33.45,-88.591,,2322
 G-GTS,The Granites,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,,,,1638
-G-GUA,Guatemala City,,,gleam_basin,,W-NA,,GT,GTM,,14.583,-90.527,1024000.0,1560
-G-GUC,Gunnison,,,gleam_basin,,W-NA,,US,USA,US-CO,38.534,-106.933,7000.0,2279
+G-GUA,Guatemala City,,,gleam_basin,,W-NA,,GT,GTM,,14.583,-90.527,1024000,1560
+G-GUC,Gunnison,,,gleam_basin,,W-NA,,US,USA,US-CO,38.534,-106.933,7000,2279
 G-GUM,Guam,,,gleam_basin,,W-OC,,GU,GUM,,,,,753
-G-GUR,Alotau,,,gleam_basin,,W-OC,,PG,PNG,,-10.311,150.334,12000.0,2989
-G-GUW,Atyrau,,,gleam_basin,,W-AS,,KZ,KAZ,,47.122,51.821,183000.0,663
-G-GVA,Geneva,,,gleam_basin,,W-EU,,CH,CHE,,46.238,6.109,1240000.0,279
-G-GVR,Governador Valadares,,,gleam_basin,,W-SA,,BR,BRA,,-18.895,-41.982,251000.0,2013
-G-GWD,Gwadar,,,gleam_basin,,W-AS,,PK,PAK,,25.233,62.329,197000.0,127
-G-GWL,Gwalior,,,gleam_basin,,W-AS,,IN,IND,,26.293,78.228,978000.0,1093
+G-GUR,Alotau,,,gleam_basin,,W-OC,,PG,PNG,,-10.311,150.334,12000,2989
+G-GUW,Atyrau,,,gleam_basin,,W-AS,,KZ,KAZ,,47.122,51.821,183000,663
+G-GVA,Geneva,,,gleam_basin,,W-EU,,CH,CHE,,46.238,6.109,1240000,279
+G-GVR,Governador Valadares,,,gleam_basin,,W-SA,,BR,BRA,,-18.895,-41.982,251000,2013
+G-GWD,Gwadar,,,gleam_basin,,W-AS,,PK,PAK,,25.233,62.329,197000,127
+G-GWL,Gwalior,,,gleam_basin,,W-AS,,IN,IND,,26.293,78.228,978000,1093
 G-GWT,Westerland,,,gleam_basin,,W-EU,,DE,DEU,,54.913,8.34,,741
 G-GXF,Sayun,,,gleam_basin,,W-AS,,YE,YEM,,15.966,48.788,,582
 G-GXH,Xiahe,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,34.81,102.645,,384
-G-GYA,Guayaramerin,,,gleam_basin,,W-SA,,BR,BRA,,-10.821,-65.346,36000.0,1975
-G-GYD,Baku,,,gleam_basin,,W-AS,,AZ,AZE,,40.467,50.047,2122000.0,2574
-G-GYE,Guayaquil,,,gleam_basin,,W-SA,,EC,ECU,,-2.157,-79.884,2514000.0,1465
+G-GYA,Guayaramerin,,,gleam_basin,,W-SA,,BR,BRA,,-10.821,-65.346,36000,1975
+G-GYD,Baku,,,gleam_basin,,W-AS,,AZ,AZE,,40.467,50.047,2122000,2574
+G-GYE,Guayaquil,,,gleam_basin,,W-SA,,EC,ECU,,-2.157,-79.884,2514000,1465
 G-GYL,Argyle,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-16.637,128.451,,1606
-G-GYN,Goiania,,,gleam_basin,,W-SA,,BR,BRA,,-16.632,-49.221,2021999.0,1976
-G-GYS,Guangyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,32.391,105.702,437000.0,367
+G-GYN,Goiania,,,gleam_basin,,W-SA,,BR,BRA,,-16.632,-49.221,2021999,1976
+G-GYS,Guangyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,32.391,105.702,437000,367
 G-GYU,Guyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-NX,36.079,106.217,,366
-G-GZO,Gizo,,,gleam_basin,,W-OC,,SB,SLB,,-8.098,156.864,6000.0,3030
-G-GZP,Gazipasa,,,gleam_basin,,W-AS,,TR,TUR,,36.299,32.301,18000.0,1772
-G-GZT,Gaziantep,,,gleam_basin,,W-AS,,TR,TUR,,36.947,37.479,1044000.0,1771
+G-GZO,Gizo,,,gleam_basin,,W-OC,,SB,SLB,,-8.098,156.864,6000,3030
+G-GZP,Gazipasa,,,gleam_basin,,W-AS,,TR,TUR,,36.299,32.301,18000,1772
+G-GZT,Gaziantep,,,gleam_basin,,W-AS,,TR,TUR,,36.947,37.479,1044000,1771
 G-HAA,Hasvik,,,gleam_basin,,W-EU,,NO,NOR,,70.487,22.14,,1141
 G-HAC,Hachijojima,,,gleam_basin,,W-AS,,JP,JPN,,33.115,139.786,,3119
-G-HAH,Moroni,,,gleam_basin,,W-AF,,KM,COM,,-11.534,43.272,129000.0,1360
-G-HAJ,Hannover,,,gleam_basin,,W-EU,,DE,DEU,,52.461,9.685,722000.0,730
-G-HAK,Haikou,,,gleam_basin,,W-AS,,CN,CHN,CN-HI,19.935,110.459,2045999.0,475
-G-HAM,Hamburg,,,gleam_basin,,W-EU,,DE,DEU,,53.63,9.988,1757000.0,735
-G-HAN,Hanoi,,,gleam_basin,,W-AS,,VN,VNM,,21.221,105.807,4378000.0,1125
+G-HAH,Moroni,,,gleam_basin,,W-AF,,KM,COM,,-11.534,43.272,129000,1360
+G-HAJ,Hannover,,,gleam_basin,,W-EU,,DE,DEU,,52.461,9.685,722000,730
+G-HAK,Haikou,,,gleam_basin,,W-AS,,CN,CHN,CN-HI,19.935,110.459,2045999,475
+G-HAM,Hamburg,,,gleam_basin,,W-EU,,DE,DEU,,53.63,9.988,1757000,735
+G-HAN,Hanoi,,,gleam_basin,,W-AS,,VN,VNM,,21.221,105.807,4378000,1125
 G-HAQ,Hanimaadhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,6.744,73.171,,1480
 G-HAS,Hail,,,gleam_basin,,W-AS,,SA,SAU,,27.438,41.686,,253
-G-HAU,Haugesund,,,gleam_basin,,W-EU,,NO,NOR,,59.345,5.208,40000.0,1143
-G-HAV,Havana,,,gleam_basin,,W-NA,,CU,CUB,,22.989,-82.409,2174000.0,3250
-G-HBA,Hobart,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-42.836,147.51,81000.0,1618
+G-HAU,Haugesund,,,gleam_basin,,W-EU,,NO,NOR,,59.345,5.208,40000,1143
+G-HAV,Havana,,,gleam_basin,,W-NA,,CU,CUB,,22.989,-82.409,2174000,3250
+G-HBA,Hobart,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-42.836,147.51,81000,1618
 G-HBE,Alexandria (EG),,,gleam_basin,,W-AF,,EG,EGY,,30.918,29.696,,56
-G-HBX,Hubli,,,gleam_basin,,W-AS,,IN,IND,,15.362,75.085,890000.0,1080
+G-HBX,Hubli,,,gleam_basin,,W-AS,,IN,IND,,15.362,75.085,890000,1080
 G-HCR,Holy Cross,,,gleam_basin,,W-NA,,US,USA,US-AK,62.188,-159.775,,2283
-G-HDD,Hyderabad,,Hyderabad (PK),gleam_basin,,W-AS,,PK,PAK,,25.318,68.366,10300000.0,123
+G-HDD,Hyderabad,,Hyderabad (PK),gleam_basin,,W-AS,,PK,PAK,,25.318,68.366,10300000,123
 G-HDF,Heringsdorf,,,gleam_basin,,W-EU,,DE,DEU,,53.879,14.152,,740
-G-HDG,Handan,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,36.526,114.426,1631000.0,408
-G-HDM,Hamadan,,,gleam_basin,,W-AS,,IR,IRN,,34.869,48.553,528000.0,2948
-G-HDN,Hayden,,,gleam_basin,,W-NA,,US,USA,US-ID,40.481,-107.218,15000.0,2308
+G-HDG,Handan,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,36.526,114.426,1631000,408
+G-HDM,Hamadan,,,gleam_basin,,W-AS,,IR,IRN,,34.869,48.553,528000,2948
+G-HDN,Hayden,,,gleam_basin,,W-NA,,US,USA,US-ID,40.481,-107.218,15000,2308
 G-HDS,Hoedspruit,,,gleam_basin,,W-AF,,ZA,ZAF,,-24.369,31.049,,633
-G-HDY,Hat Yai,,,gleam_basin,,W-AS,,TH,THA,,6.933,100.393,318000.0,536
-G-HEA,Herat,,,gleam_basin,,W-AS,,AF,AFG,,34.21,62.228,481000.0,893
+G-HDY,Hat Yai,,,gleam_basin,,W-AS,,TH,THA,,6.933,100.393,318000,536
+G-HEA,Herat,,,gleam_basin,,W-AS,,AF,AFG,,34.21,62.228,481000,893
 G-HEB,Henzada,,,gleam_basin,,W-AS,,MM,MMR,,,,,880
 G-HEH,Heho,,,gleam_basin,,W-AS,,MM,MMR,,20.747,96.792,,881
-G-HEK,Heihe,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,50.172,127.309,109000.0,433
-G-HEL,Helsinki,,,gleam_basin,,W-EU,,FI,FIN,,60.317,24.963,1115000.0,512
-G-HER,Irakleion,,,gleam_basin,,W-EU,,GR,GRC,,35.34,25.18,137000.0,928
-G-HET,Hohhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,40.851,111.824,1726000.0,429
-G-HFA,Haifa,,,gleam_basin,,W-AS,,IL,ISR,,32.809,35.043,1010999.0,1206
-G-HFE,Hefei,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,31.78,117.298,2035000.0,438
+G-HEK,Heihe,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,50.172,127.309,109000,433
+G-HEL,Helsinki,,,gleam_basin,,W-EU,,FI,FIN,,60.317,24.963,1115000,512
+G-HER,Irakleion,,,gleam_basin,,W-EU,,GR,GRC,,35.34,25.18,137000,928
+G-HET,Hohhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,40.851,111.824,1726000,429
+G-HFA,Haifa,,,gleam_basin,,W-AS,,IL,ISR,,32.809,35.043,1010999,1206
+G-HFE,Hefei,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,31.78,117.298,2035000,438
 G-HFS,Hagfors,,,gleam_basin,,W-EU,,SE,SWE,,60.02,13.579,,2566
-G-HFT,Hammerfest,,,gleam_basin,,W-EU,,NO,NOR,,70.68,23.669,10000.0,1162
+G-HFT,Hammerfest,,,gleam_basin,,W-EU,,NO,NOR,,70.68,23.669,10000,1162
 G-HGA,Hargeisa,,,gleam_basin,,W-AF,,SO,SOM,,9.518,44.089,,2833
-G-HGD,Hughenden,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.815,144.225,0.0,1666
-G-HGH,Hangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,30.229,120.434,3007000.0,457
-G-HGN,Mae Hong Son,,,gleam_basin,,W-AS,,TH,THA,,19.301,97.976,9000.0,542
-G-HGR,Hagerstown,,,gleam_basin,,W-NA,,US,USA,US-MD,39.708,-77.729,186000.0,2443
-G-HGU,Mount Hagen,,,gleam_basin,,W-OC,,PG,PNG,,-5.827,144.296,59000.0,2995
+G-HGD,Hughenden,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.815,144.225,0,1666
+G-HGH,Hangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,30.229,120.434,3007000,457
+G-HGN,Mae Hong Son,,,gleam_basin,,W-AS,,TH,THA,,19.301,97.976,9000,542
+G-HGR,Hagerstown,,,gleam_basin,,W-NA,,US,USA,US-MD,39.708,-77.729,186000,2443
+G-HGU,Mount Hagen,,,gleam_basin,,W-OC,,PG,PNG,,-5.827,144.296,59000,2995
 G-HHN,Simmern,,,gleam_basin,,W-EU,,DE,DEU,,49.949,7.264,,743
-G-HHQ,Hua Hin,,,gleam_basin,,W-AS,,TH,THA,,12.636,99.951,50000.0,540
+G-HHQ,Hua Hin,,,gleam_basin,,W-AS,,TH,THA,,12.636,99.951,50000,540
 G-HHZ,Hikueru,,,gleam_basin,,W-OC,,PF,PYF,,-17.545,-142.614,,702
-G-HIA,Huai'an,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,33.791,119.125,555000.0,449
-G-HIB,Hibbing,,,gleam_basin,,W-NA,,US,USA,US-MN,47.387,-92.839,11000.0,2414
+G-HIA,Huai'an,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,33.791,119.125,555000,449
+G-HIB,Hibbing,,,gleam_basin,,W-NA,,US,USA,US-MN,47.387,-92.839,11000,2414
 G-HID,Horn Island,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-10.586,142.29,,1659
-G-HIJ,Hiroshima,,,gleam_basin,,W-AS,,JP,JPN,,34.436,132.919,2045000.0,3144
-G-HIR,Honiara,,,gleam_basin,,W-OC,,SB,SLB,,-9.428,160.055,76000.0,3033
-G-HJJ,Huaihua,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,27.441,109.7,127000.0,463
+G-HIJ,Hiroshima,,,gleam_basin,,W-AS,,JP,JPN,,34.436,132.919,2045000,3144
+G-HIR,Honiara,,,gleam_basin,,W-OC,,SB,SLB,,-9.428,160.055,76000,3033
+G-HJJ,Huaihua,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,27.441,109.7,127000,463
 G-HJR,Khajuraho,,,gleam_basin,,W-AS,,IN,IND,,24.817,79.919,,1109
 G-HKB,Healy Lake,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2510
-G-HKD,Hakodate,,,gleam_basin,,W-AS,,JP,JPN,,41.77,140.822,303000.0,3159
-G-HKG,Hong Kong,,,gleam_basin,,W-AS,,CN,CHN,CN-HK,22.309,113.915,7206000.0,473
-G-HKK,Hokitika,,,gleam_basin,,W-OC,,NZ,NZL,,-42.714,170.985,3000.0,3054
-G-HKN,Hoskins,,,gleam_basin,,W-OC,,PG,PNG,,-5.462,150.405,1000.0,3001
-G-HKT,Phuket,,,gleam_basin,,W-AS,,TH,THA,,8.113,98.317,142000.0,549
-G-HLD,Hailar,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,49.205,119.825,211000.0,314
-G-HLH,Ulanhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,46.195,122.008,242000.0,313
-G-HLN,Helena,,,gleam_basin,,W-NA,,US,USA,US-MT,46.607,-111.983,50000.0,2064
+G-HKD,Hakodate,,,gleam_basin,,W-AS,,JP,JPN,,41.77,140.822,303000,3159
+G-HKG,Hong Kong,,,gleam_basin,,W-AS,,CN,CHN,CN-HK,22.309,113.915,7206000,473
+G-HKK,Hokitika,,,gleam_basin,,W-OC,,NZ,NZL,,-42.714,170.985,3000,3054
+G-HKN,Hoskins,,,gleam_basin,,W-OC,,PG,PNG,,-5.462,150.405,1000,3001
+G-HKT,Phuket,,,gleam_basin,,W-AS,,TH,THA,,8.113,98.317,142000,549
+G-HLD,Hailar,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,49.205,119.825,211000,314
+G-HLH,Ulanhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,46.195,122.008,242000,313
+G-HLN,Helena,,,gleam_basin,,W-NA,,US,USA,US-MT,46.607,-111.983,50000,2064
 G-HLT,Hamilton (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-37.649,142.065,,1572
 G-HLZ,Hamilton (NZ),,,gleam_basin,,W-OC,,NZ,NZL,,-37.867,175.332,,3038
-G-HMA,Khanty-Mansiysk,,,gleam_basin,,W-EU,,RU,RUS,,61.028,69.086,68000.0,1807
-G-HMB,Sohag,,,gleam_basin,,W-AF,,EG,EGY,,26.343,31.743,209000.0,49
-G-HME,Hassi Messaoud,,,gleam_basin,,W-AF,,DZ,DZA,,31.673,6.14,18000.0,15
-G-HMI,Hami,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,42.841,93.669,137000.0,321
-G-HMO,Hermosillo,,,gleam_basin,,W-NA,,MX,MEX,,29.096,-111.048,596000.0,983
+G-HMA,Khanty-Mansiysk,,,gleam_basin,,W-EU,,RU,RUS,,61.028,69.086,68000,1807
+G-HMB,Sohag,,,gleam_basin,,W-AF,,EG,EGY,,26.343,31.743,209000,49
+G-HME,Hassi Messaoud,,,gleam_basin,,W-AF,,DZ,DZA,,31.673,6.14,18000,15
+G-HMI,Hami,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,42.841,93.669,137000,321
+G-HMO,Hermosillo,,,gleam_basin,,W-NA,,MX,MEX,,29.096,-111.048,596000,983
 G-HMV,Hemavan,,,gleam_basin,,W-EU,,SE,SWE,,65.806,15.083,,2544
-G-HNA,Hanamaki,,,gleam_basin,,W-AS,,JP,JPN,,39.429,141.135,73000.0,3105
-G-HND,Tokyo,,,gleam_basin,,W-AS,,JP,JPN,,35.552,139.78,35676000.0,3106
-G-HNL,Honolulu,,,gleam_basin,,W-NA,,US,USA,US-HI,21.321,-157.924,834000.0,2511
+G-HNA,Hanamaki,,,gleam_basin,,W-AS,,JP,JPN,,39.429,141.135,73000,3105
+G-HND,Tokyo,,,gleam_basin,,W-AS,,JP,JPN,,35.552,139.78,35676000,3106
+G-HNL,Honolulu,,,gleam_basin,,W-NA,,US,USA,US-HI,21.321,-157.924,834000,2511
 G-HNS,Haines,,,gleam_basin,,W-NA,,US,USA,US-AK,59.244,-135.524,,2267
-G-HOB,Hobbs,,,gleam_basin,,W-NA,,US,USA,US-NM,32.688,-103.217,41000.0,2162
+G-HOB,Hobbs,,,gleam_basin,,W-NA,,US,USA,US-NM,32.688,-103.217,41000,2162
 G-HOD,Hodeidah,,,gleam_basin,,W-AS,,YE,YEM,,14.753,42.976,,580
 G-HOE,Houeisay,,,gleam_basin,,W-AS,,LA,LAO,,20.257,100.437,,571
 G-HOF,Hofuf,,,gleam_basin,,W-AS,,SA,SAU,,25.285,49.485,,249
-G-HOG,Holguin,,,gleam_basin,,W-NA,,CU,CUB,,20.786,-76.315,319000.0,3244
+G-HOG,Holguin,,,gleam_basin,,W-NA,,CU,CUB,,20.786,-76.315,319000,3244
 G-HOI,Hao,,,gleam_basin,,W-OC,,PF,PYF,,-18.075,-140.946,,684
-G-HOM,Homer,,,gleam_basin,,W-NA,,US,USA,US-AK,59.646,-151.477,6000.0,2340
-G-HON,Huron,,,gleam_basin,,W-NA,,US,USA,US-SD,44.385,-98.229,13000.0,2163
-G-HOR,Horta,,,gleam_basin,,W-EU,,PT,PRT,,38.52,-28.716,7000.0,1436
-G-HOT,Hot Springs,,,gleam_basin,,W-NA,,US,USA,US-AR,34.478,-93.096,58000.0,2164
+G-HOM,Homer,,,gleam_basin,,W-NA,,US,USA,US-AK,59.646,-151.477,6000,2340
+G-HON,Huron,,,gleam_basin,,W-NA,,US,USA,US-SD,44.385,-98.229,13000,2163
+G-HOR,Horta,,,gleam_basin,,W-EU,,PT,PRT,,38.52,-28.716,7000,1436
+G-HOT,Hot Springs,,,gleam_basin,,W-NA,,US,USA,US-AR,34.478,-93.096,58000,2164
 G-HOX,Homalin,,,gleam_basin,,W-AS,,MM,MMR,,24.9,94.914,,872
-G-HPH,Haiphong,,,gleam_basin,,W-AS,,VN,VNM,,20.819,106.725,1969000.0,1123
-G-HRB,Harbin,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,45.623,126.25,3621000.0,358
-G-HRE,Harare,,,gleam_basin,,W-AF,,ZW,ZWE,,-17.932,31.093,1572000.0,960
-G-HRG,Hurghada,,,gleam_basin,,W-AF,,EG,EGY,,27.178,33.799,96000.0,53
-G-HRK,Kharkiv,,,gleam_basin,,W-EU,,UA,UKR,,49.925,36.29,1461000.0,2784
-G-HRL,Harlingen,,,gleam_basin,,W-NA,,US,USA,US-TX,26.229,-97.654,137000.0,2196
+G-HPH,Haiphong,,,gleam_basin,,W-AS,,VN,VNM,,20.819,106.725,1969000,1123
+G-HRB,Harbin,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,45.623,126.25,3621000,358
+G-HRE,Harare,,,gleam_basin,,W-AF,,ZW,ZWE,,-17.932,31.093,1572000,960
+G-HRG,Hurghada,,,gleam_basin,,W-AF,,EG,EGY,,27.178,33.799,96000,53
+G-HRK,Kharkiv,,,gleam_basin,,W-EU,,UA,UKR,,49.925,36.29,1461000,2784
+G-HRL,Harlingen,,,gleam_basin,,W-NA,,US,USA,US-TX,26.229,-97.654,137000,2196
 G-HSL,Huslia,,,gleam_basin,,W-NA,,US,USA,US-AK,65.698,-156.351,,2221
-G-HSN,Zhoushan,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.934,122.362,84000.0,370
-G-HSV,Huntsville,,,gleam_basin,,W-NA,,US,USA,US-AL,34.637,-86.775,310000.0,2222
-G-HTA,Chita,,,gleam_basin,,W-EU,,RU,RUS,,52.026,113.306,308000.0,1852
+G-HSN,Zhoushan,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.934,122.362,84000,370
+G-HSV,Huntsville,,,gleam_basin,,W-NA,,US,USA,US-AL,34.637,-86.775,310000,2222
+G-HTA,Chita,,,gleam_basin,,W-EU,,RU,RUS,,52.026,113.306,308000,1852
 G-HTI,Hamilton Island,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.358,148.952,,1633
 G-HTM,Khatgal,,,gleam_basin,,W-AS,,MN,MNG,,,,,848
-G-HTN,Hotan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,37.039,79.865,262000.0,386
-G-HTS,Huntington,,,gleam_basin,,W-NA,,US,USA,US-NY,38.367,-82.558,204000.0,2255
-G-HTY,Hatay,,,gleam_basin,,W-AS,,TR,TUR,,36.363,36.282,306000.0,1764
+G-HTN,Hotan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,37.039,79.865,262000,386
+G-HTS,Huntington,,,gleam_basin,,W-NA,,US,USA,US-NY,38.367,-82.558,204000,2255
+G-HTY,Hatay,,,gleam_basin,,W-AS,,TR,TUR,,36.363,36.282,306000,1764
 G-HUE,Humera,,,gleam_basin,,W-AF,,ET,ETH,,14.25,36.583,,232
-G-HUI,Hue,,,gleam_basin,,W-AS,,VN,VNM,,16.402,107.703,950000.0,1130
-G-HUN,Hualien,,,gleam_basin,,W-AS,,TW,TWN,,24.023,121.618,350000.0,2826
+G-HUI,Hue,,,gleam_basin,,W-AS,,VN,VNM,,16.402,107.703,950000,1130
+G-HUN,Hualien,,,gleam_basin,,W-AS,,TW,TWN,,24.023,121.618,350000,2826
 G-HUS,Hughes,,,gleam_basin,,W-NA,,US,USA,US-AK,66.041,-154.263,,2282
-G-HUU,Huanuco,,,gleam_basin,,W-SA,,PE,PER,,-9.879,-76.205,158000.0,1221
-G-HUW,Humaita,,,gleam_basin,,W-SA,,BR,BRA,,-7.532,-63.072,31000.0,1991
+G-HUU,Huanuco,,,gleam_basin,,W-SA,,PE,PER,,-9.879,-76.205,158000,1221
+G-HUW,Humaita,,,gleam_basin,,W-SA,,BR,BRA,,-7.532,-63.072,31000,1991
 G-HUX,Huatulco,,,gleam_basin,,W-NA,,MX,MEX,,15.775,-96.263,,1010
-G-HVB,Hervey Bay,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.319,152.88,25000.0,1639
-G-HVD,Khovd,,,gleam_basin,,W-AS,,MN,MNG,,47.954,91.628,30000.0,850
+G-HVB,Hervey Bay,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.319,152.88,25000,1639
+G-HVD,Khovd,,,gleam_basin,,W-AS,,MN,MNG,,47.954,91.628,30000,850
 G-HVG,Honningsvag,,,gleam_basin,,W-EU,,NO,NOR,,71.01,25.984,,1157
-G-HVN,New Haven,,,gleam_basin,,W-NA,,US,USA,US-CT,41.264,-72.887,568000.0,2323
-G-HVR,Havre,,,gleam_basin,,W-NA,,US,USA,US-MT,48.543,-109.762,10000.0,2324
+G-HVN,New Haven,,,gleam_basin,,W-NA,,US,USA,US-CT,41.264,-72.887,568000,2323
+G-HVR,Havre,,,gleam_basin,,W-NA,,US,USA,US-MT,48.543,-109.762,10000,2324
 G-HYD,Hyderabad,,Hyderabad (IN),gleam_basin,,W-AS,,IN,IND,,17.231,78.43,,1094
-G-HYN,Taizhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,28.562,121.429,612000.0,434
-G-HYS,Hays,,,gleam_basin,,W-NA,,US,USA,US-KS,38.842,-99.273,22000.0,2350
+G-HYN,Taizhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,28.562,121.429,612000,434
+G-HYS,Hays,,,gleam_basin,,W-NA,,US,USA,US-KS,38.842,-99.273,22000,2350
 G-HZH,Liping,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.322,109.15,,446
-G-IAA,Igarka,,,gleam_basin,,W-EU,,RU,RUS,,67.437,86.622,7000.0,1879
-G-IAH,Houston,,,gleam_basin,,W-NA,,US,USA,US-TX,29.984,-95.341,5446000.0,2334
+G-IAA,Igarka,,,gleam_basin,,W-EU,,RU,RUS,,67.437,86.622,7000,1879
+G-IAH,Houston,,,gleam_basin,,W-NA,,US,USA,US-TX,29.984,-95.341,5446000,2334
 G-IAM,In Amenas,,,gleam_basin,,W-AF,,DZ,DZA,,28.052,9.643,,36
 G-IAO,Del Carmen,,,gleam_basin,,W-AS,,PH,PHL,,9.859,126.014,,614
-G-IAR,Yaroslavl,,,gleam_basin,,W-EU,,RU,RUS,,57.561,40.157,607000.0,1880
-G-IAS,Iasi,,,gleam_basin,,W-EU,,RO,ROU,,47.179,27.621,326000.0,147
-G-IBA,Ibadan,,,gleam_basin,,W-AF,,NG,NGA,,7.362,3.978,2628000.0,1417
-G-IBE,Ibague,,,gleam_basin,,W-SA,,CO,COL,,4.422,-75.133,422000.0,1379
-G-IBZ,Ibiza,,,gleam_basin,,W-EU,,ES,ESP,,38.873,1.373,49000.0,2899
+G-IAR,Yaroslavl,,,gleam_basin,,W-EU,,RU,RUS,,57.561,40.157,607000,1880
+G-IAS,Iasi,,,gleam_basin,,W-EU,,RO,ROU,,47.179,27.621,326000,147
+G-IBA,Ibadan,,,gleam_basin,,W-AF,,NG,NGA,,7.362,3.978,2628000,1417
+G-IBE,Ibague,,,gleam_basin,,W-SA,,CO,COL,,4.422,-75.133,422000,1379
+G-IBZ,Ibiza,,,gleam_basin,,W-EU,,ES,ESP,,38.873,1.373,49000,2899
 G-ICI,Cicia Island,,,gleam_basin,,W-OC,,FJ,FJI,,-17.743,-179.342,,1187
-G-ICN,Seoul,,,gleam_basin,,W-AS,,KR,KOR,,37.469,126.451,9796000.0,2803
-G-ICT,Wichita,,,gleam_basin,,W-NA,,US,USA,US-KS,37.65,-97.433,483000.0,2274
-G-IDA,Idaho Falls,,,gleam_basin,,W-NA,,US,USA,US-ID,43.515,-112.071,98000.0,2520
-G-IDR,Indore,,,gleam_basin,,W-AS,,IN,IND,,22.722,75.801,2025999.0,1115
+G-ICN,Seoul,,,gleam_basin,,W-AS,,KR,KOR,,37.469,126.451,9796000,2803
+G-ICT,Wichita,,,gleam_basin,,W-NA,,US,USA,US-KS,37.65,-97.433,483000,2274
+G-IDA,Idaho Falls,,,gleam_basin,,W-NA,,US,USA,US-ID,43.515,-112.071,98000,2520
+G-IDR,Indore,,,gleam_basin,,W-AS,,IN,IND,,22.722,75.801,2025999,1115
 G-IFJ,Isafjordur,,,gleam_basin,,W-EU,,IS,ISL,,66.058,-23.135,,1352
-G-IFN,Esfahan,,,gleam_basin,,W-AS,,IR,IRN,,32.751,51.861,1628000.0,2963
+G-IFN,Esfahan,,,gleam_basin,,W-AS,,IR,IRN,,32.751,51.861,1628000,2963
 G-IFO,Ivano-Frankivsk,,,gleam_basin,,W-EU,,UA,UKR,,48.884,24.686,,2793
-G-IFP,Bullhead City,,,gleam_basin,,W-NA,,US,USA,US-AZ,,,50000.0,2436
+G-IFP,Bullhead City,,,gleam_basin,,W-NA,,US,USA,US-AZ,,,50000,2436
 G-IGA,Inagua,,,gleam_basin,,W-NA,,BS,BHS,,20.975,-73.667,,3226
 G-IGD,Igdir,,,gleam_basin,,W-AS,,TR,TUR,,39.977,43.877,,1776
 G-IGG,Igiugig,,,gleam_basin,,W-NA,,US,USA,US-AK,59.324,-155.902,,2399
-G-IGM,Kingman,,,gleam_basin,,W-NA,,US,USA,US-AZ,,,44000.0,2400
+G-IGM,Kingman,,,gleam_basin,,W-NA,,US,USA,US-AZ,,,44000,2400
 G-IGR,Iguazu,,,gleam_basin,,W-SA,,AR,ARG,,-25.737,-54.473,,3208
-G-IGU,Foz do Iguacu,,,gleam_basin,,W-SA,,BR,BRA,,-25.6,-54.485,440000.0,2016
-G-IIL,Ilam,,,gleam_basin,,W-AS,,IR,IRN,,33.587,46.405,17000.0,2927
-G-IJK,Izhevsk,,,gleam_basin,,W-EU,,RU,RUS,,56.828,53.458,631000.0,1931
+G-IGU,Foz do Iguacu,,,gleam_basin,,W-SA,,BR,BRA,,-25.6,-54.485,440000,2016
+G-IIL,Ilam,,,gleam_basin,,W-AS,,IR,IRN,,33.587,46.405,17000,2927
+G-IJK,Izhevsk,,,gleam_basin,,W-EU,,RU,RUS,,56.828,53.458,631000,1931
 G-IKE,Ikerasak,,,gleam_basin,,W-NA,,GL,GRL,,,,,955
 G-IKI,Iki,,,gleam_basin,,W-AS,,JP,JPN,,33.749,129.785,,3154
 G-IKO,Nikolski,,,gleam_basin,,W-NA,,US,USA,US-AK,52.942,-168.849,,2484
-G-IKS,Tiksi,,,gleam_basin,,W-EU,,RU,RUS,,71.698,128.903,6000.0,1917
-G-IKT,Irkutsk,,,gleam_basin,,W-EU,,RU,RUS,,52.268,104.389,587000.0,1918
-G-ILD,Lleida,,,gleam_basin,,W-EU,,ES,ESP,,41.728,0.535,136000.0,2889
+G-IKS,Tiksi,,,gleam_basin,,W-EU,,RU,RUS,,71.698,128.903,6000,1917
+G-IKT,Irkutsk,,,gleam_basin,,W-EU,,RU,RUS,,52.268,104.389,587000,1918
+G-ILD,Lleida,,,gleam_basin,,W-EU,,ES,ESP,,41.728,0.535,136000,2889
 G-ILI,Iliamna,,,gleam_basin,,W-NA,,US,USA,US-AK,59.754,-154.911,,2509
-G-ILL,Willmar,,,gleam_basin,,W-NA,,US,USA,US-MN,,,20000.0,2228
-G-ILM,Wilmington,,,gleam_basin,,W-NA,,US,USA,US-NC,34.271,-77.903,246000.0,2229
+G-ILL,Willmar,,,gleam_basin,,W-NA,,US,USA,US-MN,,,20000,2228
+G-ILM,Wilmington,,,gleam_basin,,W-NA,,US,USA,US-NC,34.271,-77.903,246000,2229
 G-ILO,Ilo-Ilo,,,gleam_basin,,W-AS,,PH,PHL,,10.833,122.493,,601
 G-ILP,Ile des Pins,,,gleam_basin,,W-OC,,NC,NCL,,-22.589,167.456,,3171
-G-ILR,Ilorin,,,gleam_basin,,W-AF,,NG,NGA,,8.44,4.494,771000.0,1416
+G-ILR,Ilorin,,,gleam_basin,,W-AF,,NG,NGA,,8.44,4.494,771000,1416
 G-ILY,Islay,,,gleam_basin,,W-EU,,GB,GBR,,55.682,-6.257,,790
-G-IMF,Imphal,,,gleam_basin,,W-AS,,IN,IND,,24.76,93.897,265000.0,1069
+G-IMF,Imphal,,,gleam_basin,,W-AS,,IN,IND,,24.76,93.897,265000,1069
 G-IMK,Simikot,,,gleam_basin,,W-AS,,NP,NPL,,29.971,81.819,,557
-G-IMP,Imperatriz,,,gleam_basin,,W-SA,,BR,BRA,,-5.531,-47.46,218000.0,1972
-G-IMT,Iron Mountain,,,gleam_basin,,W-NA,,US,USA,US-MI,45.818,-88.115,19000.0,2105
-G-INC,Yinchuan,,,gleam_basin,,W-AS,,CN,CHN,CN-NX,,,991000.0,350
-G-IND,Indianapolis,,,gleam_basin,,W-NA,,US,USA,US-IN,39.717,-86.294,1565000.0,2175
+G-IMP,Imperatriz,,,gleam_basin,,W-SA,,BR,BRA,,-5.531,-47.46,218000,1972
+G-IMT,Iron Mountain,,,gleam_basin,,W-NA,,US,USA,US-MI,45.818,-88.115,19000,2105
+G-INC,Yinchuan,,,gleam_basin,,W-AS,,CN,CHN,CN-NX,,,991000,350
+G-IND,Indianapolis,,,gleam_basin,,W-NA,,US,USA,US-IN,39.717,-86.294,1565000,2175
 G-INF,In Guezzam,,,gleam_basin,,W-AF,,DZ,DZA,,,,,22
-G-INH,Inhambane,,,gleam_basin,,W-AF,,MZ,MOZ,,-23.876,35.409,116000.0,968
-G-INI,Nis,,,gleam_basin,,W-EU,,RS,SRB,,43.337,21.854,250000.0,2052
-G-INL,International Falls,,,gleam_basin,,W-NA,,US,USA,US-MN,48.566,-93.403,7000.0,2174
-G-INN,Innsbruck,,,gleam_basin,,W-EU,,AT,AUT,,47.26,11.344,155000.0,1697
+G-INH,Inhambane,,,gleam_basin,,W-AF,,MZ,MOZ,,-23.876,35.409,116000,968
+G-INI,Nis,,,gleam_basin,,W-EU,,RS,SRB,,43.337,21.854,250000,2052
+G-INL,International Falls,,,gleam_basin,,W-NA,,US,USA,US-MN,48.566,-93.403,7000,2174
+G-INN,Innsbruck,,,gleam_basin,,W-EU,,AT,AUT,,47.26,11.344,155000,1697
 G-INU,Nauru Island,,,gleam_basin,,W-OC,,NR,NRU,,-0.547,166.919,,3235
-G-INV,Inverness,,,gleam_basin,,W-EU,,GB,GBR,,57.542,-4.048,45000.0,767
+G-INV,Inverness,,,gleam_basin,,W-EU,,GB,GBR,,57.542,-4.048,45000,767
 G-INZ,In Salah,,,gleam_basin,,W-AF,,DZ,DZA,,27.251,2.512,,21
-G-IOA,Ioannina,,,gleam_basin,,W-EU,,GR,GRC,,39.696,20.823,86000.0,911
+G-IOA,Ioannina,,,gleam_basin,,W-EU,,GR,GRC,,39.696,20.823,86000,911
 G-IOM,Isle of Man,,,gleam_basin,,W-EU,,IM,IMN,,,,,1568
-G-IOS,Ilheus,,,gleam_basin,,W-SA,,BR,BRA,,-14.816,-39.033,231000.0,1954
+G-IOS,Ilheus,,,gleam_basin,,W-SA,,BR,BRA,,-14.816,-39.033,231000,1954
 G-IPA,Ipota,,,gleam_basin,,W-OC,,VU,VUT,,-18.856,169.283,,1318
 G-IPC,Easter Island,,,gleam_basin,,W-SA,,CL,CHL,,-27.165,-109.422,,299
-G-IPH,Ipoh,,,gleam_basin,,W-AS,,MY,MYS,,4.568,101.092,673000.0,181
-G-IPI,Ipiales,,,gleam_basin,,W-SA,,CO,COL,,0.862,-77.672,110000.0,1382
-G-IPL,Imperial,,,gleam_basin,,W-NA,,US,USA,US-CA,32.834,-115.579,18000.0,2306
-G-IPN,Ipatinga,,,gleam_basin,,W-SA,,BR,BRA,,-19.471,-42.488,408000.0,1996
-G-IPT,Williamsport,,,gleam_basin,,W-NA,,US,USA,US-PA,41.242,-76.921,54000.0,2307
-G-IQQ,Iquique,,,gleam_basin,,W-SA,,CL,CHL,,-20.535,-70.181,227000.0,307
-G-IQT,Iquitos,,,gleam_basin,,W-SA,,PE,PER,,-3.785,-73.309,459000.0,1228
+G-IPH,Ipoh,,,gleam_basin,,W-AS,,MY,MYS,,4.568,101.092,673000,181
+G-IPI,Ipiales,,,gleam_basin,,W-SA,,CO,COL,,0.862,-77.672,110000,1382
+G-IPL,Imperial,,,gleam_basin,,W-NA,,US,USA,US-CA,32.834,-115.579,18000,2306
+G-IPN,Ipatinga,,,gleam_basin,,W-SA,,BR,BRA,,-19.471,-42.488,408000,1996
+G-IPT,Williamsport,,,gleam_basin,,W-NA,,US,USA,US-PA,41.242,-76.921,54000,2307
+G-IQQ,Iquique,,,gleam_basin,,W-SA,,CL,CHL,,-20.535,-70.181,227000,307
+G-IQT,Iquitos,,,gleam_basin,,W-SA,,PE,PER,,-3.785,-73.309,459000,1228
 G-IRA,Kirakira,,,gleam_basin,,W-OC,,SB,SLB,,-10.45,161.898,,3029
-G-IRD,Ishurdi,,,gleam_basin,,W-AS,,BD,BGD,,24.153,89.049,82000.0,65
+G-IRD,Ishurdi,,,gleam_basin,,W-AS,,BD,BGD,,24.153,89.049,82000,65
 G-IRG,Lockhart River,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-12.787,143.305,,1619
-G-IRI,Iringa,,,gleam_basin,,W-AF,,TZ,TZA,,-7.669,35.752,112000.0,207
-G-IRJ,La Rioja,,,gleam_basin,,W-SA,,AR,ARG,,-29.382,-66.796,163000.0,3190
-G-IRK,Kirksville,,,gleam_basin,,W-NA,,US,USA,US-MO,40.093,-92.545,16000.0,2239
-G-IRM,Igrim,,,gleam_basin,,W-EU,,RU,RUS,,,,10000.0,1844
-G-IRP,Isiro,,,gleam_basin,,W-AF,,CD,COD,,2.828,27.588,157000.0,1337
+G-IRI,Iringa,,,gleam_basin,,W-AF,,TZ,TZA,,-7.669,35.752,112000,207
+G-IRJ,La Rioja,,,gleam_basin,,W-SA,,AR,ARG,,-29.382,-66.796,163000,3190
+G-IRK,Kirksville,,,gleam_basin,,W-NA,,US,USA,US-MO,40.093,-92.545,16000,2239
+G-IRM,Igrim,,,gleam_basin,,W-EU,,RU,RUS,,,,10000,1844
+G-IRP,Isiro,,,gleam_basin,,W-AF,,CD,COD,,2.828,27.588,157000,1337
 G-IRZ,Santa Isabel Rio Negro,,,gleam_basin,,W-SA,,BR,BRA,,-0.379,-64.992,,1982
-G-ISA,Mount Isa,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.664,139.489,33000.0,1605
-G-ISB,Islamabad,,,gleam_basin,,W-AS,,PK,PAK,,33.561,72.852,15300000.0,108
+G-ISA,Mount Isa,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.664,139.489,33000,1605
+G-ISB,Islamabad,,,gleam_basin,,W-AS,,PK,PAK,,33.561,72.852,15300000,108
 G-ISC,Isles of Scilly,,,gleam_basin,,W-EU,,GB,GBR,,49.913,-6.292,,777
-G-ISE,Isparta,,,gleam_basin,,W-AS,,TR,TUR,,37.855,30.368,172000.0,1754
+G-ISE,Isparta,,,gleam_basin,,W-AS,,TR,TUR,,37.855,30.368,172000,1754
 G-ISG,New Ishigaki,,,gleam_basin,,W-AS,,JP,JPN,,24.396,124.245,,3102
-G-ISN,Williston,,,gleam_basin,,W-NA,,US,USA,US-ND,48.178,-103.642,26000.0,2207
+G-ISN,Williston,,,gleam_basin,,W-NA,,US,USA,US-ND,48.178,-103.642,26000,2207
 G-ISP,Long Island Macarthur,,,gleam_basin,,W-NA,,US,USA,US-NY,40.795,-73.1,,2297
-G-IST,Istanbul,,,gleam_basin,,W-AS,,TR,TUR,,41.275,28.752,10061000.0,1758
+G-IST,Istanbul,,,gleam_basin,,W-AS,,TR,TUR,,41.275,28.752,10061000,1758
 G-ISU,Sulaymaniyah,,,gleam_basin,,W-AS,,IQ,IRQ,,35.562,45.317,,2914
-G-ITA,Itacoatiara,,,gleam_basin,,W-SA,,BR,BRA,,-3.127,-58.481,52000.0,2022
-G-ITB,Itaituba,,,gleam_basin,,W-SA,,BR,BRA,,-4.242,-56.001,92000.0,2021
-G-ITH,Ithaca,,,gleam_basin,,W-NA,,US,USA,US-NY,42.491,-76.458,55000.0,2454
-G-ITO,Hilo,,,gleam_basin,,W-NA,,US,USA,US-HI,19.721,-155.048,46000.0,2452
+G-ITA,Itacoatiara,,,gleam_basin,,W-SA,,BR,BRA,,-3.127,-58.481,52000,2022
+G-ITB,Itaituba,,,gleam_basin,,W-SA,,BR,BRA,,-4.242,-56.001,92000,2021
+G-ITH,Ithaca,,,gleam_basin,,W-NA,,US,USA,US-NY,42.491,-76.458,55000,2454
+G-ITO,Hilo,,,gleam_basin,,W-NA,,US,USA,US-HI,19.721,-155.048,46000,2452
 G-IUE,Niue,,,gleam_basin,,W-OC,,NU,NIU,,,,,715
-G-IVC,Invercargill,,,gleam_basin,,W-OC,,NZ,NZL,,-46.412,168.313,49000.0,3056
+G-IVC,Invercargill,,,gleam_basin,,W-OC,,NZ,NZL,,-46.412,168.313,49000,3056
 G-IVL,Ivalo,,,gleam_basin,,W-EU,,FI,FIN,,68.607,27.405,,513
-G-IWA,Ivanovo,,,gleam_basin,,W-EU,,RU,RUS,,56.939,40.941,421000.0,1877
-G-IWD,Ironwood,,,gleam_basin,,W-NA,,US,USA,US-MI,,,7000.0,2332
-G-IWJ,Masuda,,,gleam_basin,,W-AS,,JP,JPN,,34.676,131.79,49000.0,3134
-G-IWK,Iwakuni,,,gleam_basin,,W-AS,,JP,JPN,,34.144,132.236,104000.0,3133
-G-IXA,Agartala,,,gleam_basin,,W-AS,,IN,IND,,23.887,91.24,203000.0,1047
-G-IXB,Bagdogra,,,gleam_basin,,W-AS,,IN,IND,,26.681,88.329,17000.0,1044
-G-IXC,Chandigarh,,,gleam_basin,,W-AS,,IN,IND,,30.674,76.788,979000.0,1045
-G-IXD,Allahabad,,,gleam_basin,,W-AS,,IN,IND,,25.44,81.734,1201000.0,1049
-G-IXE,Mangalore,,,gleam_basin,,W-AS,,IN,IND,,12.961,74.89,777000.0,1050
-G-IXG,Belgaum,,,gleam_basin,,W-AS,,IN,IND,,15.859,74.618,609000.0,1048
-G-IXJ,Jammu,,,gleam_basin,,W-AS,,IN,IND,,32.689,74.837,4100000.0,1041
-G-IXL,Leh,,,gleam_basin,,W-AS,,IN,IND,,34.136,77.547,37000.0,1042
-G-IXM,Madurai,,,gleam_basin,,W-AS,,IN,IND,,9.835,78.093,910000.0,1043
-G-IXR,Ranchi,,,gleam_basin,,W-AS,,IN,IND,,23.314,85.322,1044000.0,1056
-G-IXS,Silchar,,,gleam_basin,,W-AS,,IN,IND,,24.913,92.979,152000.0,1051
-G-IXU,Aurangabad,,,gleam_basin,,W-AS,,IN,IND,,19.863,75.398,1113000.0,1052
-G-IXZ,Port Blair,,,gleam_basin,,W-AS,,IN,IND,,11.641,92.73,128000.0,1054
+G-IWA,Ivanovo,,,gleam_basin,,W-EU,,RU,RUS,,56.939,40.941,421000,1877
+G-IWD,Ironwood,,,gleam_basin,,W-NA,,US,USA,US-MI,,,7000,2332
+G-IWJ,Masuda,,,gleam_basin,,W-AS,,JP,JPN,,34.676,131.79,49000,3134
+G-IWK,Iwakuni,,,gleam_basin,,W-AS,,JP,JPN,,34.144,132.236,104000,3133
+G-IXA,Agartala,,,gleam_basin,,W-AS,,IN,IND,,23.887,91.24,203000,1047
+G-IXB,Bagdogra,,,gleam_basin,,W-AS,,IN,IND,,26.681,88.329,17000,1044
+G-IXC,Chandigarh,,,gleam_basin,,W-AS,,IN,IND,,30.674,76.788,979000,1045
+G-IXD,Allahabad,,,gleam_basin,,W-AS,,IN,IND,,25.44,81.734,1201000,1049
+G-IXE,Mangalore,,,gleam_basin,,W-AS,,IN,IND,,12.961,74.89,777000,1050
+G-IXG,Belgaum,,,gleam_basin,,W-AS,,IN,IND,,15.859,74.618,609000,1048
+G-IXJ,Jammu,,,gleam_basin,,W-AS,,IN,IND,,32.689,74.837,4100000,1041
+G-IXL,Leh,,,gleam_basin,,W-AS,,IN,IND,,34.136,77.547,37000,1042
+G-IXM,Madurai,,,gleam_basin,,W-AS,,IN,IND,,9.835,78.093,910000,1043
+G-IXR,Ranchi,,,gleam_basin,,W-AS,,IN,IND,,23.314,85.322,1044000,1056
+G-IXS,Silchar,,,gleam_basin,,W-AS,,IN,IND,,24.913,92.979,152000,1051
+G-IXU,Aurangabad,,,gleam_basin,,W-AS,,IN,IND,,19.863,75.398,1113000,1052
+G-IXZ,Port Blair,,,gleam_basin,,W-AS,,IN,IND,,11.641,92.73,128000,1054
 G-IYK,Inyokern,,,gleam_basin,,W-NA,,US,USA,US-CA,35.659,-117.83,,2495
-G-IZO,Izumo,,,gleam_basin,,W-AS,,JP,JPN,,35.414,132.89,89000.0,3150
+G-IZO,Izumo,,,gleam_basin,,W-AS,,JP,JPN,,35.414,132.89,89000,3150
 G-JAC,Jackson (US-WY),,,gleam_basin,,W-NA,,US,USA,US-WY,43.607,-110.738,,2079
-G-JAI,Jaipur,,,gleam_basin,,W-AS,,IN,IND,,26.824,75.812,2917000.0,1057
-G-JAL,Jalapa,,,gleam_basin,,W-NA,,MX,MEX,,19.475,-96.798,46000.0,1002
+G-JAI,Jaipur,,,gleam_basin,,W-AS,,IN,IND,,26.824,75.812,2917000,1057
+G-JAL,Jalapa,,,gleam_basin,,W-NA,,MX,MEX,,19.475,-96.798,46000,1002
 G-JAN,Jackson (US-MS),,,gleam_basin,,W-NA,,US,USA,US-MS,32.311,-90.076,,2077
-G-JAU,Jauja,,,gleam_basin,,W-SA,,PE,PER,,-11.783,-75.473,21000.0,1212
-G-JAV,Ilulissat,,,gleam_basin,,W-NA,,GL,GRL,,69.243,-51.057,4000.0,956
+G-JAU,Jauja,,,gleam_basin,,W-SA,,PE,PER,,-11.783,-75.473,21000,1212
+G-JAV,Ilulissat,,,gleam_basin,,W-NA,,GL,GRL,,69.243,-51.057,4000,956
 G-JAX,Jacksonville (US-FL),,,gleam_basin,,W-NA,,US,USA,US-FL,30.494,-81.688,,2076
-G-JBR,Jonesboro,,,gleam_basin,,W-NA,,US,USA,US-AR,35.832,-90.646,74000.0,2072
-G-JCB,Joacaba,,,gleam_basin,,W-SA,,BR,BRA,,-27.171,-51.553,39000.0,2036
+G-JBR,Jonesboro,,,gleam_basin,,W-NA,,US,USA,US-AR,35.832,-90.646,74000,2072
+G-JCB,Joacaba,,,gleam_basin,,W-SA,,BR,BRA,,-27.171,-51.553,39000,2036
 G-JCK,Julia Creek,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-20.668,141.723,,1679
-G-JCU,Ceuta,,,gleam_basin,,W-EU,,ES,ESP,,,,79000.0,2910
-G-JDF,Juiz de Fora,,,gleam_basin,,W-SA,,BR,BRA,,-21.792,-43.387,470000.0,2024
-G-JDH,Jodhpur,,,gleam_basin,,W-AS,,IN,IND,,26.251,73.049,995000.0,1098
-G-JDO,Juazeiro do Norte,,,gleam_basin,,W-SA,,BR,BRA,,-7.219,-39.27,225000.0,2008
-G-JDR,Sao Joao del Rei,,,gleam_basin,,W-SA,,BR,BRA,,,,79000.0,1943
-G-JDZ,Jingdezhen,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,29.339,117.176,457000.0,435
-G-JED,Jeddah,,,gleam_basin,,W-AS,,SA,SAU,,21.68,39.157,3012000.0,262
+G-JCU,Ceuta,,,gleam_basin,,W-EU,,ES,ESP,,,,79000,2910
+G-JDF,Juiz de Fora,,,gleam_basin,,W-SA,,BR,BRA,,-21.792,-43.387,470000,2024
+G-JDH,Jodhpur,,,gleam_basin,,W-AS,,IN,IND,,26.251,73.049,995000,1098
+G-JDO,Juazeiro do Norte,,,gleam_basin,,W-SA,,BR,BRA,,-7.219,-39.27,225000,2008
+G-JDR,Sao Joao del Rei,,,gleam_basin,,W-SA,,BR,BRA,,,,79000,1943
+G-JDZ,Jingdezhen,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,29.339,117.176,457000,435
+G-JED,Jeddah,,,gleam_basin,,W-AS,,SA,SAU,,21.68,39.157,3012000,262
 G-JER,Jersey,,,gleam_basin,,W-EU,,JE,JEY,,,,,1557
-G-JFK,New York,,,gleam_basin,,W-NA,,US,USA,US-NY,40.64,-73.779,8398000.0,2518
-G-JFR,Paamiut,,,gleam_basin,,W-NA,,GL,GRL,,61.992,-49.662,2000.0,945
-G-JGA,Jamnagar,,,gleam_basin,,W-AS,,IN,IND,,22.465,70.013,492000.0,1092
-G-JGD,Jiagedaqi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,50.371,124.118,136000.0,426
-G-JGN,Jiayuguan,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,39.857,98.341,148000.0,425
-G-JGS,Ji'an,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,26.857,114.737,520000.0,427
-G-JHB,Johor Bahru,,,gleam_basin,,W-AS,,MY,MYS,,1.641,103.67,875000.0,179
-G-JHG,Jinghong,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,21.974,100.76,62000.0,399
-G-JHS,Sisimiut,,,gleam_basin,,W-NA,,GL,GRL,,66.951,-53.729,5000.0,942
+G-JFK,New York,,,gleam_basin,,W-NA,,US,USA,US-NY,40.64,-73.779,8398000,2518
+G-JFR,Paamiut,,,gleam_basin,,W-NA,,GL,GRL,,61.992,-49.662,2000,945
+G-JGA,Jamnagar,,,gleam_basin,,W-AS,,IN,IND,,22.465,70.013,492000,1092
+G-JGD,Jiagedaqi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,50.371,124.118,136000,426
+G-JGN,Jiayuguan,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,39.857,98.341,148000,425
+G-JGS,Ji'an,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,26.857,114.737,520000,427
+G-JHB,Johor Bahru,,,gleam_basin,,W-AS,,MY,MYS,,1.641,103.67,875000,179
+G-JHG,Jinghong,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,21.974,100.76,62000,399
+G-JHS,Sisimiut,,,gleam_basin,,W-NA,,GL,GRL,,66.951,-53.729,5000,942
 G-JHW,Jamestown (US-NY),,Jamestown,gleam_basin,,W-NA,,US,USA,US-NY,42.153,-79.258,,2293
 G-JIB,Djibouti,,,gleam_basin,,W-AF,,DJ,DJI,,,,,494
-G-JIC,Jinchang,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,38.542,102.348,144000.0,392
-G-JIJ,Jijiga,,,gleam_basin,,W-AF,,ET,ETH,,9.332,42.912,57000.0,231
-G-JIM,Jimma,,,gleam_basin,,W-AF,,ET,ETH,,7.666,36.817,128000.0,230
-G-JIQ,Qianjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,29.513,108.831,179000.0,393
-G-JIU,Jiujiang,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,29.477,115.801,546000.0,318
-G-JJM,Meru,,,gleam_basin,,W-AF,,KE,KEN,,0.165,38.195,47000.0,1727
-G-JJN,Quanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,24.796,118.59,1463000.0,389
-G-JKG,Jonkoping,,,gleam_basin,,W-EU,,SE,SWE,,57.758,14.069,90000.0,2549
-G-JKH,Chios,,,gleam_basin,,W-EU,,GR,GRC,,38.343,26.141,27000.0,916
-G-JKR,Janakpur,,,gleam_basin,,W-AS,,NP,NPL,,26.709,85.922,94000.0,556
-G-JLN,Joplin,,,gleam_basin,,W-NA,,US,USA,US-MO,37.152,-94.498,86000.0,2119
-G-JLR,Jabalpur,,,gleam_basin,,W-AS,,IN,IND,,23.178,80.052,1285000.0,1061
+G-JIC,Jinchang,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,38.542,102.348,144000,392
+G-JIJ,Jijiga,,,gleam_basin,,W-AF,,ET,ETH,,9.332,42.912,57000,231
+G-JIM,Jimma,,,gleam_basin,,W-AF,,ET,ETH,,7.666,36.817,128000,230
+G-JIQ,Qianjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,29.513,108.831,179000,393
+G-JIU,Jiujiang,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,29.477,115.801,546000,318
+G-JJM,Meru,,,gleam_basin,,W-AF,,KE,KEN,,0.165,38.195,47000,1727
+G-JJN,Quanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,24.796,118.59,1463000,389
+G-JKG,Jonkoping,,,gleam_basin,,W-EU,,SE,SWE,,57.758,14.069,90000,2549
+G-JKH,Chios,,,gleam_basin,,W-EU,,GR,GRC,,38.343,26.141,27000,916
+G-JKR,Janakpur,,,gleam_basin,,W-AS,,NP,NPL,,26.709,85.922,94000,556
+G-JLN,Joplin,,,gleam_basin,,W-NA,,US,USA,US-MO,37.152,-94.498,86000,2119
+G-JLR,Jabalpur,,,gleam_basin,,W-AS,,IN,IND,,23.178,80.052,1285000,1061
 G-JMK,Mykonos,,,gleam_basin,,W-EU,,GR,GRC,,37.435,25.348,,932
 G-JMO,Jomsom,,,gleam_basin,,W-AS,,NP,NPL,,28.78,83.723,,554
 G-JMS,Jamestown (US-ND),,Jamestown,gleam_basin,,W-NA,,US,USA,US-ND,46.93,-98.678,,2137
-G-JMU,Jiamusi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,46.843,130.465,1020000.0,336
-G-JNB,Johannesburg,,,gleam_basin,,W-AF,,ZA,ZAF,,-26.139,28.246,3435000.0,626
-G-JNG,Jining,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,35.293,116.347,1186000.0,312
-G-JNU,Juneau,,,gleam_basin,,W-NA,,US,USA,US-AK,58.355,-134.576,25000.0,2057
-G-JNZ,Jinzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.101,121.062,956000.0,311
-G-JOE,Joensuu,,,gleam_basin,,W-EU,,FI,FIN,,62.663,29.608,53000.0,496
-G-JOG,Yogyakarta,,,gleam_basin,,W-AS,,ID,IDN,,-7.788,110.432,637000.0,1308
-G-JOI,Joinville,,,gleam_basin,,W-SA,,BR,BRA,,-26.225,-48.797,461000.0,1941
-G-JOK,Yoshkar-Ola,,,gleam_basin,,W-EU,,RU,RUS,,56.701,47.905,324000.0,1804
-G-JOL,Jolo,,,gleam_basin,,W-AS,,PH,PHL,,6.054,121.011,101000.0,589
-G-JOS,Jos,,,gleam_basin,,W-AF,,NG,NGA,,9.64,8.869,817000.0,1420
-G-JPA,Joao Pessoa,,,gleam_basin,,W-SA,,BR,BRA,,-7.146,-34.949,956000.0,2026
-G-JPR,Ji-Parana,,,gleam_basin,,W-SA,,BR,BRA,,-10.871,-61.847,65000.0,2028
-G-JRH,Jorhat,,,gleam_basin,,W-AS,,IN,IND,,26.732,94.175,69000.0,1102
+G-JMU,Jiamusi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,46.843,130.465,1020000,336
+G-JNB,Johannesburg,,,gleam_basin,,W-AF,,ZA,ZAF,,-26.139,28.246,3435000,626
+G-JNG,Jining,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,35.293,116.347,1186000,312
+G-JNU,Juneau,,,gleam_basin,,W-NA,,US,USA,US-AK,58.355,-134.576,25000,2057
+G-JNZ,Jinzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.101,121.062,956000,311
+G-JOE,Joensuu,,,gleam_basin,,W-EU,,FI,FIN,,62.663,29.608,53000,496
+G-JOG,Yogyakarta,,,gleam_basin,,W-AS,,ID,IDN,,-7.788,110.432,637000,1308
+G-JOI,Joinville,,,gleam_basin,,W-SA,,BR,BRA,,-26.225,-48.797,461000,1941
+G-JOK,Yoshkar-Ola,,,gleam_basin,,W-EU,,RU,RUS,,56.701,47.905,324000,1804
+G-JOL,Jolo,,,gleam_basin,,W-AS,,PH,PHL,,6.054,121.011,101000,589
+G-JOS,Jos,,,gleam_basin,,W-AF,,NG,NGA,,9.64,8.869,817000,1420
+G-JPA,Joao Pessoa,,,gleam_basin,,W-SA,,BR,BRA,,-7.146,-34.949,956000,2026
+G-JPR,Ji-Parana,,,gleam_basin,,W-SA,,BR,BRA,,-10.871,-61.847,65000,2028
+G-JRH,Jorhat,,,gleam_basin,,W-AS,,IN,IND,,26.732,94.175,69000,1102
 G-JRO,Kilimanjaro,,,gleam_basin,,W-AF,,TZ,TZA,,-3.429,37.075,,205
-G-JSH,Siteia,,,gleam_basin,,W-EU,,GR,GRC,,35.216,26.101,9000.0,930
+G-JSH,Siteia,,,gleam_basin,,W-EU,,GR,GRC,,35.216,26.101,9000,930
 G-JSI,Skiathos,,,gleam_basin,,W-EU,,GR,GRC,,39.177,23.504,,931
-G-JSR,Jessore,,,gleam_basin,,W-AS,,BD,BGD,,23.184,89.161,244000.0,67
+G-JSR,Jessore,,,gleam_basin,,W-AS,,BD,BGD,,23.184,89.161,244000,67
 G-JSU,Maniitsoq,,,gleam_basin,,W-NA,,GL,GRL,,65.412,-52.939,,949
-G-JTC,Bauru,,,gleam_basin,,W-SA,,BR,BRA,,-22.167,-49.05,335000.0,1999
+G-JTC,Bauru,,,gleam_basin,,W-SA,,BR,BRA,,-22.167,-49.05,335000,1999
 G-JTR,Thira,,,gleam_basin,,W-EU,,GR,GRC,,36.399,25.479,,924
 G-JTY,Astypalaia Island,,,gleam_basin,,W-EU,,GR,GRC,,36.58,26.376,,923
-G-JUB,Juba,,,gleam_basin,,W-AF,,SS,SSD,,4.872,31.601,112000.0,2538
-G-JUH,Chizhou,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,30.74,117.686,148000.0,422
+G-JUB,Juba,,,gleam_basin,,W-AF,,SS,SSD,,4.872,31.601,112000,2538
+G-JUH,Chizhou,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,30.74,117.686,148000,422
 G-JUJ,Jujuy,,,gleam_basin,,W-SA,,AR,ARG,,-24.393,-65.098,,3203
-G-JUL,Juliaca,,,gleam_basin,,W-SA,,PE,PER,,-15.467,-70.158,246000.0,1224
-G-JUM,Jumla,,,gleam_basin,,W-AS,,NP,NPL,,29.274,82.193,9000.0,563
-G-JUV,Upernavik,,,gleam_basin,,W-NA,,GL,GRL,,72.79,-56.131,1000.0,951
-G-JUZ,Quzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,28.966,118.899,370000.0,423
-G-JXA,Jixi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,45.293,131.193,965000.0,357
-G-JYV,Jyvaskyla,,,gleam_basin,,W-EU,,FI,FIN,,62.4,25.678,98000.0,505
+G-JUL,Juliaca,,,gleam_basin,,W-SA,,PE,PER,,-15.467,-70.158,246000,1224
+G-JUM,Jumla,,,gleam_basin,,W-AS,,NP,NPL,,29.274,82.193,9000,563
+G-JUV,Upernavik,,,gleam_basin,,W-NA,,GL,GRL,,72.79,-56.131,1000,951
+G-JUZ,Quzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,28.966,118.899,370000,423
+G-JXA,Jixi,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,45.293,131.193,965000,357
+G-JYV,Jyvaskyla,,,gleam_basin,,W-EU,,FI,FIN,,62.4,25.678,98000,505
 G-JZH,Jiuzhaigou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,32.853,103.682,,333
-G-KAA,Kasama,,,gleam_basin,,W-AF,,ZM,ZMB,,-10.217,31.133,200000.0,1548
+G-KAA,Kasama,,,gleam_basin,,W-AF,,ZM,ZMB,,-10.217,31.133,200000,1548
 G-KAC,Kamishly,,,gleam_basin,,W-AS,,SY,SYR,,37.021,41.191,,650
-G-KAD,Kaduna,,,gleam_basin,,W-AF,,NG,NGA,,10.696,7.32,1442000.0,1412
-G-KAE,Kake,,,gleam_basin,,W-NA,,US,USA,US-KS,,,560.0,2198
-G-KAJ,Kajaani,,,gleam_basin,,W-EU,,FI,FIN,,64.285,27.692,35000.0,502
+G-KAD,Kaduna,,,gleam_basin,,W-AF,,NG,NGA,,10.696,7.32,1442000,1412
+G-KAE,Kake,,,gleam_basin,,W-NA,,US,USA,US-KS,,,560,2198
+G-KAJ,Kajaani,,,gleam_basin,,W-EU,,FI,FIN,,64.285,27.692,35000,502
 G-KAL,Kaltag,,,gleam_basin,,W-NA,,US,USA,US-AK,64.319,-158.741,,2199
-G-KAN,Kano,,,gleam_basin,,W-AF,,NG,NGA,,12.048,8.525,3140000.0,1413
-G-KAO,Kuusamo,,,gleam_basin,,W-EU,,FI,FIN,,65.988,29.239,17000.0,503
-G-KAS,Karasburg,,,gleam_basin,,W-AF,,LY,LBY,,,,6000.0,158
-G-KAT,Kaitaia,,,gleam_basin,,W-OC,,NZ,NZL,,-35.07,173.285,5000.0,3047
+G-KAN,Kano,,,gleam_basin,,W-AF,,NG,NGA,,12.048,8.525,3140000,1413
+G-KAO,Kuusamo,,,gleam_basin,,W-EU,,FI,FIN,,65.988,29.239,17000,503
+G-KAS,Karasburg,,,gleam_basin,,W-AF,,LY,LBY,,,,6000,158
+G-KAT,Kaitaia,,,gleam_basin,,W-OC,,NZ,NZL,,-35.07,173.285,5000,3047
 G-KAW,Kawthaung,,,gleam_basin,,W-AS,,MM,MMR,,10.049,98.538,,874
-G-KAX,Kalbarri,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-27.693,114.259,2000.0,1604
+G-KAX,Kalbarri,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-27.693,114.259,2000,1604
 G-KAZ,Kau,,,gleam_basin,,W-AS,,ID,IDN,,1.185,127.896,,1259
-G-KBL,Kabul,,,gleam_basin,,W-AS,,AF,AFG,,34.566,69.212,3277000.0,898
-G-KBP,Kiev,,,gleam_basin,,W-EU,,UA,UKR,,50.345,30.895,2804000.0,2796
-G-KBR,Kota Bharu,,,gleam_basin,,W-AS,,MY,MYS,,6.167,102.293,506000.0,178
+G-KBL,Kabul,,,gleam_basin,,W-AS,,AF,AFG,,34.566,69.212,3277000,898
+G-KBP,Kiev,,,gleam_basin,,W-EU,,UA,UKR,,50.345,30.895,2804000,2796
+G-KBR,Kota Bharu,,,gleam_basin,,W-AS,,MY,MYS,,6.167,102.293,506000,178
 G-KBU,Kotabaru,,,gleam_basin,,W-AS,,ID,IDN,,,,,1270
-G-KBV,Krabi,,,gleam_basin,,W-AS,,TH,THA,,8.099,98.986,31000.0,523
-G-KCA,Kuqa,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.678,82.873,111000.0,385
-G-KCF,Kadanwari,,,gleam_basin,,W-AS,,PK,PAK,,27.167,69.317,3700000.0,120
-G-KCH,Kuching,,,gleam_basin,,W-AS,,MY,MYS,,1.485,110.347,570000.0,177
-G-KCK,Kirensk,,,gleam_basin,,W-EU,,RU,RUS,,57.773,108.064,13000.0,1899
-G-KCM,Kahramanmaras,,,gleam_basin,,W-AS,,TR,TUR,,37.539,36.954,376000.0,1763
-G-KCO,Kocaeli,,,gleam_basin,,W-AS,,TR,TUR,,40.735,30.083,467000.0,1782
-G-KCQ,Chignik,,,gleam_basin,,W-NA,,US,USA,US-MO,,,90.0,2535
+G-KBV,Krabi,,,gleam_basin,,W-AS,,TH,THA,,8.099,98.986,31000,523
+G-KCA,Kuqa,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.678,82.873,111000,385
+G-KCF,Kadanwari,,,gleam_basin,,W-AS,,PK,PAK,,27.167,69.317,3700000,120
+G-KCH,Kuching,,,gleam_basin,,W-AS,,MY,MYS,,1.485,110.347,570000,177
+G-KCK,Kirensk,,,gleam_basin,,W-EU,,RU,RUS,,57.773,108.064,13000,1899
+G-KCM,Kahramanmaras,,,gleam_basin,,W-AS,,TR,TUR,,37.539,36.954,376000,1763
+G-KCO,Kocaeli,,,gleam_basin,,W-AS,,TR,TUR,,40.735,30.083,467000,1782
+G-KCQ,Chignik,,,gleam_basin,,W-NA,,US,USA,US-MO,,,90,2535
 G-KCZ,Kochi (JP),,,gleam_basin,,W-AS,,JP,JPN,,33.546,133.669,,3123
-G-KDH,Kandahar,,,gleam_basin,,W-AS,,AF,AFG,,31.506,65.848,716000.0,892
-G-KDI,Kendari,,,gleam_basin,,W-AS,,ID,IDN,,-4.082,122.418,165000.0,1280
+G-KDH,Kandahar,,,gleam_basin,,W-AS,,AF,AFG,,31.506,65.848,716000,892
+G-KDI,Kendari,,,gleam_basin,,W-AS,,ID,IDN,,-4.082,122.418,165000,1280
 G-KDL,Kardla,,,gleam_basin,,W-EU,,EE,EST,,58.991,22.831,,2868
 G-KDM,Kaadedhdhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,0.488,72.997,,1483
 G-KDO,Kadhdhoo Island,,,gleam_basin,,W-AS,,MV,MDV,,1.859,73.522,,1484
-G-KDU,Skardu,,,gleam_basin,,W-AS,,PK,PAK,,35.335,75.536,1900000.0,128
+G-KDU,Skardu,,,gleam_basin,,W-AS,,PK,PAK,,35.335,75.536,1900000,128
 G-KDV,Kadavu Island,,,gleam_basin,,W-OC,,FJ,FJI,,-19.058,178.157,,1189
-G-KDZ,Kandy,,,gleam_basin,,W-AS,,LK,LKA,,,,112000.0,756
-G-KEF,Reykjavik,,,gleam_basin,,W-EU,,IS,ISL,,63.985,-22.606,166000.0,1350
-G-KEJ,Kemerovo,,,gleam_basin,,W-EU,,RU,RUS,,55.27,86.107,477000.0,1873
-G-KEM,Kemi,,,gleam_basin,,W-EU,,FI,FIN,,65.779,24.582,23000.0,510
-G-KEP,Nepalganj,,,gleam_basin,,W-AS,,NP,NPL,,28.104,81.667,64000.0,561
-G-KER,Kerman,,,gleam_basin,,W-AS,,IR,IRN,,30.274,56.951,578000.0,2951
+G-KDZ,Kandy,,,gleam_basin,,W-AS,,LK,LKA,,,,112000,756
+G-KEF,Reykjavik,,,gleam_basin,,W-EU,,IS,ISL,,63.985,-22.606,166000,1350
+G-KEJ,Kemerovo,,,gleam_basin,,W-EU,,RU,RUS,,55.27,86.107,477000,1873
+G-KEM,Kemi,,,gleam_basin,,W-EU,,FI,FIN,,65.779,24.582,23000,510
+G-KEP,Nepalganj,,,gleam_basin,,W-AS,,NP,NPL,,28.104,81.667,64000,561
+G-KER,Kerman,,,gleam_basin,,W-AS,,IR,IRN,,30.274,56.951,578000,2951
 G-KET,Kengtung,,,gleam_basin,,W-AS,,MM,MMR,,21.302,99.636,,879
 G-KFP,False Pass,,,gleam_basin,,W-NA,,US,USA,US-AK,54.847,-163.41,,2412
-G-KFS,Kastamonu,,,gleam_basin,,W-AS,,TR,TUR,,41.314,33.796,70000.0,1778
-G-KGA,Kananga,,,gleam_basin,,W-AF,,CD,COD,,-5.9,22.469,765000.0,1344
+G-KFS,Kastamonu,,,gleam_basin,,W-AS,,TR,TUR,,41.314,33.796,70000,1778
+G-KGA,Kananga,,,gleam_basin,,W-AF,,CD,COD,,-5.9,22.469,765000,1344
 G-KGC,Kingscote,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-35.714,137.521,,1649
-G-KGD,Kaliningrad,,,gleam_basin,,W-EU,,RU,RUS,,54.89,20.593,435000.0,1895
+G-KGD,Kaliningrad,,,gleam_basin,,W-EU,,RU,RUS,,54.89,20.593,435000,1895
 G-KGE,Kagau Island,,,gleam_basin,,W-OC,,SB,SLB,,-7.33,157.585,,3032
-G-KGF,Karaganda,,,gleam_basin,,W-AS,,KZ,KAZ,,49.671,73.334,466000.0,667
+G-KGF,Karaganda,,,gleam_basin,,W-AS,,KZ,KAZ,,49.671,73.334,466000,667
 G-KGI,Kalgoorlie-Boulder,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-30.789,121.462,,1650
-G-KGL,Kigali,,,gleam_basin,,W-AF,,RW,RWA,,-1.969,30.14,860000.0,1543
-G-KGP,Kogalym,,,gleam_basin,,W-EU,,RU,RUS,,62.19,74.534,58000.0,1893
-G-KGS,Kos,,,gleam_basin,,W-EU,,GR,GRC,,36.793,27.092,19000.0,939
-G-KGT,Kangding,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.157,101.735,100000.0,444
-G-KHD,Khorramabad,,,gleam_basin,,W-AS,,IR,IRN,,33.435,48.283,375000.0,2970
-G-KHE,Kherson,,,gleam_basin,,W-EU,,UA,UKR,,46.676,32.506,320000.0,2790
+G-KGL,Kigali,,,gleam_basin,,W-AF,,RW,RWA,,-1.969,30.14,860000,1543
+G-KGP,Kogalym,,,gleam_basin,,W-EU,,RU,RUS,,62.19,74.534,58000,1893
+G-KGS,Kos,,,gleam_basin,,W-EU,,GR,GRC,,36.793,27.092,19000,939
+G-KGT,Kangding,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.157,101.735,100000,444
+G-KHD,Khorramabad,,,gleam_basin,,W-AS,,IR,IRN,,33.435,48.283,375000,2970
+G-KHE,Kherson,,,gleam_basin,,W-EU,,UA,UKR,,46.676,32.506,320000,2790
 G-KHG,Kashi,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,39.543,76.02,,474
-G-KHH,Kaohsiung,,,gleam_basin,,W-AS,,TW,TWN,,22.577,120.35,2769000.0,2828
-G-KHI,Karachi,,,gleam_basin,,W-AS,,PK,PAK,,24.907,67.161,16800000.0,105
-G-KHN,Nanchang,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,28.865,115.9,2350000.0,472
-G-KHS,Khasab,,,gleam_basin,,W-AS,,OM,OMN,,26.171,56.241,18000.0,1786
-G-KHV,Khabarovsk,,,gleam_basin,,W-EU,,RU,RUS,,48.528,135.188,579000.0,1882
-G-KHY,Khoy,,,gleam_basin,,W-AS,,IR,IRN,,38.428,44.974,201000.0,2969
-G-KID,Kristianstad,,,gleam_basin,,W-EU,,SE,SWE,,55.922,14.085,32000.0,2548
+G-KHH,Kaohsiung,,,gleam_basin,,W-AS,,TW,TWN,,22.577,120.35,2769000,2828
+G-KHI,Karachi,,,gleam_basin,,W-AS,,PK,PAK,,24.907,67.161,16800000,105
+G-KHN,Nanchang,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,28.865,115.9,2350000,472
+G-KHS,Khasab,,,gleam_basin,,W-AS,,OM,OMN,,26.171,56.241,18000,1786
+G-KHV,Khabarovsk,,,gleam_basin,,W-EU,,RU,RUS,,48.528,135.188,579000,1882
+G-KHY,Khoy,,,gleam_basin,,W-AS,,IR,IRN,,38.428,44.974,201000,2969
+G-KID,Kristianstad,,,gleam_basin,,W-EU,,SE,SWE,,55.922,14.085,32000,2548
 G-KIH,Kish Island,,,gleam_basin,,W-AS,,IR,IRN,,26.526,53.98,,2965
-G-KIJ,Niigata,,,gleam_basin,,W-AS,,JP,JPN,,37.956,139.121,570000.0,3152
-G-KIM,Kimberley,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.803,24.765,165000.0,640
+G-KIJ,Niigata,,,gleam_basin,,W-AS,,JP,JPN,,37.956,139.121,570000,3152
+G-KIM,Kimberley,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.803,24.765,165000,640
 G-KIN,Kingston (JM),,,gleam_basin,,W-NA,,JM,JAM,,17.936,-76.787,,492
 G-KIR,Kerry,,,gleam_basin,,W-EU,,IE,IRL,,52.181,-9.524,,2926
-G-KIS,Kisumu,,,gleam_basin,,W-AF,,KE,KEN,,-0.086,34.729,396000.0,1736
+G-KIS,Kisumu,,,gleam_basin,,W-AF,,KE,KEN,,-0.086,34.729,396000,1736
 G-KIT,Kythira,,,gleam_basin,,W-EU,,GR,GRC,,36.274,23.017,,934
-G-KIV,Chisinau,,,gleam_basin,,W-EU,,MD,MDA,,46.928,28.931,688000.0,1441
-G-KIX,Osaka,,,gleam_basin,,W-AS,,JP,JPN,,34.427,135.244,11294000.0,3151
-G-KJA,Krasnoyarsk,,,gleam_basin,,W-EU,,RU,RUS,,56.173,92.493,925000.0,1874
+G-KIV,Chisinau,,,gleam_basin,,W-EU,,MD,MDA,,46.928,28.931,688000,1441
+G-KIX,Osaka,,,gleam_basin,,W-AS,,JP,JPN,,34.427,135.244,11294000,3151
+G-KJA,Krasnoyarsk,,,gleam_basin,,W-EU,,RU,RUS,,56.173,92.493,925000,1874
 G-KJI,Burqin,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,48.222,86.996,,324
 G-KKA,Koyuk,,,gleam_basin,,W-NA,,US,USA,US-AK,64.939,-161.154,,2065
-G-KKC,Khon Kaen,,,gleam_basin,,W-AS,,TH,THA,,16.467,102.784,251000.0,525
+G-KKC,Khon Kaen,,,gleam_basin,,W-AS,,TH,THA,,16.467,102.784,251000,525
 G-KKD,Kokoda,,,gleam_basin,,W-OC,,PG,PNG,,,,,2977
-G-KKE,Kerikeri,,,gleam_basin,,W-OC,,NZ,NZL,,-35.263,173.912,6000.0,3039
-G-KKJ,Kitakyushu,,,gleam_basin,,W-AS,,JP,JPN,,33.846,131.035,998000.0,3139
-G-KKN,Kirkenes,,,gleam_basin,,W-EU,,NO,NOR,,69.726,29.891,3000.0,1144
+G-KKE,Kerikeri,,,gleam_basin,,W-OC,,NZ,NZL,,-35.263,173.912,6000,3039
+G-KKJ,Kitakyushu,,,gleam_basin,,W-AS,,JP,JPN,,33.846,131.035,998000,3139
+G-KKN,Kirkenes,,,gleam_basin,,W-EU,,NO,NOR,,69.726,29.891,3000,1144
 G-KKR,Kaukura,,,gleam_basin,,W-OC,,PF,PYF,,-15.663,-146.885,,680
-G-KLM,Kalaleh,,,gleam_basin,,W-AS,,IR,IRN,,37.383,55.452,34000.0,2936
+G-KLM,Kalaleh,,,gleam_basin,,W-AS,,IR,IRN,,37.383,55.452,34000,2936
 G-KLO,Kalibo,,,gleam_basin,,W-AS,,PH,PHL,,11.679,122.376,,602
-G-KLR,Kalmar,,,gleam_basin,,W-EU,,SE,SWE,,56.686,16.288,35000.0,2545
-G-KLU,Klagenfurt,,,gleam_basin,,W-EU,,AT,AUT,,46.643,14.338,91000.0,1696
-G-KLV,Karlovy Vary,,,gleam_basin,,W-EU,,CZ,CZE,,50.203,12.915,52000.0,1177
-G-KLX,Kalamata,,,gleam_basin,,W-EU,,GR,GRC,,37.068,22.025,72000.0,913
-G-KMA,Kerema,,,gleam_basin,,W-OC,,PG,PNG,,-7.964,145.771,6000.0,2982
-G-KME,Cyangugu,,,gleam_basin,,W-AF,,RW,RWA,,-2.462,28.908,20000.0,1544
-G-KMG,Kunming,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.102,102.929,2931000.0,458
-G-KMI,Miyazaki,,,gleam_basin,,W-AS,,JP,JPN,,31.877,131.449,324000.0,3107
-G-KMJ,Kumamoto,,,gleam_basin,,W-AS,,JP,JPN,,32.837,130.855,718000.0,3153
-G-KMQ,Komatsu,,,gleam_basin,,W-AS,,JP,JPN,,36.395,136.407,109000.0,3108
-G-KMS,Kumasi,,,gleam_basin,,W-AF,,GH,GHA,,6.715,-1.591,1646000.0,101
+G-KLR,Kalmar,,,gleam_basin,,W-EU,,SE,SWE,,56.686,16.288,35000,2545
+G-KLU,Klagenfurt,,,gleam_basin,,W-EU,,AT,AUT,,46.643,14.338,91000,1696
+G-KLV,Karlovy Vary,,,gleam_basin,,W-EU,,CZ,CZE,,50.203,12.915,52000,1177
+G-KLX,Kalamata,,,gleam_basin,,W-EU,,GR,GRC,,37.068,22.025,72000,913
+G-KMA,Kerema,,,gleam_basin,,W-OC,,PG,PNG,,-7.964,145.771,6000,2982
+G-KME,Cyangugu,,,gleam_basin,,W-AF,,RW,RWA,,-2.462,28.908,20000,1544
+G-KMG,Kunming,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,25.102,102.929,2931000,458
+G-KMI,Miyazaki,,,gleam_basin,,W-AS,,JP,JPN,,31.877,131.449,324000,3107
+G-KMJ,Kumamoto,,,gleam_basin,,W-AS,,JP,JPN,,32.837,130.855,718000,3153
+G-KMQ,Komatsu,,,gleam_basin,,W-AS,,JP,JPN,,36.395,136.407,109000,3108
+G-KMS,Kumasi,,,gleam_basin,,W-AF,,GH,GHA,,6.715,-1.591,1646000,101
 G-KMU,Kisimayu,,,gleam_basin,,W-AF,,SO,SOM,,-0.377,42.459,,2835
 G-KMV,Kalemyo,,,gleam_basin,,W-AS,,MM,MMR,,23.189,94.051,,870
-G-KND,Kindu,,,gleam_basin,,W-AF,,CD,COD,,-2.919,25.915,263000.0,1333
+G-KND,Kindu,,,gleam_basin,,W-AF,,CD,COD,,-2.919,25.915,263000,1333
 G-KNG,Utarom,,,gleam_basin,,W-AS,,ID,IDN,,-3.645,133.696,,1258
 G-KNH,Kinmen,,,gleam_basin,,W-AS,,TW,TWN,,24.428,118.359,,2823
 G-KNQ,Kone,,,gleam_basin,,W-OC,,NC,NCL,,-21.054,164.837,,3170
 G-KNS,King Island,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-39.877,143.878,,1602
-G-KNU,Kanpur,,,gleam_basin,,W-AS,,IN,IND,,26.404,80.41,2823000.0,1067
-G-KNX,Kununurra,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-15.778,128.708,6000.0,1611
+G-KNU,Kanpur,,,gleam_basin,,W-AS,,IN,IND,,26.404,80.41,2823000,1067
+G-KNX,Kununurra,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-15.778,128.708,6000,1611
 G-KOA,Kona,,,gleam_basin,,W-NA,,US,USA,US-HI,19.739,-156.046,,2445
 G-KOC,Koumac,,,gleam_basin,,W-OC,,NC,NCL,,-20.546,164.256,,3168
-G-KOE,Kupang,,,gleam_basin,,W-AS,,ID,IDN,,-10.172,123.671,282000.0,1296
-G-KOJ,Kagoshima,,,gleam_basin,,W-AS,,JP,JPN,,31.803,130.719,555000.0,3115
-G-KOK,Kokkola,,,gleam_basin,,W-EU,,FI,FIN,,63.721,23.143,47000.0,501
-G-KOO,Kongolo,,,gleam_basin,,W-AF,,CD,COD,,-5.394,26.99,105000.0,1332
-G-KOP,Nakhon Phanom,,,gleam_basin,,W-AS,,TH,THA,,17.384,104.643,55000.0,541
-G-KOS,Sihanoukville,,,gleam_basin,,W-AS,,KH,KHM,,10.58,103.637,157000.0,223
+G-KOE,Kupang,,,gleam_basin,,W-AS,,ID,IDN,,-10.172,123.671,282000,1296
+G-KOJ,Kagoshima,,,gleam_basin,,W-AS,,JP,JPN,,31.803,130.719,555000,3115
+G-KOK,Kokkola,,,gleam_basin,,W-EU,,FI,FIN,,63.721,23.143,47000,501
+G-KOO,Kongolo,,,gleam_basin,,W-AF,,CD,COD,,-5.394,26.99,105000,1332
+G-KOP,Nakhon Phanom,,,gleam_basin,,W-AS,,TH,THA,,17.384,104.643,55000,541
+G-KOS,Sihanoukville,,,gleam_basin,,W-AS,,KH,KHM,,10.58,103.637,157000,223
 G-KOT,Kotlik,,,gleam_basin,,W-NA,,US,USA,US-AK,63.031,-163.533,,2413
-G-KOV,Kokshetau,,,gleam_basin,,W-AS,,KZ,KAZ,,53.329,69.595,129000.0,669
-G-KOW,Ganzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,25.853,114.779,1500000.0,450
+G-KOV,Kokshetau,,,gleam_basin,,W-AS,,KZ,KAZ,,53.329,69.595,129000,669
+G-KOW,Ganzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JX,25.853,114.779,1500000,450
 G-KQA,Akutan,,,gleam_basin,,W-NA,,US,USA,US-AK,54.134,-165.779,,2328
-G-KQT,Qurghonteppa,,,gleam_basin,,W-AS,,TJ,TJK,,37.866,68.865,312000.0,974
+G-KQT,Qurghonteppa,,,gleam_basin,,W-AS,,TJ,TJK,,37.866,68.865,312000,974
 G-KRC,Kerinci,,,gleam_basin,,W-AS,,ID,IDN,,-2.093,101.468,,1281
 G-KRF,Kramfors,,,gleam_basin,,W-EU,,SE,SWE,,63.049,17.769,,2540
-G-KRK,Krakow,,,gleam_basin,,W-EU,,PL,POL,,50.078,19.785,756000.0,2855
-G-KRL,Korla,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.698,86.129,206000.0,310
-G-KRN,Kiruna,,,gleam_basin,,W-EU,,SE,SWE,,67.822,20.337,18000.0,2560
-G-KRO,Kurgan,,,gleam_basin,,W-EU,,RU,RUS,,55.475,65.416,343000.0,1932
+G-KRK,Krakow,,,gleam_basin,,W-EU,,PL,POL,,50.078,19.785,756000,2855
+G-KRL,Korla,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,41.698,86.129,206000,310
+G-KRN,Kiruna,,,gleam_basin,,W-EU,,SE,SWE,,67.822,20.337,18000,2560
+G-KRO,Kurgan,,,gleam_basin,,W-EU,,RU,RUS,,55.475,65.416,343000,1932
 G-KRP,Karup,,,gleam_basin,,W-EU,,DK,DNK,,56.298,9.125,,1563
-G-KRR,Krasnodar,,,gleam_basin,,W-EU,,RU,RUS,,45.035,39.171,650000.0,1883
-G-KRS,Kristiansand,,,gleam_basin,,W-EU,,NO,NOR,,58.204,8.085,64000.0,1161
-G-KRT,Khartoum,,,gleam_basin,,W-AF,,SD,SDN,,15.59,32.553,4754000.0,3017
-G-KRY,Karamay,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,45.467,84.953,109000.0,431
+G-KRR,Krasnodar,,,gleam_basin,,W-EU,,RU,RUS,,45.035,39.171,650000,1883
+G-KRS,Kristiansand,,,gleam_basin,,W-EU,,NO,NOR,,58.204,8.085,64000,1161
+G-KRT,Khartoum,,,gleam_basin,,W-AF,,SD,SDN,,15.59,32.553,4754000,3017
+G-KRY,Karamay,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,45.467,84.953,109000,431
 G-KSA,Kosrae,,,gleam_basin,,W-OC,,FM,FSM,,5.357,162.958,,1211
-G-KSC,Kosice,,,gleam_basin,,W-EU,,SK,SVK,,48.663,21.241,237000.0,2814
-G-KSD,Karlstad,,,gleam_basin,,W-EU,,SE,SWE,,59.445,13.337,74000.0,2557
-G-KSE,Kasese,,,gleam_basin,,W-AF,,UG,UGA,,0.183,30.1,67000.0,3164
-G-KSF,Kassel,,,gleam_basin,,W-EU,,DE,DEU,,51.417,9.385,290000.0,737
-G-KSH,Kermanshah,,,gleam_basin,,W-AS,,IR,IRN,,34.346,47.158,828000.0,2949
-G-KSL,Kassala,,,gleam_basin,,W-AF,,SD,SDN,,15.387,36.329,401000.0,3015
+G-KSC,Kosice,,,gleam_basin,,W-EU,,SK,SVK,,48.663,21.241,237000,2814
+G-KSD,Karlstad,,,gleam_basin,,W-EU,,SE,SWE,,59.445,13.337,74000,2557
+G-KSE,Kasese,,,gleam_basin,,W-AF,,UG,UGA,,0.183,30.1,67000,3164
+G-KSF,Kassel,,,gleam_basin,,W-EU,,DE,DEU,,51.417,9.385,290000,737
+G-KSH,Kermanshah,,,gleam_basin,,W-AS,,IR,IRN,,34.346,47.158,828000,2949
+G-KSL,Kassala,,,gleam_basin,,W-AF,,SD,SDN,,15.387,36.329,401000,3015
 G-KSM,St Marys,,,gleam_basin,,W-NA,,US,USA,US-AK,62.061,-163.302,,2494
-G-KSN,Kostanay,,,gleam_basin,,W-AS,,KZ,KAZ,,53.207,63.55,210000.0,665
+G-KSN,Kostanay,,,gleam_basin,,W-AS,,KZ,KAZ,,53.207,63.55,210000,665
 G-KSO,Kastoria,,,gleam_basin,,W-EU,,GR,GRC,,40.446,21.282,,921
-G-KSQ,Karshi,,,gleam_basin,,W-AS,,UZ,UZB,,38.834,65.922,205000.0,2839
-G-KSY,Kars,,,gleam_basin,,W-AS,,TR,TUR,,40.562,43.115,77000.0,1769
-G-KSZ,Kotlas,,,gleam_basin,,W-EU,,RU,RUS,,61.236,46.697,60000.0,1869
-G-KTA,Karratha,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-20.712,116.773,17000.0,1661
+G-KSQ,Karshi,,,gleam_basin,,W-AS,,UZ,UZB,,38.834,65.922,205000,2839
+G-KSY,Kars,,,gleam_basin,,W-AS,,TR,TUR,,40.562,43.115,77000,1769
+G-KSZ,Kotlas,,,gleam_basin,,W-EU,,RU,RUS,,61.236,46.697,60000,1869
+G-KTA,Karratha,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-20.712,116.773,17000,1661
 G-KTE,Kerteh,,,gleam_basin,,W-AS,,MY,MYS,,4.537,103.427,,193
 G-KTG,Ketapang,,,gleam_basin,,W-AS,,ID,IDN,,-1.817,109.963,,1298
-G-KTL,Kitale,,,gleam_basin,,W-AF,,KE,KEN,,0.972,34.959,150000.0,1733
-G-KTM,Kathmandu,,,gleam_basin,,W-AS,,NP,NPL,,27.697,85.359,895000.0,566
-G-KTN,Ketchikan,,,gleam_basin,,W-NA,,US,USA,US-AK,55.356,-131.714,11000.0,2522
+G-KTL,Kitale,,,gleam_basin,,W-AF,,KE,KEN,,0.972,34.959,150000,1733
+G-KTM,Kathmandu,,,gleam_basin,,W-AS,,NP,NPL,,27.697,85.359,895000,566
+G-KTN,Ketchikan,,,gleam_basin,,W-NA,,US,USA,US-AK,55.356,-131.714,11000,2522
 G-KTS,Teller Mission,,,gleam_basin,,W-NA,,US,USA,US-AK,65.331,-166.466,,2476
 G-KTT,Kittila,,,gleam_basin,,W-EU,,FI,FIN,,67.701,24.847,,515
-G-KTW,Katowice,,,gleam_basin,,W-EU,,PL,POL,,50.474,19.08,2746000.0,2856
-G-KUA,Kuantan,,,gleam_basin,,W-AS,,MY,MYS,,3.775,103.209,366000.0,185
-G-KUD,Kudat,,,gleam_basin,,W-AS,,MY,MYS,,6.923,116.836,32000.0,170
-G-KUF,Samara,,,gleam_basin,,W-EU,,RU,RUS,,53.505,50.164,1137000.0,1826
-G-KUH,Kushiro,,,gleam_basin,,W-AS,,JP,JPN,,43.041,144.193,184000.0,3116
-G-KUL,Kuala Lumpur,,,gleam_basin,,W-AS,,MY,MYS,,2.746,101.71,1448000.0,182
-G-KUN,Kaunas,,,gleam_basin,,W-EU,,LT,LTU,,54.964,24.085,375000.0,1539
-G-KUO,Kuopio,,,gleam_basin,,W-EU,,FI,FIN,,63.007,27.798,92000.0,514
+G-KTW,Katowice,,,gleam_basin,,W-EU,,PL,POL,,50.474,19.08,2746000,2856
+G-KUA,Kuantan,,,gleam_basin,,W-AS,,MY,MYS,,3.775,103.209,366000,185
+G-KUD,Kudat,,,gleam_basin,,W-AS,,MY,MYS,,6.923,116.836,32000,170
+G-KUF,Samara,,,gleam_basin,,W-EU,,RU,RUS,,53.505,50.164,1137000,1826
+G-KUH,Kushiro,,,gleam_basin,,W-AS,,JP,JPN,,43.041,144.193,184000,3116
+G-KUL,Kuala Lumpur,,,gleam_basin,,W-AS,,MY,MYS,,2.746,101.71,1448000,182
+G-KUN,Kaunas,,,gleam_basin,,W-EU,,LT,LTU,,54.964,24.085,375000,1539
+G-KUO,Kuopio,,,gleam_basin,,W-EU,,FI,FIN,,63.007,27.798,92000,514
 G-KUS,Kulusuk Island,,,gleam_basin,,W-NA,,GL,GRL,,,,,948
-G-KUT,Kutaisi,,,gleam_basin,,W-AS,,GE,GEO,,42.177,42.483,184000.0,841
+G-KUT,Kutaisi,,,gleam_basin,,W-AS,,GE,GEO,,42.177,42.483,184000,841
 G-KUU,Kullu,,,gleam_basin,,W-AS,,IN,IND,,31.877,77.154,,1110
-G-KUV,Gunsan,,,gleam_basin,,W-AS,,KR,KOR,,35.904,126.616,243000.0,2805
-G-KVA,Kavala,,,gleam_basin,,W-EU,,GR,GRC,,40.913,24.619,59000.0,937
-G-KVD,Ganja,,,gleam_basin,,W-AS,,AZ,AZE,,40.738,46.318,313000.0,2577
-G-KVG,Kavieng,,,gleam_basin,,W-OC,,PG,PNG,,-2.579,150.808,20000.0,3002
-G-KVK,Kirovsk,,,gleam_basin,,W-EU,,RU,RUS,,67.463,33.588,30000.0,1887
+G-KUV,Gunsan,,,gleam_basin,,W-AS,,KR,KOR,,35.904,126.616,243000,2805
+G-KVA,Kavala,,,gleam_basin,,W-EU,,GR,GRC,,40.913,24.619,59000,937
+G-KVD,Ganja,,,gleam_basin,,W-AS,,AZ,AZE,,40.738,46.318,313000,2577
+G-KVG,Kavieng,,,gleam_basin,,W-OC,,PG,PNG,,-2.579,150.808,20000,3002
+G-KVK,Kirovsk,,,gleam_basin,,W-EU,,RU,RUS,,67.463,33.588,30000,1887
 G-KVL,Kivalina,,,gleam_basin,,W-NA,,US,USA,US-AK,67.736,-164.563,,2512
-G-KVX,Kirov,,,gleam_basin,,W-EU,,RU,RUS,,58.503,49.348,457000.0,1923
+G-KVX,Kirov,,,gleam_basin,,W-EU,,RU,RUS,,58.503,49.348,457000,1923
 G-KWA,Kwajalein Island,,,gleam_basin,,W-OC,,MH,MHL,,8.72,167.732,,858
-G-KWE,Guiyang,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.538,106.801,3662000.0,460
+G-KWE,Guiyang,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,26.538,106.801,3662000,460
 G-KWG,Krivyi Rih,,,gleam_basin,,W-EU,,UA,UKR,,48.043,33.21,,2794
 G-KWI,Kuwait,,,gleam_basin,,W-AS,,KW,KWT,,,,,2861
-G-KWJ,Gwangju,,,gleam_basin,,W-AS,,KR,KOR,,35.123,126.805,1440000.0,2808
-G-KWL,Guilin,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,25.218,110.039,987000.0,461
+G-KWJ,Gwangju,,,gleam_basin,,W-AS,,KR,KOR,,35.123,126.805,1440000,2808
+G-KWL,Guilin,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,25.218,110.039,987000,461
 G-KWM,Kowanyama,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-15.486,141.751,,1588
 G-KWN,Quinhagak,,,gleam_basin,,W-NA,,US,USA,US-AK,59.755,-161.845,,2129
 G-KXK,Komsomolsk-na-Amure,,,gleam_basin,,W-EU,,RU,RUS,,50.409,136.934,,1851
 G-KXU,Katiu,,,gleam_basin,,W-OC,,PF,PYF,,,,,694
-G-KYA,Konya,,,gleam_basin,,W-AS,,TR,TUR,,37.979,32.562,919000.0,1740
-G-KYP,Kyaukpyu,,,gleam_basin,,W-AS,,MM,MMR,,19.426,93.535,4000.0,869
-G-KZI,Kozani,,,gleam_basin,,W-EU,,GR,GRC,,40.286,21.841,36000.0,919
-G-KZN,Kazan,,,gleam_basin,,W-EU,,RU,RUS,,55.606,49.279,24000.0,1840
-G-KZO,Kyzylorda,,,gleam_basin,,W-AS,,KZ,KAZ,,44.707,65.592,300000.0,658
-G-KZR,Kutahya,,,gleam_basin,,W-AS,,TR,TUR,,39.113,30.128,185000.0,1748
+G-KYA,Konya,,,gleam_basin,,W-AS,,TR,TUR,,37.979,32.562,919000,1740
+G-KYP,Kyaukpyu,,,gleam_basin,,W-AS,,MM,MMR,,19.426,93.535,4000,869
+G-KZI,Kozani,,,gleam_basin,,W-EU,,GR,GRC,,40.286,21.841,36000,919
+G-KZN,Kazan,,,gleam_basin,,W-EU,,RU,RUS,,55.606,49.279,24000,1840
+G-KZO,Kyzylorda,,,gleam_basin,,W-AS,,KZ,KAZ,,44.707,65.592,300000,658
+G-KZR,Kutahya,,,gleam_basin,,W-AS,,TR,TUR,,39.113,30.128,185000,1748
 G-KZS,Megisti,,,gleam_basin,,W-EU,,GR,GRC,,36.142,29.576,,912
-G-LAD,Luanda,,,gleam_basin,,W-AF,,AO,AGO,,-8.858,13.231,5173000.0,11
-G-LAE,Lae,,,gleam_basin,,W-OC,,PG,PNG,,-6.57,146.726,131000.0,2993
-G-LAI,Lannion,,,gleam_basin,,W-EU,,FR,FRA,,48.754,-3.472,21000.0,1523
+G-LAD,Luanda,,,gleam_basin,,W-AF,,AO,AGO,,-8.858,13.231,5173000,11
+G-LAE,Lae,,,gleam_basin,,W-OC,,PG,PNG,,-6.57,146.726,131000,2993
+G-LAI,Lannion,,,gleam_basin,,W-EU,,FR,FRA,,48.754,-3.472,21000,1523
 G-LAK,Aklavik,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,68.223,-135.006,,2741
-G-LAN,Lansing,,,gleam_basin,,W-NA,,US,USA,US-MI,42.779,-84.587,321000.0,2392
-G-LAO,Laoag,,,gleam_basin,,W-AS,,PH,PHL,,18.178,120.532,207000.0,612
+G-LAN,Lansing,,,gleam_basin,,W-NA,,US,USA,US-MI,42.779,-84.587,321000,2392
+G-LAO,Laoag,,,gleam_basin,,W-AS,,PH,PHL,,18.178,120.532,207000,612
 G-LAP,La Paz (MX),,,gleam_basin,,W-NA,,MX,MEX,,24.073,-110.362,,1026
 G-LAQ,Beida,,,gleam_basin,,W-AF,,LY,LBY,,32.789,21.964,,163
-G-LAR,Laramie,,,gleam_basin,,W-NA,,US,USA,US-WY,41.312,-105.675,34000.0,2395
-G-LAS,Las Vegas,,,gleam_basin,,W-NA,,US,USA,US-NV,36.08,-115.152,2073000.0,2396
-G-LAU,Lamu,,,gleam_basin,,W-AF,,KE,KEN,,-2.252,40.913,25000.0,1732
-G-LAW,Lawton,,,gleam_basin,,W-NA,,US,USA,US-OK,34.568,-98.417,91000.0,2394
-G-LAX,Los Angeles,,,gleam_basin,,W-NA,,US,USA,US-CA,33.943,-118.408,12815000.0,2393
+G-LAR,Laramie,,,gleam_basin,,W-NA,,US,USA,US-WY,41.312,-105.675,34000,2395
+G-LAS,Las Vegas,,,gleam_basin,,W-NA,,US,USA,US-NV,36.08,-115.152,2073000,2396
+G-LAU,Lamu,,,gleam_basin,,W-AF,,KE,KEN,,-2.252,40.913,25000,1732
+G-LAW,Lawton,,,gleam_basin,,W-NA,,US,USA,US-OK,34.568,-98.417,91000,2394
+G-LAX,Los Angeles,,,gleam_basin,,W-NA,,US,USA,US-CA,33.943,-118.408,12815000,2393
 G-LBA,Leeds Bradford,,,gleam_basin,,W-EU,,GB,GBR,,53.866,-1.661,,787
-G-LBB,Lubbock,,,gleam_basin,,W-NA,,US,USA,US-TX,33.664,-101.823,263000.0,2423
-G-LBC,Lubeck,,,gleam_basin,,W-EU,,DE,DEU,,53.805,10.719,235000.0,746
-G-LBD,Khujand,,,gleam_basin,,W-AS,,TJ,TJK,,40.215,69.695,438000.0,977
-G-LBE,Latrobe,,,gleam_basin,,W-NA,,US,USA,US-PA,40.276,-79.405,8000.0,2424
-G-LBF,North Platte,,,gleam_basin,,W-NA,,US,USA,US-NE,41.126,-100.684,24000.0,2425
-G-LBJ,Labuan Bajo,,,gleam_basin,,W-AS,,ID,IDN,,-8.487,119.889,189000.0,1300
-G-LBL,Liberal,,,gleam_basin,,W-NA,,US,USA,US-KS,37.044,-100.96,20000.0,2426
+G-LBB,Lubbock,,,gleam_basin,,W-NA,,US,USA,US-TX,33.664,-101.823,263000,2423
+G-LBC,Lubeck,,,gleam_basin,,W-EU,,DE,DEU,,53.805,10.719,235000,746
+G-LBD,Khujand,,,gleam_basin,,W-AS,,TJ,TJK,,40.215,69.695,438000,977
+G-LBE,Latrobe,,,gleam_basin,,W-NA,,US,USA,US-PA,40.276,-79.405,8000,2424
+G-LBF,North Platte,,,gleam_basin,,W-NA,,US,USA,US-NE,41.126,-100.684,24000,2425
+G-LBJ,Labuan Bajo,,,gleam_basin,,W-AS,,ID,IDN,,-8.487,119.889,189000,1300
+G-LBL,Liberal,,,gleam_basin,,W-NA,,US,USA,US-KS,37.044,-100.96,20000,2426
 G-LBP,Long Banga,,,gleam_basin,,W-AS,,MY,MYS,,,,,190
 G-LBR,Labrea,,,gleam_basin,,W-SA,,BR,BRA,,-7.279,-64.77,,2019
-G-LBS,Labasa,,,gleam_basin,,W-OC,,FJ,FJI,,-16.467,179.34,24000.0,1190
-G-LBU,Labuan,,,gleam_basin,,W-AS,,MY,MYS,,5.301,115.25,34000.0,191
-G-LBV,Libreville,,,gleam_basin,,W-AF,,GA,GAB,,0.459,9.412,578000.0,647
-G-LCA,Larnaca,,,gleam_basin,,W-AS,,CY,CYP,,34.875,33.625,49000.0,2817
-G-LCH,Lake Charles,,,gleam_basin,,W-NA,,US,USA,US-LA,30.126,-93.223,154000.0,2480
-G-LCJ,Lodz,,,gleam_basin,,W-EU,,PL,POL,,51.722,19.398,758000.0,2860
-G-LCR,La Chorrera,,,gleam_basin,,W-SA,,CO,COL,,,,61000.0,1403
-G-LCX,Longyan,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,25.675,116.747,368000.0,467
-G-LDB,Londrina,,,gleam_basin,,W-SA,,BR,BRA,,-23.334,-51.13,520000.0,1957
+G-LBS,Labasa,,,gleam_basin,,W-OC,,FJ,FJI,,-16.467,179.34,24000,1190
+G-LBU,Labuan,,,gleam_basin,,W-AS,,MY,MYS,,5.301,115.25,34000,191
+G-LBV,Libreville,,,gleam_basin,,W-AF,,GA,GAB,,0.459,9.412,578000,647
+G-LCA,Larnaca,,,gleam_basin,,W-AS,,CY,CYP,,34.875,33.625,49000,2817
+G-LCH,Lake Charles,,,gleam_basin,,W-NA,,US,USA,US-LA,30.126,-93.223,154000,2480
+G-LCJ,Lodz,,,gleam_basin,,W-EU,,PL,POL,,51.722,19.398,758000,2860
+G-LCR,La Chorrera,,,gleam_basin,,W-SA,,CO,COL,,,,61000,1403
+G-LCX,Longyan,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,25.675,116.747,368000,467
+G-LDB,Londrina,,,gleam_basin,,W-SA,,BR,BRA,,-23.334,-51.13,520000,1957
 G-LDG,Leshukonskoye,,,gleam_basin,,W-EU,,RU,RUS,,64.896,45.723,,1839
-G-LDH,Lord Howe Island,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.538,159.077,300.0,1614
-G-LDS,Yichun (Heilongjiang),,,gleam_basin,,W-AS,,CN,CHN,CN-HL,47.752,129.019,814000.0,374
-G-LDU,Lahad Datu,,,gleam_basin,,W-AS,,MY,MYS,,5.032,118.324,106000.0,172
-G-LDY,Derry,,,gleam_basin,,W-EU,,GB,GBR,,55.043,-7.161,84000.0,774
+G-LDH,Lord Howe Island,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.538,159.077,300,1614
+G-LDS,Yichun (Heilongjiang),,,gleam_basin,,W-AS,,CN,CHN,CN-HL,47.752,129.019,814000,374
+G-LDU,Lahad Datu,,,gleam_basin,,W-AS,,MY,MYS,,5.032,118.324,106000,172
+G-LDY,Derry,,,gleam_basin,,W-EU,,GB,GBR,,55.043,-7.161,84000,774
 G-LEA,Learmonth,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-22.236,114.089,,1674
 G-LEB,Lebanon,,,gleam_basin,,W-NA,,US,USA,US-NH,,,,2264
 G-LEC,Lencois,,,gleam_basin,,W-SA,,BR,BRA,,-12.482,-41.277,,1986
 G-LED,St Petersburg,,,gleam_basin,,W-EU,,RU,RUS,,59.8,30.263,,1855
-G-LEI,Almeria,,,gleam_basin,,W-EU,,ES,ESP,,36.844,-2.37,179000.0,2894
-G-LEJ,Leipzig,,,gleam_basin,,W-EU,,DE,DEU,,51.424,12.236,543000.0,736
+G-LEI,Almeria,,,gleam_basin,,W-EU,,ES,ESP,,36.844,-2.37,179000,2894
+G-LEJ,Leipzig,,,gleam_basin,,W-EU,,DE,DEU,,51.424,12.236,543000,736
 G-LEN,Leon (ES),,,gleam_basin,,W-EU,,ES,ESP,,42.589,-5.656,,2895
-G-LET,Leticia,,,gleam_basin,,W-SA,,BR,BRA,,-4.194,-69.943,60000.0,2001
-G-LEX,Lexington,,,gleam_basin,,W-NA,,US,USA,US-KY,38.036,-84.606,316000.0,2265
-G-LFT,Lafayette,,,gleam_basin,,W-NA,,US,USA,US-LA,30.205,-91.988,266000.0,2148
-G-LFW,Lome,,,gleam_basin,,W-AF,,TG,TGO,,6.166,1.255,1452000.0,723
-G-LGG,Liege,,,gleam_basin,,W-EU,,BE,BEL,,50.637,5.443,749000.0,719
+G-LET,Leticia,,,gleam_basin,,W-SA,,BR,BRA,,-4.194,-69.943,60000,2001
+G-LEX,Lexington,,,gleam_basin,,W-NA,,US,USA,US-KY,38.036,-84.606,316000,2265
+G-LFT,Lafayette,,,gleam_basin,,W-NA,,US,USA,US-LA,30.205,-91.988,266000,2148
+G-LFW,Lome,,,gleam_basin,,W-AF,,TG,TGO,,6.166,1.255,1452000,723
+G-LGG,Liege,,,gleam_basin,,W-EU,,BE,BEL,,50.637,5.443,749000,719
 G-LGI,Deadmans Cay,,,gleam_basin,,W-NA,,BS,BHS,,23.179,-75.094,,3227
 G-LGK,Langkawi,,,gleam_basin,,W-AS,,MY,MYS,,6.33,99.729,,183
-G-LGP,Legaspi,,,gleam_basin,,W-AS,,PH,PHL,,13.158,123.735,179000.0,609
+G-LGP,Legaspi,,,gleam_basin,,W-AS,,PH,PHL,,13.158,123.735,179000,609
 G-LGQ,Lago Agrio,,,gleam_basin,,W-SA,,EC,ECU,,,,,1467
-G-LHE,Lahore,,,gleam_basin,,W-AS,,PK,PAK,,31.522,74.404,16400000.0,115
+G-LHE,Lahore,,,gleam_basin,,W-AS,,PK,PAK,,31.522,74.404,16400000,115
 G-LHR,London (UK),,,gleam_basin,,W-EU,,GB,GBR,,51.471,-0.462,,791
-G-LHW,Lanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,36.515,103.62,2561000.0,343
+G-LHW,Lanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,36.515,103.62,2561000,343
 G-LIF,Lifou,,,gleam_basin,,W-OC,,NC,NCL,,-20.775,167.24,,3169
-G-LIG,Limoges,,,gleam_basin,,W-EU,,FR,FRA,,45.863,1.179,152000.0,1531
+G-LIG,Limoges,,,gleam_basin,,W-EU,,FR,FRA,,45.863,1.179,152000,1531
 G-LIH,Kauai Island,,,gleam_basin,,W-NA,,US,USA,US-HI,21.976,-159.339,,2193
-G-LIL,Lille,,,gleam_basin,,W-EU,,FR,FRA,,50.563,3.087,1044000.0,1505
-G-LIM,Lima,,,gleam_basin,,W-SA,,PE,PER,,-12.022,-77.114,8012000.0,1216
+G-LIL,Lille,,,gleam_basin,,W-EU,,FR,FRA,,50.563,3.087,1044000,1505
+G-LIM,Lima,,,gleam_basin,,W-SA,,PE,PER,,-12.022,-77.114,8012000,1216
 G-LIR,Liberia,,,gleam_basin,,W-NA,,CR,CRI,,,,,803
-G-LIS,Lisbon,,,gleam_basin,,W-EU,,PT,PRT,,38.781,-9.136,2812000.0,1439
-G-LIT,Little Rock,,,gleam_basin,,W-NA,,US,USA,US-AR,34.729,-92.224,443000.0,2194
+G-LIS,Lisbon,,,gleam_basin,,W-EU,,PT,PRT,,38.781,-9.136,2812000,1439
+G-LIT,Little Rock,,,gleam_basin,,W-NA,,US,USA,US-AR,34.729,-92.224,443000,2194
 G-LIX,Likoma Island,,,gleam_basin,,W-AF,,MW,MWI,,-12.076,34.737,,2869
-G-LJA,Lodja,,,gleam_basin,,W-AF,,CD,COD,,-3.417,23.45,68000.0,1336
-G-LJG,Lijiang,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,26.68,100.246,1138000.0,375
-G-LJU,Ljubljana,,,gleam_basin,,W-EU,,SI,SVN,,46.224,14.458,315000.0,272
+G-LJA,Lodja,,,gleam_basin,,W-AF,,CD,COD,,-3.417,23.45,68000,1336
+G-LJG,Lijiang,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,26.68,100.246,1138000,375
+G-LJU,Ljubljana,,,gleam_basin,,W-EU,,SI,SVN,,46.224,14.458,315000,272
 G-LKB,Lakeba Island,,,gleam_basin,,W-OC,,FJ,FJI,,-18.199,-178.817,,1186
 G-LKG,Lokichogio,,,gleam_basin,,W-AF,,KE,KEN,,4.204,34.348,,1729
 G-LKL,Lakselv,,,gleam_basin,,W-EU,,NO,NOR,,70.069,24.973,,1148
 G-LKN,Leknes,,,gleam_basin,,W-EU,,NO,NOR,,68.152,13.609,,1159
-G-LKO,Lucknow,,,gleam_basin,,W-AS,,IN,IND,,26.761,80.889,2695000.0,1082
+G-LKO,Lucknow,,,gleam_basin,,W-AS,,IN,IND,,26.761,80.889,2695000,1082
 G-LKY,Lake Manyara,,,gleam_basin,,W-AF,,TZ,TZA,,-3.376,35.818,,213
-G-LLA,Lulea,,,gleam_basin,,W-EU,,SE,SWE,,65.544,22.122,49000.0,2573
+G-LLA,Lulea,,,gleam_basin,,W-EU,,SE,SWE,,65.544,22.122,49000,2573
 G-LLB,Libo,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,25.453,107.962,,478
-G-LLF,Yongzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,26.339,111.61,1000000.0,479
+G-LLF,Yongzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-HN,26.339,111.61,1000000,479
 G-LLI,Lalibela,,,gleam_basin,,W-AF,,ET,ETH,,11.975,38.98,,242
-G-LLK,Lankaran,,,gleam_basin,,W-AS,,AZ,AZE,,38.746,48.818,60000.0,2578
-G-LLW,Lilongwe,,,gleam_basin,,W-AF,,MW,MWI,,-13.789,33.781,647000.0,2872
+G-LLK,Lankaran,,,gleam_basin,,W-AS,,AZ,AZE,,38.746,48.818,60000,2578
+G-LLW,Lilongwe,,,gleam_basin,,W-AF,,MW,MWI,,-13.789,33.781,647000,2872
 G-LMA,Lake Minchumina,,,gleam_basin,,W-NA,,US,USA,US-AK,63.886,-152.302,,2068
 G-LMC,Lamacarena,,,gleam_basin,,W-SA,,CO,COL,,,,,1362
-G-LMM,Los Mochis,,,gleam_basin,,W-NA,,MX,MEX,,25.685,-109.081,249000.0,994
-G-LMN,Limbang,,,gleam_basin,,W-AS,,MY,MYS,,4.808,115.01,26000.0,187
-G-LMP,Lampedusa,,,gleam_basin,,W-EU,,IT,ITA,,35.498,12.618,5230.0,3066
-G-LMT,Klamath Falls,,,gleam_basin,,W-NA,,US,USA,US-OR,42.156,-121.733,42000.0,2067
+G-LMM,Los Mochis,,,gleam_basin,,W-NA,,MX,MEX,,25.685,-109.081,249000,994
+G-LMN,Limbang,,,gleam_basin,,W-AS,,MY,MYS,,4.808,115.01,26000,187
+G-LMP,Lampedusa,,,gleam_basin,,W-EU,,IT,ITA,,35.498,12.618,5230,3066
+G-LMT,Klamath Falls,,,gleam_basin,,W-NA,,US,USA,US-OR,42.156,-121.733,42000,2067
 G-LNJ,Lincang,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,23.738,100.025,,416
-G-LNK,Lincoln,,,gleam_basin,,W-NA,,US,USA,US-NE,40.851,-96.759,285000.0,2093
+G-LNK,Lincoln,,,gleam_basin,,W-NA,,US,USA,US-NE,40.851,-96.759,285000,2093
 G-LNV,Lihir Island,,,gleam_basin,,W-OC,,PG,PNG,,,,,2978
-G-LNZ,Linz,,,gleam_basin,,W-EU,,AT,AUT,,48.233,14.188,349000.0,1695
+G-LNZ,Linz,,,gleam_basin,,W-EU,,AT,AUT,,48.233,14.188,349000,1695
 G-LOD,Longana,,,gleam_basin,,W-OC,,VU,VUT,,-15.307,167.967,,1321
-G-LOE,Loei,,,gleam_basin,,W-AS,,TH,THA,,17.439,101.722,35000.0,524
-G-LOH,Loja,,,gleam_basin,,W-SA,,EC,ECU,,-3.996,-79.372,126000.0,1461
-G-LOK,Lodwar,,,gleam_basin,,W-AF,,KE,KEN,,3.122,35.609,20000.0,1725
-G-LOO,Laghouat,,,gleam_basin,,W-AF,,DZ,DZA,,33.764,2.928,114000.0,17
-G-LOP,Praya,,,gleam_basin,,W-AS,,ID,IDN,,-8.757,116.277,35000.0,1251
-G-LOS,Lagos,,,gleam_basin,,W-AF,,NG,NGA,,6.577,3.321,9466000.0,1409
+G-LOE,Loei,,,gleam_basin,,W-AS,,TH,THA,,17.439,101.722,35000,524
+G-LOH,Loja,,,gleam_basin,,W-SA,,EC,ECU,,-3.996,-79.372,126000,1461
+G-LOK,Lodwar,,,gleam_basin,,W-AF,,KE,KEN,,3.122,35.609,20000,1725
+G-LOO,Laghouat,,,gleam_basin,,W-AF,,DZ,DZA,,33.764,2.928,114000,17
+G-LOP,Praya,,,gleam_basin,,W-AS,,ID,IDN,,-8.757,116.277,35000,1251
+G-LOS,Lagos,,,gleam_basin,,W-AF,,NG,NGA,,6.577,3.321,9466000,1409
 G-LPA,Gran Canaria,,,gleam_basin,,W-EU,,ES,ESP,,27.932,-15.387,,2905
 G-LPB,La Paz (BO),,,gleam_basin,,W-SA,,BO,BOL,,-16.513,-68.192,,96
 G-LPD,La Pedrera,,,gleam_basin,,W-SA,,CO,COL,,-1.329,-69.58,,1398
-G-LPK,Lipetsk,,,gleam_basin,,W-EU,,RU,RUS,,52.703,39.538,516000.0,1903
-G-LPP,Lappeenranta,,,gleam_basin,,W-EU,,FI,FIN,,61.045,28.145,59000.0,516
-G-LPQ,Luang Prabang,,,gleam_basin,,W-AS,,LA,LAO,,19.897,102.161,47000.0,577
-G-LPT,Lampang,,,gleam_basin,,W-AS,,TH,THA,,18.271,99.504,204000.0,543
+G-LPK,Lipetsk,,,gleam_basin,,W-EU,,RU,RUS,,52.703,39.538,516000,1903
+G-LPP,Lappeenranta,,,gleam_basin,,W-EU,,FI,FIN,,61.045,28.145,59000,516
+G-LPQ,Luang Prabang,,,gleam_basin,,W-AS,,LA,LAO,,19.897,102.161,47000,577
+G-LPT,Lampang,,,gleam_basin,,W-AS,,TH,THA,,18.271,99.504,204000,543
 G-LPU,Long Apung,,,gleam_basin,,W-AS,,ID,IDN,,1.704,114.97,,1261
 G-LPY,Le Puy,,,gleam_basin,,W-EU,,FR,FRA,,45.081,3.763,,1527
 G-LQM,Puerto Leguizamo,,,gleam_basin,,W-SA,,CO,COL,,-0.182,-74.771,,1400
-G-LRD,Laredo,,,gleam_basin,,W-NA,,US,USA,US-TX,27.544,-99.462,260000.0,2519
-G-LRE,Longreach,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.434,144.28,3000.0,1688
-G-LRH,La Rochelle,,,gleam_basin,,W-EU,,FR,FRA,,46.179,-1.195,77000.0,1537
-G-LRM,La Romana,,,gleam_basin,,W-NA,,DO,DOM,,18.451,-68.912,208000.0,1202
-G-LRR,Lar,,,gleam_basin,,W-AS,,IR,IRN,,27.675,54.383,27000.0,2972
-G-LRT,Lorient,,,gleam_basin,,W-EU,,FR,FRA,,47.761,-3.44,85000.0,1538
+G-LRD,Laredo,,,gleam_basin,,W-NA,,US,USA,US-TX,27.544,-99.462,260000,2519
+G-LRE,Longreach,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.434,144.28,3000,1688
+G-LRH,La Rochelle,,,gleam_basin,,W-EU,,FR,FRA,,46.179,-1.195,77000,1537
+G-LRM,La Romana,,,gleam_basin,,W-NA,,DO,DOM,,18.451,-68.912,208000,1202
+G-LRR,Lar,,,gleam_basin,,W-AS,,IR,IRN,,27.675,54.383,27000,2972
+G-LRT,Lorient,,,gleam_basin,,W-EU,,FR,FRA,,47.761,-3.44,85000,1538
 G-LSA,Losuia,,,gleam_basin,,W-OC,,PG,PNG,,,,,2976
-G-LSC,La Serena,,,gleam_basin,,W-SA,,CL,CHL,,-29.916,-71.2,155000.0,291
-G-LSE,La Crosse,,,gleam_basin,,W-NA,,US,USA,US-WI,43.879,-91.257,102000.0,2059
-G-LSH,Lashio,,,gleam_basin,,W-AS,,MM,MMR,,22.978,97.752,131000.0,868
+G-LSC,La Serena,,,gleam_basin,,W-SA,,CL,CHL,,-29.916,-71.2,155000,291
+G-LSE,La Crosse,,,gleam_basin,,W-NA,,US,USA,US-WI,43.879,-91.257,102000,2059
+G-LSH,Lashio,,,gleam_basin,,W-AS,,MM,MMR,,22.978,97.752,131000,868
 G-LSI,Shetland Islands,,,gleam_basin,,W-EU,,GB,GBR,,59.879,-1.296,,793
-G-LSP,Las Piedras,,,gleam_basin,,W-SA,,VE,VEN,,11.781,-70.151,7000.0,1703
-G-LST,Launceston,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-41.545,147.214,72000.0,1571
+G-LSP,Las Piedras,,,gleam_basin,,W-SA,,VE,VEN,,11.781,-70.151,7000,1703
+G-LST,Launceston,,,gleam_basin,,W-OC,,AU,AUS,AU-TAS,-41.545,147.214,72000,1571
 G-LSW,Lhok Seumawe,,,gleam_basin,,W-AS,,ID,IDN,,5.227,96.95,,1235
 G-LTD,Ghadames,,,gleam_basin,,W-AF,,LY,LBY,,30.152,9.715,,162
-G-LTI,Altai,,,gleam_basin,,W-AS,,MN,MNG,,46.376,96.221,16000.0,849
-G-LTK,Latakia,,,gleam_basin,,W-AS,,SY,SYR,,35.401,35.949,539000.0,651
-G-LTO,Loreto,,,gleam_basin,,W-NA,,MX,MEX,,25.989,-111.348,11000.0,1014
+G-LTI,Altai,,,gleam_basin,,W-AS,,MN,MNG,,46.376,96.221,16000,849
+G-LTK,Latakia,,,gleam_basin,,W-AS,,SY,SYR,,35.401,35.949,539000,651
+G-LTO,Loreto,,,gleam_basin,,W-NA,,MX,MEX,,25.989,-111.348,11000,1014
 G-LTQ,Le Touquet,,,gleam_basin,,W-EU,,FR,FRA,,50.517,1.621,,1516
-G-LTX,Latacunga,,,gleam_basin,,W-SA,,EC,ECU,,-0.907,-78.616,95000.0,1466
+G-LTX,Latacunga,,,gleam_basin,,W-SA,,EC,ECU,,-0.907,-78.616,95000,1466
 G-LUA,Lukla,,,gleam_basin,,W-AS,,NP,NPL,,27.687,86.73,,560
-G-LUD,Luderitz,,,gleam_basin,,W-AF,,NA,NAM,,-26.687,15.243,15000.0,79
-G-LUG,Lugano,,,gleam_basin,,W-EU,,CH,CHE,,46.004,8.911,105000.0,277
-G-LUH,Ludhiana,,,gleam_basin,,W-AS,,IN,IND,,30.855,75.953,1649000.0,1088
+G-LUD,Luderitz,,,gleam_basin,,W-AF,,NA,NAM,,-26.687,15.243,15000,79
+G-LUG,Lugano,,,gleam_basin,,W-EU,,CH,CHE,,46.004,8.911,105000,277
+G-LUH,Ludhiana,,,gleam_basin,,W-AS,,IN,IND,,30.855,75.953,1649000,1088
 G-LUM,Mangshi,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,24.401,98.532,,414
-G-LUN,Lusaka,,,gleam_basin,,W-AF,,ZM,ZMB,,-15.331,28.453,1328000.0,1549
-G-LUO,Luena,,,gleam_basin,,W-AF,,AO,AGO,,-11.768,19.898,21000.0,7
-G-LUQ,San Luis,,,gleam_basin,,W-SA,,AR,ARG,,-33.273,-66.356,432000.0,3201
+G-LUN,Lusaka,,,gleam_basin,,W-AF,,ZM,ZMB,,-15.331,28.453,1328000,1549
+G-LUO,Luena,,,gleam_basin,,W-AF,,AO,AGO,,-11.768,19.898,21000,7
+G-LUQ,San Luis,,,gleam_basin,,W-SA,,AR,ARG,,-33.273,-66.356,432000,3201
 G-LUR,Cape Lisburne,,,gleam_basin,,W-NA,,US,USA,US-AK,68.875,-166.11,,2319
 G-LUV,Langgur,,,gleam_basin,,W-AS,,ID,IDN,,-5.662,132.731,,1275
-G-LUW,Luwuk,,,gleam_basin,,W-AS,,ID,IDN,,-1.039,122.772,48000.0,1276
+G-LUW,Luwuk,,,gleam_basin,,W-AS,,ID,IDN,,-1.039,122.772,48000,1276
 G-LUX,Luxembourg,,,gleam_basin,,W-EU,,LU,LUX,,,,,1203
-G-LUZ,Lublin,,,gleam_basin,,W-EU,,PL,POL,,51.24,22.714,360000.0,2854
-G-LVI,Livingstone,,,gleam_basin,,W-AF,,ZM,ZMB,,-17.822,25.823,165000.0,1551
-G-LWB,Lewisburg,,,gleam_basin,,W-NA,,US,USA,US-TN,37.858,-80.399,11000.0,2380
-G-LWN,Gyumri,,,gleam_basin,,W-AS,,AM,ARM,,40.75,43.859,148000.0,3234
-G-LWO,Lviv,,,gleam_basin,,W-EU,,UA,UKR,,49.812,23.956,718000.0,2791
-G-LWS,Lewiston,,,gleam_basin,,W-NA,,US,USA,US-ME,46.375,-117.015,59000.0,2378
-G-LWT,Lewistown,,,gleam_basin,,W-NA,,US,USA,US-PA,47.049,-109.467,22000.0,2379
-G-LXA,Lhasa,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,29.298,90.912,220000.0,372
+G-LUZ,Lublin,,,gleam_basin,,W-EU,,PL,POL,,51.24,22.714,360000,2854
+G-LVI,Livingstone,,,gleam_basin,,W-AF,,ZM,ZMB,,-17.822,25.823,165000,1551
+G-LWB,Lewisburg,,,gleam_basin,,W-NA,,US,USA,US-TN,37.858,-80.399,11000,2380
+G-LWN,Gyumri,,,gleam_basin,,W-AS,,AM,ARM,,40.75,43.859,148000,3234
+G-LWO,Lviv,,,gleam_basin,,W-EU,,UA,UKR,,49.812,23.956,718000,2791
+G-LWS,Lewiston,,,gleam_basin,,W-NA,,US,USA,US-ME,46.375,-117.015,59000,2378
+G-LWT,Lewistown,,,gleam_basin,,W-NA,,US,USA,US-PA,47.049,-109.467,22000,2379
+G-LXA,Lhasa,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,29.298,90.912,220000,372
 G-LXG,Luang Namtha,,,gleam_basin,,W-AS,,LA,LAO,,20.967,101.4,,573
-G-LXR,Luxor,,,gleam_basin,,W-AF,,EG,EGY,,25.671,32.707,609000.0,55
+G-LXR,Luxor,,,gleam_basin,,W-AF,,EG,EGY,,25.671,32.707,609000,55
 G-LXS,Limnos,,,gleam_basin,,W-EU,,GR,GRC,,39.917,25.236,,918
-G-LYA,Luoyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,34.741,112.388,1715000.0,381
+G-LYA,Luoyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,34.741,112.388,1715000,381
 G-LYC,Lycksele,,,gleam_basin,,W-EU,,SE,SWE,,64.548,18.716,,2555
-G-LYG,Lianyungang,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,34.572,118.874,687000.0,380
-G-LYH,Lynchburg,,,gleam_basin,,W-NA,,US,USA,US-VA,37.327,-79.2,125000.0,2247
-G-LYI,Linyi,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,35.046,118.412,2081999.0,382
-G-LYP,Faisalabad,,,gleam_basin,,W-AS,,PK,PAK,,31.365,72.995,30800000.0,118
-G-LYR,Longyearbyen,,,gleam_basin,,W-EU,,SJ,SJM,,78.246,15.466,2000.0,1700
-G-LYS,Lyon,,,gleam_basin,,W-EU,,FR,FRA,,45.726,5.081,1423000.0,1513
+G-LYG,Lianyungang,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,34.572,118.874,687000,380
+G-LYH,Lynchburg,,,gleam_basin,,W-NA,,US,USA,US-VA,37.327,-79.2,125000,2247
+G-LYI,Linyi,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,35.046,118.412,2081999,382
+G-LYP,Faisalabad,,,gleam_basin,,W-AS,,PK,PAK,,31.365,72.995,30800000,118
+G-LYR,Longyearbyen,,,gleam_basin,,W-EU,,SJ,SJM,,78.246,15.466,2000,1700
+G-LYS,Lyon,,,gleam_basin,,W-EU,,FR,FRA,,45.726,5.081,1423000,1513
 G-LYX,Lydd,,,gleam_basin,,W-EU,,GB,GBR,,50.956,0.939,,775
-G-LZC,Lazaro Cardenas,,,gleam_basin,,W-NA,,MX,MEX,,18.002,-102.221,179000.0,1011
-G-LZH,Liuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,24.207,109.391,1497000.0,397
-G-LZO,Luzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,28.852,105.393,1537000.0,398
+G-LZC,Lazaro Cardenas,,,gleam_basin,,W-NA,,MX,MEX,,18.002,-102.221,179000,1011
+G-LZH,Liuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,24.207,109.391,1497000,397
+G-LZO,Luzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,28.852,105.393,1537000,398
 G-LZY,Nyingchi,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,29.303,94.335,,396
-G-MAA,Chennai,,,gleam_basin,,W-AS,,IN,IND,,12.99,80.169,7163000.0,1053
-G-MAB,Maraba,,,gleam_basin,,W-SA,,BR,BRA,,-5.369,-49.138,166000.0,1935
-G-MAD,Madrid,,,gleam_basin,,W-EU,,ES,ESP,,40.472,-3.563,5567000.0,2874
-G-MAF,Midland,,,gleam_basin,,W-NA,,US,USA,US-TX,31.942,-102.202,144000.0,2058
-G-MAG,Madang,,,gleam_basin,,W-OC,,PG,PNG,,-5.207,145.789,62000.0,2975
+G-MAA,Chennai,,,gleam_basin,,W-AS,,IN,IND,,12.99,80.169,7163000,1053
+G-MAB,Maraba,,,gleam_basin,,W-SA,,BR,BRA,,-5.369,-49.138,166000,1935
+G-MAD,Madrid,,,gleam_basin,,W-EU,,ES,ESP,,40.472,-3.563,5567000,2874
+G-MAF,Midland,,,gleam_basin,,W-NA,,US,USA,US-TX,31.942,-102.202,144000,2058
+G-MAG,Madang,,,gleam_basin,,W-OC,,PG,PNG,,-5.207,145.789,62000,2975
 G-MAH,Menorca,,,gleam_basin,,W-EU,,ES,ESP,,39.863,4.219,,2875
-G-MAJ,Majuro,,,gleam_basin,,W-OC,,MH,MHL,,7.065,171.272,25000.0,857
-G-MAM,Matamoros,,,gleam_basin,,W-NA,,MX,MEX,,25.77,-97.525,104000.0,981
-G-MAN,Manchester,,,gleam_basin,,W-EU,,GB,GBR,,53.354,-2.275,2230000.0,789
-G-MAO,Manaus,,,gleam_basin,,W-SA,,BR,BRA,,-3.039,-60.05,1753000.0,1936
-G-MAQ,Mae Sot,,,gleam_basin,,W-AS,,TH,THA,,16.7,98.545,46000.0,534
-G-MAR,Maracaibo,,,gleam_basin,,W-SA,,VE,VEN,,10.558,-71.728,2072000.0,1701
+G-MAJ,Majuro,,,gleam_basin,,W-OC,,MH,MHL,,7.065,171.272,25000,857
+G-MAM,Matamoros,,,gleam_basin,,W-NA,,MX,MEX,,25.77,-97.525,104000,981
+G-MAN,Manchester,,,gleam_basin,,W-EU,,GB,GBR,,53.354,-2.275,2230000,789
+G-MAO,Manaus,,,gleam_basin,,W-SA,,BR,BRA,,-3.039,-60.05,1753000,1936
+G-MAQ,Mae Sot,,,gleam_basin,,W-AS,,TH,THA,,16.7,98.545,46000,534
+G-MAR,Maracaibo,,,gleam_basin,,W-SA,,VE,VEN,,10.558,-71.728,2072000,1701
 G-MAS,Manus Island,,,gleam_basin,,W-OC,,PG,PNG,,-2.062,147.424,,2974
 G-MAU,Maupiti Island,,,gleam_basin,,W-OC,,PF,PYF,,-16.427,-152.244,,676
-G-MBA,Mombasa,,,gleam_basin,,W-AF,,KE,KEN,,-4.035,39.594,882000.0,1737
+G-MBA,Mombasa,,,gleam_basin,,W-AF,,KE,KEN,,-4.035,39.594,882000,1737
 G-MBE,Monbetsu,,,gleam_basin,,W-AS,,JP,JPN,,44.304,143.404,,3156
-G-MBI,Mbeya,,,gleam_basin,,W-AF,,TZ,TZA,,-8.92,33.274,292000.0,214
-G-MBJ,Montego Bay,,,gleam_basin,,W-NA,,JM,JAM,,18.504,-77.913,126000.0,491
-G-MBL,Manistee,,,gleam_basin,,W-NA,,US,USA,US-MI,44.272,-86.247,9000.0,2497
-G-MBS,Saginaw,,,gleam_basin,,W-NA,,US,USA,US-MI,43.533,-84.08,119000.0,2501
-G-MBT,Masbate,,,gleam_basin,,W-AS,,PH,PHL,,12.37,123.63,47000.0,621
-G-MCE,Merced,,,gleam_basin,,W-NA,,US,USA,US-CA,37.285,-120.514,144000.0,2466
+G-MBI,Mbeya,,,gleam_basin,,W-AF,,TZ,TZA,,-8.92,33.274,292000,214
+G-MBJ,Montego Bay,,,gleam_basin,,W-NA,,JM,JAM,,18.504,-77.913,126000,491
+G-MBL,Manistee,,,gleam_basin,,W-NA,,US,USA,US-MI,44.272,-86.247,9000,2497
+G-MBS,Saginaw,,,gleam_basin,,W-NA,,US,USA,US-MI,43.533,-84.08,119000,2501
+G-MBT,Masbate,,,gleam_basin,,W-AS,,PH,PHL,,12.37,123.63,47000,621
+G-MCE,Merced,,,gleam_basin,,W-NA,,US,USA,US-CA,37.285,-120.514,144000,2466
 G-MCG,Mcgrath,,,gleam_basin,,W-NA,,US,USA,US-AK,62.953,-155.606,,2469
-G-MCI,Kansas City,,,gleam_basin,,W-NA,,US,USA,US-MO,39.298,-94.714,1616000.0,2465
-G-MCK,Mccook,,,gleam_basin,,W-NA,,US,USA,US-NE,40.206,-100.592,7000.0,2464
+G-MCI,Kansas City,,,gleam_basin,,W-NA,,US,USA,US-MO,39.298,-94.714,1616000,2465
+G-MCK,Mccook,,,gleam_basin,,W-NA,,US,USA,US-NE,40.206,-100.592,7000,2464
 G-MCM,Monaco,,,gleam_basin,,W-EU,,MC,MCO,,,,,3064
-G-MCN,Macon,,,gleam_basin,,W-NA,,US,USA,US-GA,32.693,-83.649,153000.0,2463
-G-MCO,Orlando,,,gleam_basin,,W-NA,,US,USA,US-FL,28.429,-81.309,1777000.0,2532
-G-MCP,Macapa,,,gleam_basin,,W-SA,,BR,BRA,,0.051,-51.072,499000.0,2029
-G-MCT,Muscat,,,gleam_basin,,W-AS,,OM,OMN,,23.593,58.284,735000.0,1784
+G-MCN,Macon,,,gleam_basin,,W-NA,,US,USA,US-GA,32.693,-83.649,153000,2463
+G-MCO,Orlando,,,gleam_basin,,W-NA,,US,USA,US-FL,28.429,-81.309,1777000,2532
+G-MCP,Macapa,,,gleam_basin,,W-SA,,BR,BRA,,0.051,-51.072,499000,2029
+G-MCT,Muscat,,,gleam_basin,,W-AS,,OM,OMN,,23.593,58.284,735000,1784
 G-MCV,Mcarthur River Mine,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-16.442,136.084,,1672
-G-MCW,Mason City,,,gleam_basin,,W-NA,,US,USA,US-IA,43.158,-93.331,26000.0,2468
-G-MCX,Makhachkala,,,gleam_basin,,W-EU,,RU,RUS,,42.817,47.652,555000.0,1915
-G-MCY,Sunshine Coast,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.603,153.091,286000.0,1671
-G-MCZ,Maceio,,,gleam_basin,,W-SA,,BR,BRA,,-9.511,-35.792,1186000.0,2027
-G-MDC,Manado,,,gleam_basin,,W-AS,,ID,IDN,,1.549,124.926,452000.0,1295
-G-MDE,Medellin,,,gleam_basin,,W-SA,,CO,COL,,6.165,-75.423,3297000.0,1396
-G-MDG,Mudanjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,44.524,129.569,1244000.0,436
-G-MDK,Mbandaka,,,gleam_basin,,W-AF,,CD,COD,,0.023,18.289,275000.0,1342
-G-MDL,Mandalay,,,gleam_basin,,W-AS,,MM,MMR,,21.702,95.978,1300000.0,884
-G-MDQ,Mar del Plata,,,gleam_basin,,W-SA,,AR,ARG,,-37.934,-57.573,556000.0,3210
-G-MDT,Harrisburg,,,gleam_basin,,W-NA,,US,USA,US-PA,40.194,-76.763,442000.0,2406
-G-MDU,Mendi,,,gleam_basin,,W-OC,,PG,PNG,,-6.148,143.657,26000.0,2994
-G-MDZ,Mendoza,,,gleam_basin,,W-SA,,AR,ARG,,-32.832,-68.793,893000.0,3204
-G-MEA,Macae,,,gleam_basin,,W-SA,,BR,BRA,,-22.343,-41.766,143000.0,1997
-G-MEC,Manta,,,gleam_basin,,W-SA,,EC,ECU,,-0.946,-80.679,183000.0,1469
+G-MCW,Mason City,,,gleam_basin,,W-NA,,US,USA,US-IA,43.158,-93.331,26000,2468
+G-MCX,Makhachkala,,,gleam_basin,,W-EU,,RU,RUS,,42.817,47.652,555000,1915
+G-MCY,Sunshine Coast,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.603,153.091,286000,1671
+G-MCZ,Maceio,,,gleam_basin,,W-SA,,BR,BRA,,-9.511,-35.792,1186000,2027
+G-MDC,Manado,,,gleam_basin,,W-AS,,ID,IDN,,1.549,124.926,452000,1295
+G-MDE,Medellin,,,gleam_basin,,W-SA,,CO,COL,,6.165,-75.423,3297000,1396
+G-MDG,Mudanjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,44.524,129.569,1244000,436
+G-MDK,Mbandaka,,,gleam_basin,,W-AF,,CD,COD,,0.023,18.289,275000,1342
+G-MDL,Mandalay,,,gleam_basin,,W-AS,,MM,MMR,,21.702,95.978,1300000,884
+G-MDQ,Mar del Plata,,,gleam_basin,,W-SA,,AR,ARG,,-37.934,-57.573,556000,3210
+G-MDT,Harrisburg,,,gleam_basin,,W-NA,,US,USA,US-PA,40.194,-76.763,442000,2406
+G-MDU,Mendi,,,gleam_basin,,W-OC,,PG,PNG,,-6.148,143.657,26000,2994
+G-MDZ,Mendoza,,,gleam_basin,,W-SA,,AR,ARG,,-32.832,-68.793,893000,3204
+G-MEA,Macae,,,gleam_basin,,W-SA,,BR,BRA,,-22.343,-41.766,143000,1997
+G-MEC,Manta,,,gleam_basin,,W-SA,,EC,ECU,,-0.946,-80.679,183000,1469
 G-MED,Madinah,,,gleam_basin,,W-AS,,SA,SAU,,24.553,39.705,,252
 G-MEE,Mare,,,gleam_basin,,W-OC,,NC,NCL,,-21.482,168.038,,3174
 G-MEG,Malange,,,gleam_basin,,W-AF,,AO,AGO,,-9.525,16.312,,9
-G-MEI,Meridian,,,gleam_basin,,W-NA,,US,USA,US-ID,32.333,-88.752,100000.0,2377
+G-MEI,Meridian,,,gleam_basin,,W-NA,,US,USA,US-ID,32.333,-88.752,100000,2377
 G-MEL,Melbourne (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-37.673,144.843,,1648
-G-MEM,Memphis,,,gleam_basin,,W-NA,,US,USA,US-TN,35.042,-89.977,1069000.0,2316
+G-MEM,Memphis,,,gleam_basin,,W-NA,,US,USA,US-TN,35.042,-89.977,1069000,2316
 G-MEQ,Cut Nyak Dien,,,gleam_basin,,W-AS,,ID,IDN,,4.25,96.217,,1289
-G-MES,Medan,,,gleam_basin,,W-AS,,ID,IDN,,3.559,98.671,2115000.0,1290
-G-MEX,Mexico City,,,gleam_basin,,W-NA,,MX,MEX,,19.436,-99.072,19028000.0,1024
-G-MFE,Mcallen,,,gleam_basin,,W-NA,,US,USA,US-TX,26.176,-98.239,801000.0,2462
-G-MFR,Medford,,,gleam_basin,,W-NA,,US,USA,US-OR,42.374,-122.873,168000.0,2473
+G-MES,Medan,,,gleam_basin,,W-AS,,ID,IDN,,3.559,98.671,2115000,1290
+G-MEX,Mexico City,,,gleam_basin,,W-NA,,MX,MEX,,19.436,-99.072,19028000,1024
+G-MFE,Mcallen,,,gleam_basin,,W-NA,,US,USA,US-TX,26.176,-98.239,801000,2462
+G-MFR,Medford,,,gleam_basin,,W-NA,,US,USA,US-OR,42.374,-122.873,168000,2473
 G-MFU,Mfuwe,,,gleam_basin,,W-AF,,ZM,ZMB,,-13.259,31.937,,1550
-G-MGA,Managua,,,gleam_basin,,W-NA,,NI,NIC,,12.142,-86.168,920000.0,654
-G-MGB,Mount Gambier,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-37.746,140.785,23000.0,1646
-G-MGF,Maringa,,,gleam_basin,,W-SA,,BR,BRA,,-23.479,-52.012,328000.0,2000
-G-MGM,Montgomery,,,gleam_basin,,W-NA,,US,USA,US-AL,32.301,-86.394,256000.0,2315
-G-MGQ,Mogadishu,,,gleam_basin,,W-AF,,SO,SOM,,2.014,45.305,1100000.0,2831
+G-MGA,Managua,,,gleam_basin,,W-NA,,NI,NIC,,12.142,-86.168,920000,654
+G-MGB,Mount Gambier,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-37.746,140.785,23000,1646
+G-MGF,Maringa,,,gleam_basin,,W-SA,,BR,BRA,,-23.479,-52.012,328000,2000
+G-MGM,Montgomery,,,gleam_basin,,W-NA,,US,USA,US-AL,32.301,-86.394,256000,2315
+G-MGQ,Mogadishu,,,gleam_basin,,W-AF,,SO,SOM,,2.014,45.305,1100000,2831
 G-MGS,Mangaia Island,,,gleam_basin,,W-OC,,CK,COK,,-21.896,-157.907,,1356
 G-MGT,Milingimbi Island,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.094,134.894,,1636
-G-MGW,Morgantown,,,gleam_basin,,W-NA,,US,USA,US-WV,39.643,-79.916,72000.0,2317
-G-MGZ,Myeik,,,gleam_basin,,W-AS,,MM,MMR,,12.44,98.621,267000.0,878
-G-MHC,Castro,,,gleam_basin,,W-SA,,CL,CHL,,-42.34,-73.716,42000.0,300
-G-MHD,Mashhad,,,gleam_basin,,W-AS,,IR,IRN,,36.235,59.641,2469000.0,2955
+G-MGW,Morgantown,,,gleam_basin,,W-NA,,US,USA,US-WV,39.643,-79.916,72000,2317
+G-MGZ,Myeik,,,gleam_basin,,W-AS,,MM,MMR,,12.44,98.621,267000,878
+G-MHC,Castro,,,gleam_basin,,W-SA,,CL,CHL,,-42.34,-73.716,42000,300
+G-MHD,Mashhad,,,gleam_basin,,W-AS,,IR,IRN,,36.235,59.641,2469000,2955
 G-MHH,Marsh Harbour,,,gleam_basin,,W-NA,,BS,BHS,,26.511,-77.084,,3231
-G-MHK,Manhattan,,,gleam_basin,,W-NA,,US,USA,US-NY,39.141,-96.671,312000.0,2344
-G-MHQ,Mariehamn,,,gleam_basin,,W-EU,,AX,ALA,,60.122,19.898,11000.0,1788
+G-MHK,Manhattan,,,gleam_basin,,W-NA,,US,USA,US-NY,39.141,-96.671,312000,2344
+G-MHQ,Mariehamn,,,gleam_basin,,W-EU,,AX,ALA,,60.122,19.898,11000,1788
 G-MHU,Mount Hotham,,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-37.048,147.334,,1676
-G-MIA,Miami,,,gleam_basin,,W-NA,,US,USA,US-FL,25.793,-80.291,6382000.0,2305
+G-MIA,Miami,,,gleam_basin,,W-NA,,US,USA,US-FL,25.793,-80.291,6382000,2305
 G-MID,Merida (MX),,,gleam_basin,,W-NA,,MX,MEX,,20.937,-89.658,,1015
-G-MIG,Mianyang,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,31.428,104.741,1396000.0,405
-G-MII,Marilia,,,gleam_basin,,W-SA,,BR,BRA,,-22.197,-49.926,212000.0,1964
-G-MIM,Merimbula,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.909,149.901,6000.0,1609
+G-MIG,Mianyang,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,31.428,104.741,1396000,405
+G-MII,Marilia,,,gleam_basin,,W-SA,,BR,BRA,,-22.197,-49.926,212000,1964
+G-MIM,Merimbula,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.909,149.901,6000,1609
 G-MIS,Misima Island,,,gleam_basin,,W-OC,,PG,PNG,,-10.689,152.838,,2990
-G-MIU,Maiduguri,,,gleam_basin,,W-AF,,NG,NGA,,11.855,13.081,896000.0,1419
-G-MJD,Mohenjodaro,,,gleam_basin,,W-AS,,PK,PAK,,27.335,68.143,4500000.0,122
+G-MIU,Maiduguri,,,gleam_basin,,W-AF,,NG,NGA,,11.855,13.081,896000,1419
+G-MJD,Mohenjodaro,,,gleam_basin,,W-AS,,PK,PAK,,27.335,68.143,4500000,122
 G-MJF,Mosjoen,,,gleam_basin,,W-EU,,NO,NOR,,65.784,13.215,,1151
-G-MJM,Mbuji-Mayi,,,gleam_basin,,W-AF,,CD,COD,,-6.121,23.569,1295000.0,1339
-G-MJN,Mahajanga,,,gleam_basin,,W-AF,,MG,MDG,,-15.667,46.351,155000.0,1450
-G-MJT,Mytilini,,,gleam_basin,,W-EU,,GR,GRC,,39.057,26.598,29000.0,936
+G-MJM,Mbuji-Mayi,,,gleam_basin,,W-AF,,CD,COD,,-6.121,23.569,1295000,1339
+G-MJN,Mahajanga,,,gleam_basin,,W-AF,,MG,MDG,,-15.667,46.351,155000,1450
+G-MJT,Mytilini,,,gleam_basin,,W-EU,,GR,GRC,,39.057,26.598,29000,936
 G-MJU,Mamuju,,,gleam_basin,,W-AS,,ID,IDN,,,,,1267
-G-MJV,Murcia,,,gleam_basin,,W-EU,,ES,ESP,,37.775,-0.812,407000.0,2897
-G-MJZ,Mirny,,,gleam_basin,,W-EU,,RU,RUS,,62.535,114.039,40000.0,1857
-G-MKE,Milwaukee,,,gleam_basin,,W-NA,,US,USA,US-WI,42.947,-87.897,1378000.0,2288
-G-MKG,Muskegon,,,gleam_basin,,W-NA,,US,USA,US-MI,43.169,-86.238,160000.0,2286
+G-MJV,Murcia,,,gleam_basin,,W-EU,,ES,ESP,,37.775,-0.812,407000,2897
+G-MJZ,Mirny,,,gleam_basin,,W-EU,,RU,RUS,,62.535,114.039,40000,1857
+G-MKE,Milwaukee,,,gleam_basin,,W-NA,,US,USA,US-WI,42.947,-87.897,1378000,2288
+G-MKG,Muskegon,,,gleam_basin,,W-NA,,US,USA,US-MI,43.169,-86.238,160000,2286
 G-MKL,Jackson (US-TN),,,gleam_basin,,W-NA,,US,USA,US-TN,35.6,-88.916,,2269
 G-MKM,Mukah,,,gleam_basin,,W-AS,,MY,MYS,,2.906,112.08,,174
 G-MKP,Makemo,,,gleam_basin,,W-OC,,PF,PYF,,-16.584,-143.658,,690
-G-MKQ,Merauke,,,gleam_basin,,W-AS,,ID,IDN,,-8.52,140.418,34000.0,1271
-G-MKW,Manokwari,,,gleam_basin,,W-AS,,ID,IDN,,-0.892,134.049,75000.0,1272
-G-MKY,Mackay,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-21.172,149.18,76000.0,1629
-G-MKZ,Malacca,,,gleam_basin,,W-AS,,MY,MYS,,2.263,102.252,181000.0,175
+G-MKQ,Merauke,,,gleam_basin,,W-AS,,ID,IDN,,-8.52,140.418,34000,1271
+G-MKW,Manokwari,,,gleam_basin,,W-AS,,ID,IDN,,-0.892,134.049,75000,1272
+G-MKY,Mackay,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-21.172,149.18,76000,1629
+G-MKZ,Malacca,,,gleam_basin,,W-AS,,MY,MYS,,2.263,102.252,181000,175
 G-MLA,Malta,,,gleam_basin,,W-EU,,MT,MLT,,,,,655
 G-MLB,Melbourne (US),,,gleam_basin,,W-NA,,US,USA,US-FL,28.103,-80.645,,2133
-G-MLE,Male,,,gleam_basin,,W-AS,,MV,MDV,,4.192,73.529,113000.0,1479
-G-MLG,Malang,,,gleam_basin,,W-AS,,ID,IDN,,-7.927,112.715,805000.0,1252
-G-MLI,Moline,,,gleam_basin,,W-NA,,US,USA,US-IL,41.449,-90.507,42000.0,2218
-G-MLM,Morelia,,,gleam_basin,,W-NA,,MX,MEX,,19.85,-101.025,644000.0,1000
-G-MLN,Melilla,,,gleam_basin,,W-EU,,ES,ESP,,35.28,-2.956,73000.0,2878
+G-MLE,Male,,,gleam_basin,,W-AS,,MV,MDV,,4.192,73.529,113000,1479
+G-MLG,Malang,,,gleam_basin,,W-AS,,ID,IDN,,-7.927,112.715,805000,1252
+G-MLI,Moline,,,gleam_basin,,W-NA,,US,USA,US-IL,41.449,-90.507,42000,2218
+G-MLM,Morelia,,,gleam_basin,,W-NA,,MX,MEX,,19.85,-101.025,644000,1000
+G-MLN,Melilla,,,gleam_basin,,W-EU,,ES,ESP,,35.28,-2.956,73000,2878
 G-MLO,Milos,,,gleam_basin,,W-EU,,GR,GRC,,36.697,24.477,,908
-G-MLS,Miles City,,,gleam_basin,,W-NA,,US,USA,US-MT,46.428,-105.886,10000.0,2142
-G-MLU,Monroe,,,gleam_basin,,W-NA,,US,USA,US-LA,32.511,-92.038,115000.0,2219
-G-MLX,Malatya,,,gleam_basin,,W-AS,,TR,TUR,,38.435,38.091,462000.0,1757
+G-MLS,Miles City,,,gleam_basin,,W-NA,,US,USA,US-MT,46.428,-105.886,10000,2142
+G-MLU,Monroe,,,gleam_basin,,W-NA,,US,USA,US-LA,32.511,-92.038,115000,2219
+G-MLX,Malatya,,,gleam_basin,,W-AS,,TR,TUR,,38.435,38.091,462000,1757
 G-MLY,Manley Hot Springs,,,gleam_basin,,W-NA,,US,USA,US-AK,64.998,-150.644,,2147
 G-MMB,Memambetsu,,,gleam_basin,,W-AS,,JP,JPN,,43.881,144.164,,3114
-G-MME,Durham,,,gleam_basin,,W-EU,,GB,GBR,,54.509,-1.429,408000.0,769
-G-MMH,Mammoth Lakes,,,gleam_basin,,W-NA,,US,USA,US-CA,37.624,-118.838,8000.0,2184
-G-MMJ,Matsumoto,,,gleam_basin,,W-AS,,JP,JPN,,36.167,137.923,211000.0,3113
-G-MMK,Murmansk,,,gleam_basin,,W-EU,,RU,RUS,,68.782,32.751,319000.0,1822
-G-MMX,Malmo,,,gleam_basin,,W-EU,,SE,SWE,,55.536,13.376,269000.0,2547
-G-MMY,Miyako,,,gleam_basin,,W-AS,,JP,JPN,,24.783,125.295,52000.0,3112
-G-MMZ,Maimanah,,,gleam_basin,,W-AS,,AF,AFG,,35.931,64.761,200000.0,888
+G-MME,Durham,,,gleam_basin,,W-EU,,GB,GBR,,54.509,-1.429,408000,769
+G-MMH,Mammoth Lakes,,,gleam_basin,,W-NA,,US,USA,US-CA,37.624,-118.838,8000,2184
+G-MMJ,Matsumoto,,,gleam_basin,,W-AS,,JP,JPN,,36.167,137.923,211000,3113
+G-MMK,Murmansk,,,gleam_basin,,W-EU,,RU,RUS,,68.782,32.751,319000,1822
+G-MMX,Malmo,,,gleam_basin,,W-EU,,SE,SWE,,55.536,13.376,269000,2547
+G-MMY,Miyako,,,gleam_basin,,W-AS,,JP,JPN,,24.783,125.295,52000,3112
+G-MMZ,Maimanah,,,gleam_basin,,W-AS,,AF,AFG,,35.931,64.761,200000,888
 G-MNA,Melangguane,,,gleam_basin,,W-AS,,ID,IDN,,4.007,126.673,,1253
-G-MNC,Nacala,,,gleam_basin,,W-AF,,MZ,MOZ,,-14.488,40.712,225000.0,965
+G-MNC,Nacala,,,gleam_basin,,W-AF,,MZ,MOZ,,-14.488,40.712,225000,965
 G-MNG,Maningrida,,,gleam_basin,,W-OC,,AU,AUS,AU-NT,-12.056,134.234,,1592
 G-MNI,Montserrat,,,gleam_basin,,W-NA,,MS,MSR,,,,,722
-G-MNL,Manila,,,gleam_basin,,W-AS,,PH,PHL,,14.509,121.02,11100000.0,596
-G-MNR,Mongu,,,gleam_basin,,W-AF,,ZM,ZMB,,-15.255,23.162,53000.0,1546
-G-MNS,Mansa,,,gleam_basin,,W-AF,,ZM,ZMB,,-11.137,28.873,42000.0,1547
-G-MNT,Minto,,,gleam_basin,,W-NA,,US,USA,US-CO,,,600.0,2138
-G-MNU,Mawlamyine,,,gleam_basin,,W-AS,,MM,MMR,,16.445,97.661,439000.0,871
+G-MNL,Manila,,,gleam_basin,,W-AS,,PH,PHL,,14.509,121.02,11100000,596
+G-MNR,Mongu,,,gleam_basin,,W-AF,,ZM,ZMB,,-15.255,23.162,53000,1546
+G-MNS,Mansa,,,gleam_basin,,W-AF,,ZM,ZMB,,-11.137,28.873,42000,1547
+G-MNT,Minto,,,gleam_basin,,W-NA,,US,USA,US-CO,,,600,2138
+G-MNU,Mawlamyine,,,gleam_basin,,W-AS,,MM,MMR,,16.445,97.661,439000,871
 G-MNY,Mono Island,,,gleam_basin,,W-OC,,SB,SLB,,-7.417,155.565,,3021
-G-MOA,Moa,,,gleam_basin,,W-NA,,CU,CUB,,20.654,-74.922,93000.0,3240
-G-MOB,Mobile,,,gleam_basin,,W-NA,,US,USA,US-AL,30.691,-88.243,318000.0,2118
-G-MOC,Montes Claros,,,gleam_basin,,W-SA,,BR,BRA,,-16.707,-43.819,332000.0,1951
-G-MOF,Maumere,,,gleam_basin,,W-AS,,ID,IDN,,-8.641,122.237,104000.0,1247
-G-MOL,Molde,,,gleam_basin,,W-EU,,NO,NOR,,62.745,7.262,19000.0,1156
+G-MOA,Moa,,,gleam_basin,,W-NA,,CU,CUB,,20.654,-74.922,93000,3240
+G-MOB,Mobile,,,gleam_basin,,W-NA,,US,USA,US-AL,30.691,-88.243,318000,2118
+G-MOC,Montes Claros,,,gleam_basin,,W-SA,,BR,BRA,,-16.707,-43.819,332000,1951
+G-MOF,Maumere,,,gleam_basin,,W-AS,,ID,IDN,,-8.641,122.237,104000,1247
+G-MOL,Molde,,,gleam_basin,,W-EU,,NO,NOR,,62.745,7.262,19000,1156
 G-MON,Mount Cook,,,gleam_basin,,W-OC,,NZ,NZL,,-43.765,170.133,,3045
-G-MOQ,Morondava,,,gleam_basin,,W-AF,,MG,MDG,,-20.285,44.318,37000.0,1444
-G-MOT,Minot,,,gleam_basin,,W-NA,,US,USA,US-ND,48.259,-101.28,50000.0,2117
-G-MOV,Moranbah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.058,148.077,10000.0,1587
-G-MPA,Katima Mulilo,,,gleam_basin,,W-AF,,NA,NAM,,-17.634,24.177,25000.0,75
+G-MOQ,Morondava,,,gleam_basin,,W-AF,,MG,MDG,,-20.285,44.318,37000,1444
+G-MOT,Minot,,,gleam_basin,,W-NA,,US,USA,US-ND,48.259,-101.28,50000,2117
+G-MOV,Moranbah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.058,148.077,10000,1587
+G-MPA,Katima Mulilo,,,gleam_basin,,W-AF,,NA,NAM,,-17.634,24.177,25000,75
 G-MPH,Caticlan,,,gleam_basin,,W-AS,,PH,PHL,,11.925,121.954,,597
-G-MPL,Montpellier,,,gleam_basin,,W-EU,,FR,FRA,,43.576,3.963,327000.0,1506
-G-MPM,Maputo,,,gleam_basin,,W-AF,,MZ,MOZ,,-25.921,32.573,1446000.0,966
-G-MPN,Mount Pleasant,,,gleam_basin,,W-SA,,FK,FLK,,-51.823,-58.447,87000.0,759
-G-MQF,Magnitogorsk,,,gleam_basin,,W-EU,,RU,RUS,,53.393,58.756,413000.0,1811
+G-MPL,Montpellier,,,gleam_basin,,W-EU,,FR,FRA,,43.576,3.963,327000,1506
+G-MPM,Maputo,,,gleam_basin,,W-AF,,MZ,MOZ,,-25.921,32.573,1446000,966
+G-MPN,Mount Pleasant,,,gleam_basin,,W-SA,,FK,FLK,,-51.823,-58.447,87000,759
+G-MQF,Magnitogorsk,,,gleam_basin,,W-EU,,RU,RUS,,53.393,58.756,413000,1811
 G-MQJ,Khonuu,,,gleam_basin,,W-EU,,RU,RUS,,66.451,143.262,,1812
-G-MQL,Mildura,,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-34.229,142.086,48000.0,1583
-G-MQM,Mardin,,,gleam_basin,,W-AS,,TR,TUR,,37.223,40.632,71000.0,1744
-G-MQN,Mo I Rana,,,gleam_basin,,W-EU,,NO,NOR,,66.364,14.301,20000.0,1166
-G-MQP,Nelspruit,,,gleam_basin,,W-AF,,ZA,ZAF,,-25.383,31.106,110000.0,628
-G-MQT,Marquette,,,gleam_basin,,W-NA,,US,USA,US-MI,46.354,-87.395,26000.0,2108
-G-MQX,Mekele,,,gleam_basin,,W-AF,,ET,ETH,,13.467,39.534,96000.0,226
+G-MQL,Mildura,,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-34.229,142.086,48000,1583
+G-MQM,Mardin,,,gleam_basin,,W-AS,,TR,TUR,,37.223,40.632,71000,1744
+G-MQN,Mo I Rana,,,gleam_basin,,W-EU,,NO,NOR,,66.364,14.301,20000,1166
+G-MQP,Nelspruit,,,gleam_basin,,W-AF,,ZA,ZAF,,-25.383,31.106,110000,628
+G-MQT,Marquette,,,gleam_basin,,W-NA,,US,USA,US-MI,46.354,-87.395,26000,2108
+G-MQX,Mekele,,,gleam_basin,,W-AF,,ET,ETH,,13.467,39.534,96000,226
 G-MRA,Misurata,,,gleam_basin,,W-AF,,LY,LBY,,,,,159
 G-MRD,Merida (VE),,,gleam_basin,,W-SA,,VE,VEN,,8.582,-71.161,,1706
 G-MRE,Masai Mara,,,gleam_basin,,W-AF,,KE,KEN,,-1.406,35.008,,1728
-G-MRO,Masterton,,,gleam_basin,,W-OC,,NZ,NZL,,-40.973,175.634,20000.0,3050
+G-MRO,Masterton,,,gleam_basin,,W-OC,,NZ,NZL,,-40.973,175.634,20000,3050
 G-MRQ,Marinduque,,,gleam_basin,,W-AS,,PH,PHL,,13.361,121.826,,590
-G-MRS,Marseille,,,gleam_basin,,W-EU,,FR,FRA,,43.439,5.221,1400000.0,1503
+G-MRS,Marseille,,,gleam_basin,,W-EU,,FR,FRA,,43.439,5.221,1400000,1503
 G-MRU,Mauritius,,,gleam_basin,,W-AF,,MU,MUS,,,,,1196
-G-MRV,Mineralnye Vody,,,gleam_basin,,W-EU,,RU,RUS,,44.225,43.082,76000.0,1805
+G-MRV,Mineralnye Vody,,,gleam_basin,,W-EU,,RU,RUS,,44.225,43.082,76000,1805
 G-MRX,Bandar Mahshahr,,,gleam_basin,,W-AS,,IR,IRN,,30.556,49.152,,2929
-G-MRY,Monterey,,,gleam_basin,,W-NA,,US,USA,US-CA,36.587,-121.843,29000.0,2075
-G-MRZ,Moree,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-29.499,149.845,8000.0,1617
+G-MRY,Monterey,,,gleam_basin,,W-NA,,US,USA,US-CA,36.587,-121.843,29000,2075
+G-MRZ,Moree,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-29.499,149.845,8000,1617
 G-MSA,Muskrat Dam,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.441,-91.763,,2778
 G-MSE,Manston,,,gleam_basin,,W-EU,,GB,GBR,,51.342,1.346,,792
-G-MSJ,Misawa,,,gleam_basin,,W-AS,,JP,JPN,,40.703,141.368,43000.0,3160
-G-MSL,Muscle Shoals,,,gleam_basin,,W-NA,,US,USA,US-AL,34.745,-87.61,14000.0,2491
-G-MSN,Madison,,,gleam_basin,,W-NA,,US,USA,US-WI,43.14,-89.338,440000.0,2530
-G-MSO,Missoula,,,gleam_basin,,W-NA,,US,USA,US-MT,46.916,-114.091,90000.0,2529
-G-MSP,Minneapolis,,,gleam_basin,,W-NA,,US,USA,US-MN,44.882,-93.222,2927000.0,2528
-G-MSQ,Minsk,,,gleam_basin,,W-EU,,BY,BLR,,53.882,28.031,1805000.0,905
-G-MSR,Mus,,,gleam_basin,,W-AS,,TR,TUR,,38.748,41.661,83000.0,1781
-G-MSS,Massena,,,gleam_basin,,W-NA,,US,USA,US-NY,44.936,-74.846,11000.0,2527
-G-MST,Maastricht,,,gleam_basin,,W-EU,,NL,NLD,,50.912,5.77,122000.0,838
-G-MSU,Maseru,,,gleam_basin,,W-AF,,LS,LSO,,-29.462,27.552,361000.0,829
-G-MSW,Massawa,,,gleam_basin,,W-AF,,ER,ERI,,15.67,39.37,143000.0,2849
-G-MSY,New Orleans,,,gleam_basin,,W-NA,,US,USA,US-LA,29.993,-90.258,1028999.0,2524
-G-MSZ,Namibe,,,gleam_basin,,W-AF,,AO,AGO,,-15.261,12.147,133000.0,13
-G-MTJ,Montrose,,,gleam_basin,,W-NA,,US,USA,US-CO,38.51,-107.894,23000.0,2502
-G-MTR,Monteria,,,gleam_basin,,W-SA,,CO,COL,,8.824,-75.826,275000.0,1405
-G-MTS,Manzini,,,gleam_basin,,W-AF,,SZ,SWZ,,-26.529,31.308,111000.0,2580
-G-MTT,Minatitlan,,,gleam_basin,,W-NA,,MX,MEX,,18.103,-94.581,202000.0,1033
-G-MTY,Monterrey,,,gleam_basin,,W-NA,,MX,MEX,,25.778,-100.107,3712000.0,1032
+G-MSJ,Misawa,,,gleam_basin,,W-AS,,JP,JPN,,40.703,141.368,43000,3160
+G-MSL,Muscle Shoals,,,gleam_basin,,W-NA,,US,USA,US-AL,34.745,-87.61,14000,2491
+G-MSN,Madison,,,gleam_basin,,W-NA,,US,USA,US-WI,43.14,-89.338,440000,2530
+G-MSO,Missoula,,,gleam_basin,,W-NA,,US,USA,US-MT,46.916,-114.091,90000,2529
+G-MSP,Minneapolis,,,gleam_basin,,W-NA,,US,USA,US-MN,44.882,-93.222,2927000,2528
+G-MSQ,Minsk,,,gleam_basin,,W-EU,,BY,BLR,,53.882,28.031,1805000,905
+G-MSR,Mus,,,gleam_basin,,W-AS,,TR,TUR,,38.748,41.661,83000,1781
+G-MSS,Massena,,,gleam_basin,,W-NA,,US,USA,US-NY,44.936,-74.846,11000,2527
+G-MST,Maastricht,,,gleam_basin,,W-EU,,NL,NLD,,50.912,5.77,122000,838
+G-MSU,Maseru,,,gleam_basin,,W-AF,,LS,LSO,,-29.462,27.552,361000,829
+G-MSW,Massawa,,,gleam_basin,,W-AF,,ER,ERI,,15.67,39.37,143000,2849
+G-MSY,New Orleans,,,gleam_basin,,W-NA,,US,USA,US-LA,29.993,-90.258,1028999,2524
+G-MSZ,Namibe,,,gleam_basin,,W-AF,,AO,AGO,,-15.261,12.147,133000,13
+G-MTJ,Montrose,,,gleam_basin,,W-NA,,US,USA,US-CO,38.51,-107.894,23000,2502
+G-MTR,Monteria,,,gleam_basin,,W-SA,,CO,COL,,8.824,-75.826,275000,1405
+G-MTS,Manzini,,,gleam_basin,,W-AF,,SZ,SWZ,,-26.529,31.308,111000,2580
+G-MTT,Minatitlan,,,gleam_basin,,W-NA,,MX,MEX,,18.103,-94.581,202000,1033
+G-MTY,Monterrey,,,gleam_basin,,W-NA,,MX,MEX,,25.778,-100.107,3712000,1032
 G-MUA,Munda,,,gleam_basin,,W-OC,,SB,SLB,,-8.328,157.263,,3035
-G-MUB,Maun,,,gleam_basin,,W-AF,,BW,BWA,,-19.973,23.431,50000.0,217
-G-MUC,Munich,,,gleam_basin,,W-EU,,DE,DEU,,48.354,11.786,1275000.0,748
-G-MUH,Mersa Matruh,,,gleam_basin,,W-AF,,EG,EGY,,31.325,27.222,62000.0,48
-G-MUN,Maturin,,,gleam_basin,,W-SA,,VE,VEN,,9.755,-63.147,411000.0,1719
-G-MUW,Mascara,,,gleam_basin,,W-AF,,DZ,DZA,,35.208,0.147,108000.0,44
-G-MUX,Multan,,,gleam_basin,,W-AS,,PK,PAK,,30.203,71.419,12600000.0,131
-G-MVD,Montevideo,,,gleam_basin,,W-SA,,UY,URY,,-34.838,-56.031,1513000.0,519
-G-MVP,Mitu,,,gleam_basin,,W-SA,,CO,COL,,1.254,-70.234,6000.0,1393
-G-MVR,Maroua,,,gleam_basin,,W-AF,,CM,CMR,,10.451,14.257,320000.0,809
+G-MUB,Maun,,,gleam_basin,,W-AF,,BW,BWA,,-19.973,23.431,50000,217
+G-MUC,Munich,,,gleam_basin,,W-EU,,DE,DEU,,48.354,11.786,1275000,748
+G-MUH,Mersa Matruh,,,gleam_basin,,W-AF,,EG,EGY,,31.325,27.222,62000,48
+G-MUN,Maturin,,,gleam_basin,,W-SA,,VE,VEN,,9.755,-63.147,411000,1719
+G-MUW,Mascara,,,gleam_basin,,W-AF,,DZ,DZA,,35.208,0.147,108000,44
+G-MUX,Multan,,,gleam_basin,,W-AS,,PK,PAK,,30.203,71.419,12600000,131
+G-MVD,Montevideo,,,gleam_basin,,W-SA,,UY,URY,,-34.838,-56.031,1513000,519
+G-MVP,Mitu,,,gleam_basin,,W-SA,,CO,COL,,1.254,-70.234,6000,1393
+G-MVR,Maroua,,,gleam_basin,,W-AF,,CM,CMR,,10.451,14.257,320000,809
 G-MVT,Mataiva,,,gleam_basin,,W-OC,,PF,PYF,,-14.868,-148.717,,707
-G-MWA,Marion,,,gleam_basin,,W-NA,,US,USA,US-OH,37.755,-89.011,45000.0,2140
-G-MWX,Muan,,,gleam_basin,,W-AS,,KR,KOR,,34.991,126.383,76000.0,2799
-G-MWZ,Mwanza,,,gleam_basin,,W-AF,,TZ,TZA,,-2.444,32.933,494000.0,211
-G-MXH,Moro,,,gleam_basin,,W-OC,,PG,PNG,,-6.363,143.238,77000.0,2991
-G-MXL,Mexicali,,,gleam_basin,,W-NA,,MX,MEX,,32.631,-115.242,885000.0,1027
-G-MXP,Milan,,,gleam_basin,,W-EU,,IT,ITA,,45.631,8.728,2945000.0,3093
-G-MXV,Moron,,,gleam_basin,,W-AS,,MN,MNG,,49.663,100.099,66000.0,852
-G-MXX,Mora,,,gleam_basin,,W-EU,,SE,SWE,,60.958,14.511,55000.0,2564
+G-MWA,Marion,,,gleam_basin,,W-NA,,US,USA,US-OH,37.755,-89.011,45000,2140
+G-MWX,Muan,,,gleam_basin,,W-AS,,KR,KOR,,34.991,126.383,76000,2799
+G-MWZ,Mwanza,,,gleam_basin,,W-AF,,TZ,TZA,,-2.444,32.933,494000,211
+G-MXH,Moro,,,gleam_basin,,W-OC,,PG,PNG,,-6.363,143.238,77000,2991
+G-MXL,Mexicali,,,gleam_basin,,W-NA,,MX,MEX,,32.631,-115.242,885000,1027
+G-MXP,Milan,,,gleam_basin,,W-EU,,IT,ITA,,45.631,8.728,2945000,3093
+G-MXV,Moron,,,gleam_basin,,W-AS,,MN,MNG,,49.663,100.099,66000,852
+G-MXX,Mora,,,gleam_basin,,W-EU,,SE,SWE,,60.958,14.511,55000,2564
 G-MXZ,Meixian,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,24.35,116.133,,447
 G-MYA,Moruya,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-35.898,150.144,,1644
-G-MYD,Malindi,,,gleam_basin,,W-AF,,KE,KEN,,-3.229,40.102,94000.0,1730
+G-MYD,Malindi,,,gleam_basin,,W-AF,,KE,KEN,,-3.229,40.102,94000,1730
 G-MYE,Miyakejima,,,gleam_basin,,W-AS,,JP,JPN,,34.074,139.56,,3138
 G-MYG,Mayaguana,,,gleam_basin,,W-NA,,BS,BHS,,22.379,-73.013,,3225
-G-MYJ,Matsuyama,,,gleam_basin,,W-AS,,JP,JPN,,33.827,132.7,534000.0,3137
-G-MYQ,Mysore,,,gleam_basin,,W-AS,,IN,IND,,12.23,76.656,887000.0,1097
-G-MYR,Myrtle Beach,,,gleam_basin,,W-NA,,US,USA,US-SC,33.68,-78.928,260000.0,2120
-G-MYT,Myitkyina,,,gleam_basin,,W-AS,,MM,MMR,,25.384,97.352,139000.0,883
+G-MYJ,Matsuyama,,,gleam_basin,,W-AS,,JP,JPN,,33.827,132.7,534000,3137
+G-MYQ,Mysore,,,gleam_basin,,W-AS,,IN,IND,,12.23,76.656,887000,1097
+G-MYR,Myrtle Beach,,,gleam_basin,,W-NA,,US,USA,US-SC,33.68,-78.928,260000,2120
+G-MYT,Myitkyina,,,gleam_basin,,W-AS,,MM,MMR,,25.384,97.352,139000,883
 G-MYU,Mekoryuk,,,gleam_basin,,W-NA,,US,USA,US-AK,60.371,-166.271,,2361
-G-MYW,Mtwara,,,gleam_basin,,W-AF,,TZ,TZA,,-10.339,40.182,97000.0,210
-G-MYY,Miri,,,gleam_basin,,W-AS,,MY,MYS,,4.322,113.987,228000.0,192
+G-MYW,Mtwara,,,gleam_basin,,W-AF,,TZ,TZA,,-10.339,40.182,97000,210
+G-MYY,Miri,,,gleam_basin,,W-AS,,MY,MYS,,4.322,113.987,228000,192
 G-MZB,Mocimboa Da Praia,,,gleam_basin,,W-AF,,MZ,MOZ,,-11.362,40.355,,971
-G-MZG,Magong,,,gleam_basin,,W-AS,,TW,TWN,,23.569,119.628,56000.0,2827
-G-MZH,Amasya,,,gleam_basin,,W-AS,,TR,TUR,,40.829,35.522,83000.0,1773
-G-MZJ,Marana,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.511,-111.328,45000.0,2339
+G-MZG,Magong,,,gleam_basin,,W-AS,,TW,TWN,,23.569,119.628,56000,2827
+G-MZH,Amasya,,,gleam_basin,,W-AS,,TR,TUR,,40.829,35.522,83000,1773
+G-MZJ,Marana,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.511,-111.328,45000,2339
 G-MZO,Manzanillo (CU),,,gleam_basin,,W-NA,,CU,CUB,,20.288,-77.089,,3247
-G-MZR,Mazar-e Sharif,,,gleam_basin,,W-AS,,AF,AFG,,36.707,67.21,458000.0,891
-G-MZT,Mazatlan,,,gleam_basin,,W-NA,,MX,MEX,,23.161,-106.266,368000.0,1017
+G-MZR,Mazar-e Sharif,,,gleam_basin,,W-AS,,AF,AFG,,36.707,67.21,458000,891
+G-MZT,Mazatlan,,,gleam_basin,,W-NA,,MX,MEX,,23.161,-106.266,368000,1017
 G-MZV,Mulu,,,gleam_basin,,W-AS,,MY,MYS,,4.048,114.805,,184
 G-MZW,Mecheria,,,gleam_basin,,W-AF,,DZ,DZA,,33.536,-0.242,,37
-G-NAA,Narrabri,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.319,149.827,7000.0,1620
+G-NAA,Narrabri,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-30.319,149.827,7000,1620
 G-NAC,Naracoorte,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-36.985,140.725,,1585
-G-NAG,Nagpur,,,gleam_basin,,W-AS,,IN,IND,,21.092,79.047,2454000.0,1079
+G-NAG,Nagpur,,,gleam_basin,,W-AS,,IN,IND,,21.092,79.047,2454000,1079
 G-NAH,Tahuna,,,gleam_basin,,W-AS,,ID,IDN,,3.683,125.528,,1264
 G-NAJ,Nakchivan,,,gleam_basin,,W-AS,,AZ,AZE,,39.189,45.458,,2575
 G-NAL,Nalchik,,,gleam_basin,,W-EU,,RU,RUS,,43.513,43.637,,1845
-G-NAN,Nadi,,,gleam_basin,,W-OC,,FJ,FJI,,-17.755,177.443,42000.0,1184
-G-NAO,Nanchong,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.795,106.163,7150000.0,418
-G-NAP,Naples,,,gleam_basin,,W-EU,,IT,ITA,,40.886,14.291,2250000.0,3071
-G-NAQ,Qaanaaq,,,gleam_basin,,W-NA,,GL,GRL,,77.489,-69.389,1000.0,950
-G-NAS,Nassau,,,gleam_basin,,W-NA,,BS,BHS,,25.039,-77.466,228000.0,3224
-G-NAT,Natal,,,gleam_basin,,W-SA,,BR,BRA,,-5.768,-35.376,1088000.0,2002
+G-NAN,Nadi,,,gleam_basin,,W-OC,,FJ,FJI,,-17.755,177.443,42000,1184
+G-NAO,Nanchong,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,30.795,106.163,7150000,418
+G-NAP,Naples,,,gleam_basin,,W-EU,,IT,ITA,,40.886,14.291,2250000,3071
+G-NAQ,Qaanaaq,,,gleam_basin,,W-NA,,GL,GRL,,77.489,-69.389,1000,950
+G-NAS,Nassau,,,gleam_basin,,W-NA,,BS,BHS,,25.039,-77.466,228000,3224
+G-NAT,Natal,,,gleam_basin,,W-SA,,BR,BRA,,-5.768,-35.376,1088000,2002
 G-NAU,Napuka,,,gleam_basin,,W-OC,,PF,PYF,,-14.177,-141.267,,697
-G-NAV,Nevsehir,,,gleam_basin,,W-AS,,TR,TUR,,38.772,34.535,76000.0,1762
-G-NAW,Narathiwat,,,gleam_basin,,W-AS,,TH,THA,,6.52,101.743,68000.0,532
-G-NBC,Nizhnekamsk,,,gleam_basin,,W-EU,,RU,RUS,,55.565,52.092,234000.0,1818
+G-NAV,Nevsehir,,,gleam_basin,,W-AS,,TR,TUR,,38.772,34.535,76000,1762
+G-NAW,Narathiwat,,,gleam_basin,,W-AS,,TH,THA,,6.52,101.743,68000,532
+G-NBC,Nizhnekamsk,,,gleam_basin,,W-EU,,RU,RUS,,55.565,52.092,234000,1818
 G-NBE,Enfidha,,,gleam_basin,,W-AF,,TN,TUN,,36.076,10.439,,1792
-G-NBO,Nairobi,,,gleam_basin,,W-AF,,KE,KEN,,-1.319,36.928,3010000.0,1738
-G-NBS,Baishan,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,42.067,127.602,330000.0,339
-G-NBX,Nabire,,,gleam_basin,,W-AS,,ID,IDN,,-3.368,135.496,44000.0,1255
-G-NCE,Nice,,,gleam_basin,,W-EU,,FR,FRA,,43.658,7.216,927000.0,1534
-G-NCJ,Sunchales,,,gleam_basin,,W-SA,,AR,ARG,,-30.957,-61.528,13000.0,3186
+G-NBO,Nairobi,,,gleam_basin,,W-AF,,KE,KEN,,-1.319,36.928,3010000,1738
+G-NBS,Baishan,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,42.067,127.602,330000,339
+G-NBX,Nabire,,,gleam_basin,,W-AS,,ID,IDN,,-3.368,135.496,44000,1255
+G-NCE,Nice,,,gleam_basin,,W-EU,,FR,FRA,,43.658,7.216,927000,1534
+G-NCJ,Sunchales,,,gleam_basin,,W-SA,,AR,ARG,,-30.957,-61.528,13000,3186
 G-NCL,Newcastle (UK),,,gleam_basin,,W-EU,,GB,GBR,,55.037,-1.692,,770
-G-NCU,Nukus,,,gleam_basin,,W-AS,,UZ,UZB,,42.488,59.623,230000.0,2838
-G-NDB,Nouadhibou,,,gleam_basin,,W-AF,,MR,MRT,,20.933,-17.03,87000.0,282
-G-NDC,Nanded,,,gleam_basin,,W-AS,,IN,IND,,19.183,77.317,624000.0,1075
-G-NDG,Qiqihar,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,47.24,123.918,1641000.0,488
-G-NDJ,N'djamena,,,gleam_basin,,W-AF,,TD,TCD,,12.134,15.034,989000.0,840
-G-NDR,Nador,,,gleam_basin,,W-AF,,MA,MAR,,34.989,-3.028,129000.0,821
-G-NDU,Rundu,,,gleam_basin,,W-AF,,NA,NAM,,-17.956,19.719,58000.0,78
-G-NER,Neryungri,,,gleam_basin,,W-EU,,RU,RUS,,56.914,124.914,66000.0,1828
-G-NGB,Ningbo,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.827,121.462,1923000.0,407
-G-NGE,Ngaoundere,,,gleam_basin,,W-AF,,CM,CMR,,7.357,13.559,231000.0,808
-G-NGK,Nogliki,,,gleam_basin,,W-EU,,RU,RUS,,51.78,143.139,10000.0,1801
-G-NGO,Nagoya,,,gleam_basin,,W-AS,,JP,JPN,,34.858,136.805,3230000.0,3141
+G-NCU,Nukus,,,gleam_basin,,W-AS,,UZ,UZB,,42.488,59.623,230000,2838
+G-NDB,Nouadhibou,,,gleam_basin,,W-AF,,MR,MRT,,20.933,-17.03,87000,282
+G-NDC,Nanded,,,gleam_basin,,W-AS,,IN,IND,,19.183,77.317,624000,1075
+G-NDG,Qiqihar,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,47.24,123.918,1641000,488
+G-NDJ,N'djamena,,,gleam_basin,,W-AF,,TD,TCD,,12.134,15.034,989000,840
+G-NDR,Nador,,,gleam_basin,,W-AF,,MA,MAR,,34.989,-3.028,129000,821
+G-NDU,Rundu,,,gleam_basin,,W-AF,,NA,NAM,,-17.956,19.719,58000,78
+G-NER,Neryungri,,,gleam_basin,,W-EU,,RU,RUS,,56.914,124.914,66000,1828
+G-NGB,Ningbo,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.827,121.462,1923000,407
+G-NGE,Ngaoundere,,,gleam_basin,,W-AF,,CM,CMR,,7.357,13.559,231000,808
+G-NGK,Nogliki,,,gleam_basin,,W-EU,,RU,RUS,,51.78,143.139,10000,1801
+G-NGO,Nagoya,,,gleam_basin,,W-AS,,JP,JPN,,34.858,136.805,3230000,3141
 G-NGQ,Shiquande,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,32.1,80.053,,409
-G-NGS,Nagasaki,,,gleam_basin,,W-AS,,JP,JPN,,32.917,129.914,435000.0,3129
+G-NGS,Nagasaki,,,gleam_basin,,W-AS,,JP,JPN,,32.917,129.914,435000,3129
 G-NHV,Nuku Hiva,,,gleam_basin,,W-OC,,PF,PYF,,-8.796,-140.229,,708
 G-NIB,Nikolai,,,gleam_basin,,W-NA,,US,USA,US-AK,63.019,-154.358,,2200
-G-NIM,Niamey,,,gleam_basin,,W-AF,,NE,NER,,13.482,2.184,915000.0,70
+G-NIM,Niamey,,,gleam_basin,,W-AF,,NE,NER,,13.482,2.184,915000,70
 G-NIU,Niau,,,gleam_basin,,W-OC,,PF,PYF,,-16.119,-146.368,,711
-G-NJC,Nizhnevartovsk,,,gleam_basin,,W-EU,,RU,RUS,,60.949,76.484,245000.0,1925
+G-NJC,Nizhnevartovsk,,,gleam_basin,,W-EU,,RU,RUS,,60.949,76.484,245000,1925
 G-NJF,Al Najaf,,,gleam_basin,,W-AS,,IQ,IRQ,,31.99,44.404,,2917
-G-NKC,Nouakchott,,,gleam_basin,,W-AF,,MR,MRT,,18.31,-15.97,742000.0,283
-G-NKG,Nanjing,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.742,118.862,3679000.0,445
-G-NKT,Sirnak,,,gleam_basin,,W-AS,,TR,TUR,,37.365,42.058,53000.0,1765
-G-NLA,Ndola,,,gleam_basin,,W-AF,,ZM,ZMB,,-12.998,28.665,396000.0,1545
-G-NLD,Nuevo Laredo,,,gleam_basin,,W-NA,,MX,MEX,,27.444,-99.571,350000.0,1009
+G-NKC,Nouakchott,,,gleam_basin,,W-AF,,MR,MRT,,18.31,-15.97,742000,283
+G-NKG,Nanjing,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.742,118.862,3679000,445
+G-NKT,Sirnak,,,gleam_basin,,W-AS,,TR,TUR,,37.365,42.058,53000,1765
+G-NLA,Ndola,,,gleam_basin,,W-AF,,ZM,ZMB,,-12.998,28.665,396000,1545
+G-NLD,Nuevo Laredo,,,gleam_basin,,W-NA,,MX,MEX,,27.444,-99.571,350000,1009
 G-NLK,Norfolk Island,,,gleam_basin,,W-OC,,NF,NFK,,,,,865
-G-NLT,Xinyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.432,83.379,300000.0,320
+G-NLT,Xinyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.432,83.379,300000,320
 G-NLV,Mykolaiv,,,gleam_basin,,W-EU,,UA,UKR,,47.058,31.92,,2781
-G-NMA,Namangan,,,gleam_basin,,W-AS,,UZ,UZB,,40.985,71.557,750000.0,2837
+G-NMA,Namangan,,,gleam_basin,,W-AS,,UZ,UZB,,40.985,71.557,750000,2837
 G-NNB,Santa Ana Island,,,gleam_basin,,W-OC,,SB,SLB,,-10.848,162.454,,3031
-G-NNG,Nanning,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,22.608,108.172,2167000.0,470
+G-NNG,Nanning,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,22.608,108.172,2167000,470
 G-NNM,Naryan-Mar,,,gleam_basin,,W-EU,,RU,RUS,,67.64,53.122,,1863
-G-NNT,Nan,,,gleam_basin,,W-AS,,TH,THA,,18.808,100.783,82000.0,550
+G-NNT,Nan,,,gleam_basin,,W-AS,,TH,THA,,18.808,100.783,82000,550
 G-NNX,Nunukan,,,gleam_basin,,W-AS,,ID,IDN,,4.133,117.667,,1310
-G-NNY,Nanyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,32.981,112.615,1944000.0,432
+G-NNY,Nanyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HA,32.981,112.615,1944000,432
 G-NOC,Knock,,,gleam_basin,,W-EU,,IE,IRL,,53.91,-8.818,,2920
 G-NOJ,Nojabrsk,,,gleam_basin,,W-EU,,RU,RUS,,63.183,75.27,,1798
 G-NOS,Nosy-Be,,,gleam_basin,,W-AF,,MG,MDG,,-13.312,48.315,,1445
-G-NOU,Noumea,,,gleam_basin,,W-OC,,NC,NCL,,-22.015,166.213,93000.0,3173
-G-NOV,Huambo,,,gleam_basin,,W-AF,,AO,AGO,,-12.809,15.76,1100000.0,1
-G-NOZ,Novokuznetsk,,,gleam_basin,,W-EU,,RU,RUS,,53.811,86.877,540000.0,1800
+G-NOU,Noumea,,,gleam_basin,,W-OC,,NC,NCL,,-22.015,166.213,93000,3173
+G-NOV,Huambo,,,gleam_basin,,W-AF,,AO,AGO,,-12.809,15.76,1100000,1
+G-NOZ,Novokuznetsk,,,gleam_basin,,W-EU,,RU,RUS,,53.811,86.877,540000,1800
 G-NPE,Napier-Hastings,,,gleam_basin,,W-OC,,NZ,NZL,,-39.466,176.87,,3053
-G-NPL,New Plymouth,,,gleam_basin,,W-OC,,NZ,NZL,,-39.009,174.179,52000.0,3052
-G-NQN,Neuquen,,,gleam_basin,,W-SA,,AR,ARG,,-38.949,-68.156,242000.0,3200
-G-NQU,Nuqui,,,gleam_basin,,W-SA,,CO,COL,,5.696,-77.281,3000.0,1381
-G-NQY,Newquay,,,gleam_basin,,W-EU,,GB,GBR,,50.441,-4.995,20000.0,780
+G-NPL,New Plymouth,,,gleam_basin,,W-OC,,NZ,NZL,,-39.009,174.179,52000,3052
+G-NQN,Neuquen,,,gleam_basin,,W-SA,,AR,ARG,,-38.949,-68.156,242000,3200
+G-NQU,Nuqui,,,gleam_basin,,W-SA,,CO,COL,,5.696,-77.281,3000,1381
+G-NQY,Newquay,,,gleam_basin,,W-EU,,GB,GBR,,50.441,-4.995,20000,780
 G-NRA,Narrandera,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-34.702,146.512,,1608
-G-NRN,Kevelaer,,,gleam_basin,,W-EU,,DE,DEU,,51.602,6.142,28000.0,734
+G-NRN,Kevelaer,,,gleam_basin,,W-EU,,DE,DEU,,51.602,6.142,28000,734
 G-NRT,Tokyo Narita,,,gleam_basin,,W-AS,,JP,JPN,,35.765,140.386,,3127
 G-NSH,Now Shahr,,,gleam_basin,,W-AS,,IR,IRN,,36.663,51.465,,2943
-G-NSI,Yaounde,,,gleam_basin,,W-AF,,CM,CMR,,3.723,11.553,1611000.0,807
-G-NSK,Norilsk,,,gleam_basin,,W-EU,,RU,RUS,,69.311,87.332,141000.0,1843
-G-NSN,Nelson,,,gleam_basin,,W-OC,,NZ,NZL,,-41.298,173.221,61000.0,3049
+G-NSI,Yaounde,,,gleam_basin,,W-AF,,CM,CMR,,3.723,11.553,1611000,807
+G-NSK,Norilsk,,,gleam_basin,,W-EU,,RU,RUS,,69.311,87.332,141000,1843
+G-NSN,Nelson,,,gleam_basin,,W-OC,,NZ,NZL,,-41.298,173.221,61000,3049
 G-NSQ,Nuussuaq,,,gleam_basin,,W-NA,,GL,GRL,,,,,943
-G-NST,Nakhon Si Thammarat,,,gleam_basin,,W-AS,,TH,THA,,8.54,99.945,232000.0,527
-G-NTE,Nantes,,,gleam_basin,,W-EU,,FR,FRA,,47.153,-1.611,439000.0,1525
-G-NTG,Nantong,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,,,947000.0,448
+G-NST,Nakhon Si Thammarat,,,gleam_basin,,W-AS,,TH,THA,,8.54,99.945,232000,527
+G-NTE,Nantes,,,gleam_basin,,W-EU,,FR,FRA,,47.153,-1.611,439000,1525
+G-NTG,Nantong,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,,,947000,448
 G-NTL,Newcastle (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-32.795,151.834,,1657
 G-NTN,Normanton,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-17.684,141.07,,1653
 G-NTQ,Wajima,,,gleam_basin,,W-AS,,JP,JPN,,37.293,136.962,,3142
 G-NTX,Natuna,,,gleam_basin,,W-AS,,ID,IDN,,3.909,108.388,,1292
-G-NTY,Sun City,,,gleam_basin,,W-AF,,ZA,ZAF,,-25.334,27.173,39000.0,636
-G-NUE,Nuremberg,,,gleam_basin,,W-EU,,DE,DEU,,49.499,11.078,737000.0,749
+G-NTY,Sun City,,,gleam_basin,,W-AF,,ZA,ZAF,,-25.334,27.173,39000,636
+G-NUE,Nuremberg,,,gleam_basin,,W-EU,,DE,DEU,,49.499,11.078,737000,749
 G-NUI,Nuiqsut,,,gleam_basin,,W-NA,,US,USA,US-AK,70.21,-151.006,,2448
 G-NUK,Nukutavake,,,gleam_basin,,W-OC,,PF,PYF,,-19.285,-138.772,,683
 G-NUS,Norsup,,,gleam_basin,,W-OC,,VU,VUT,,-16.08,167.401,,1325
-G-NUU,Nakuru,,,gleam_basin,,W-AF,,KE,KEN,,,,365000.0,1735
-G-NUX,Novy Urengoy,,,gleam_basin,,W-EU,,RU,RUS,,66.069,76.52,114000.0,1808
-G-NVA,Neiva,,,gleam_basin,,W-SA,,CO,COL,,2.95,-75.294,353000.0,1404
-G-NVI,Navoi,,,gleam_basin,,W-AS,,UZ,UZB,,40.117,65.171,138000.0,2843
-G-NVT,Navegantes,,,gleam_basin,,W-SA,,BR,BRA,,-26.88,-48.651,48000.0,2033
-G-NWI,Norwich,,,gleam_basin,,W-EU,,GB,GBR,,52.676,1.283,204000.0,784
-G-NYA,Nyagan,,,gleam_basin,,W-EU,,RU,RUS,,62.11,65.615,52000.0,1878
-G-NYI,Sunyani,,,gleam_basin,,W-AF,,GH,GHA,,7.362,-2.329,70000.0,99
-G-NYK,Nanyuki,,,gleam_basin,,W-AF,,KE,KEN,,-0.062,37.041,36000.0,1723
-G-NYM,Nadym,,,gleam_basin,,W-EU,,RU,RUS,,65.481,72.699,46000.0,1796
-G-NYO,Nykoping,,,gleam_basin,,W-EU,,SE,SWE,,58.789,16.912,28000.0,2552
-G-NYT,Nay Pyi Taw,,,gleam_basin,,W-AS,,MM,MMR,,19.624,96.201,930000.0,866
+G-NUU,Nakuru,,,gleam_basin,,W-AF,,KE,KEN,,,,365000,1735
+G-NUX,Novy Urengoy,,,gleam_basin,,W-EU,,RU,RUS,,66.069,76.52,114000,1808
+G-NVA,Neiva,,,gleam_basin,,W-SA,,CO,COL,,2.95,-75.294,353000,1404
+G-NVI,Navoi,,,gleam_basin,,W-AS,,UZ,UZB,,40.117,65.171,138000,2843
+G-NVT,Navegantes,,,gleam_basin,,W-SA,,BR,BRA,,-26.88,-48.651,48000,2033
+G-NWI,Norwich,,,gleam_basin,,W-EU,,GB,GBR,,52.676,1.283,204000,784
+G-NYA,Nyagan,,,gleam_basin,,W-EU,,RU,RUS,,62.11,65.615,52000,1878
+G-NYI,Sunyani,,,gleam_basin,,W-AF,,GH,GHA,,7.362,-2.329,70000,99
+G-NYK,Nanyuki,,,gleam_basin,,W-AF,,KE,KEN,,-0.062,37.041,36000,1723
+G-NYM,Nadym,,,gleam_basin,,W-EU,,RU,RUS,,65.481,72.699,46000,1796
+G-NYO,Nykoping,,,gleam_basin,,W-EU,,SE,SWE,,58.789,16.912,28000,2552
+G-NYT,Nay Pyi Taw,,,gleam_basin,,W-AS,,MM,MMR,,19.624,96.201,930000,866
 G-NYU,Bagan,,,gleam_basin,,W-AS,,MM,MMR,,21.179,94.93,,867
-G-NZH,Manzhouli,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,49.567,117.33,94000.0,359
-G-OAG,Orange,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.382,149.133,141000.0,1663
+G-NZH,Manzhouli,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,49.567,117.33,94000,359
+G-OAG,Orange,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.382,149.133,141000,1663
 G-OAJ,Jacksonville (US-NC),,,gleam_basin,,W-NA,,US,USA,US-NC,34.829,-77.612,,2095
-G-OAL,Cacoal,,,gleam_basin,,W-SA,,BR,BRA,,-11.496,-61.451,56000.0,1950
-G-OAX,Oaxaca,,,gleam_basin,,W-NA,,MX,MEX,,17,-96.727,531000.0,1019
+G-OAL,Cacoal,,,gleam_basin,,W-SA,,BR,BRA,,-11.496,-61.451,56000,1950
+G-OAX,Oaxaca,,,gleam_basin,,W-NA,,MX,MEX,,17,-96.727,531000,1019
 G-OAZ,Camp Bastion,,,gleam_basin,,W-AS,,AF,AFG,,31.864,64.225,,895
 G-OBN,Oban,,,gleam_basin,,W-EU,,GB,GBR,,56.464,-5.4,,768
-G-OBO,Obihiro,,,gleam_basin,,W-AS,,JP,JPN,,42.733,143.217,174000.0,3155
+G-OBO,Obihiro,,,gleam_basin,,W-AS,,JP,JPN,,42.733,143.217,174000,3155
 G-OCC,Coca,,,gleam_basin,,W-SA,,EC,ECU,,-0.463,-76.987,,1471
-G-ODO,Bodaybo,,,gleam_basin,,W-EU,,RU,RUS,,57.866,114.243,16000.0,1853
-G-ODS,Odesa,,,gleam_basin,,W-EU,,UA,UKR,,46.427,30.677,991000.0,2787
-G-ODY,Muang Xay,,,gleam_basin,,W-AS,,LA,LAO,,20.683,101.994,25000.0,574
-G-OER,Ornskoldsvik,,,gleam_basin,,W-EU,,SE,SWE,,63.408,18.99,28000.0,2553
+G-ODO,Bodaybo,,,gleam_basin,,W-EU,,RU,RUS,,57.866,114.243,16000,1853
+G-ODS,Odesa,,,gleam_basin,,W-EU,,UA,UKR,,46.427,30.677,991000,2787
+G-ODY,Muang Xay,,,gleam_basin,,W-AS,,LA,LAO,,20.683,101.994,25000,574
+G-OER,Ornskoldsvik,,,gleam_basin,,W-EU,,SE,SWE,,63.408,18.99,28000,2553
 G-OFI,Ouango-Fitini,,,gleam_basin,,W-AF,,CI,CIV,,,,,2049
-G-OGG,Kahului,,,gleam_basin,,W-NA,,US,USA,US-HI,20.899,-156.43,31000.0,2318
+G-OGG,Kahului,,,gleam_basin,,W-NA,,US,USA,US-HI,20.899,-156.43,31000,2318
 G-OGN,Yonaguni Jima,,,gleam_basin,,W-AS,,JP,JPN,,24.467,122.978,,3117
-G-OGS,Ogdensburg,,,gleam_basin,,W-NA,,US,USA,US-NY,44.682,-75.465,11000.0,2301
-G-OGX,Ouargla,,,gleam_basin,,W-AF,,DZ,DZA,,31.917,5.413,176000.0,25
-G-OGZ,Vladikavkaz,,,gleam_basin,,W-EU,,RU,RUS,,43.205,44.607,365000.0,1897
-G-OHD,Ohrid,,,gleam_basin,,W-EU,,MK,MKD,,41.18,20.742,55000.0,1326
+G-OGS,Ogdensburg,,,gleam_basin,,W-NA,,US,USA,US-NY,44.682,-75.465,11000,2301
+G-OGX,Ouargla,,,gleam_basin,,W-AF,,DZ,DZA,,31.917,5.413,176000,25
+G-OGZ,Vladikavkaz,,,gleam_basin,,W-EU,,RU,RUS,,43.205,44.607,365000,1897
+G-OHD,Ohrid,,,gleam_basin,,W-EU,,MK,MKD,,41.18,20.742,55000,1326
 G-OHE,Mohe,,,gleam_basin,,W-AS,,CN,CHN,CN-HL,52.913,122.43,,335
-G-OHH,Okha,,,gleam_basin,,W-EU,,RU,RUS,,,,27000.0,1815
+G-OHH,Okha,,,gleam_basin,,W-EU,,RU,RUS,,,,27000,1815
 G-OIM,Oshima,,,gleam_basin,,W-AS,,JP,JPN,,34.782,139.36,,3103
-G-OIT,Oita,,,gleam_basin,,W-AS,,JP,JPN,,33.479,131.737,449000.0,3104
-G-OKA,Okinawa,,,gleam_basin,,W-AS,,JP,JPN,,26.196,127.646,125000.0,3135
-G-OKC,Oklahoma City,,,gleam_basin,,W-NA,,US,USA,US-OK,35.393,-97.601,956000.0,2354
+G-OIT,Oita,,,gleam_basin,,W-AS,,JP,JPN,,33.479,131.737,449000,3104
+G-OKA,Okinawa,,,gleam_basin,,W-AS,,JP,JPN,,26.196,127.646,125000,3135
+G-OKC,Oklahoma City,,,gleam_basin,,W-NA,,US,USA,US-OK,35.393,-97.601,956000,2354
 G-OKI,Oki,,,gleam_basin,,W-AS,,JP,JPN,,36.181,133.325,,3136
-G-OKJ,Okayama,,,gleam_basin,,W-AS,,JP,JPN,,34.757,133.855,866000.0,3110
+G-OKJ,Okayama,,,gleam_basin,,W-AS,,JP,JPN,,34.757,133.855,866000,3110
 G-OKL,Oksibil,,,gleam_basin,,W-AS,,ID,IDN,,-4.907,140.628,,1256
-G-OLA,Orland,,,gleam_basin,,W-EU,,NO,NOR,,63.699,9.604,10000.0,1169
-G-OLB,Olbia,,,gleam_basin,,W-EU,,IT,ITA,,40.899,9.518,45000.0,3094
+G-OLA,Orland,,,gleam_basin,,W-EU,,NO,NOR,,63.699,9.604,10000,1169
+G-OLB,Olbia,,,gleam_basin,,W-EU,,IT,ITA,,40.899,9.518,45000,3094
 G-OLC,Sao Paula de Olivenca,,,gleam_basin,,W-SA,,BR,BRA,,-3.468,-68.92,,1985
 G-OLF,Wolf Point,,,gleam_basin,,W-NA,,US,USA,US-MT,48.095,-105.575,,2482
 G-OLJ,Olpoi,,,gleam_basin,,W-OC,,VU,VUT,,-14.882,166.558,,1323
 G-OLP,Olympic Dam,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-30.485,136.877,,1677
-G-OLZ,Olekminsk,,,gleam_basin,,W-EU,,RU,RUS,,60.397,120.471,10000.0,1854
-G-OMA,Omaha,,,gleam_basin,,W-NA,,US,USA,US-NE,41.303,-95.894,828000.0,2453
-G-OMD,Oranjemund,,,gleam_basin,,W-AF,,NA,NAM,,-28.585,16.447,8000.0,80
+G-OLZ,Olekminsk,,,gleam_basin,,W-EU,,RU,RUS,,60.397,120.471,10000,1854
+G-OMA,Omaha,,,gleam_basin,,W-NA,,US,USA,US-NE,41.303,-95.894,828000,2453
+G-OMD,Oranjemund,,,gleam_basin,,W-AF,,NA,NAM,,-28.585,16.447,8000,80
 G-OME,Nome,,,gleam_basin,,W-NA,,US,USA,US-AK,64.512,-165.445,,2112
 G-OMH,Urumiyeh,,,gleam_basin,,W-AS,,IR,IRN,,37.668,45.069,,2964
-G-OMR,Oradea,,,gleam_basin,,W-EU,,RO,ROU,,47.025,21.903,214000.0,148
-G-OMS,Omsk,,,gleam_basin,,W-EU,,RU,RUS,,54.967,73.311,1135000.0,1912
+G-OMR,Oradea,,,gleam_basin,,W-EU,,RO,ROU,,47.025,21.903,214000,148
+G-OMS,Omsk,,,gleam_basin,,W-EU,,RU,RUS,,54.967,73.311,1135000,1912
 G-OND,Ondangwa,,,gleam_basin,,W-AF,,NA,NAM,,-17.878,15.953,,74
 G-ONG,Mornington Island,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-16.663,139.178,,1576
-G-ONJ,Odate,,,gleam_basin,,W-AS,,JP,JPN,,40.192,140.371,65000.0,3101
+G-ONJ,Odate,,,gleam_basin,,W-AS,,JP,JPN,,40.192,140.371,65000,3101
 G-ONL,Oneill,,,gleam_basin,,W-NA,,US,USA,US-NE,,,,2070
-G-OOL,Gold Coast,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-28.164,153.505,528000.0,1691
-G-OOM,Cooma,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.301,148.974,7000.0,1693
-G-OPO,Porto,,,gleam_basin,,W-EU,,PT,PRT,,41.248,-8.681,1337000.0,1440
-G-OPS,Sinop,,,gleam_basin,,W-SA,,BR,BRA,,-11.885,-55.586,35000.0,2031
+G-OOL,Gold Coast,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-28.164,153.505,528000,1691
+G-OOM,Cooma,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-36.301,148.974,7000,1693
+G-OPO,Porto,,,gleam_basin,,W-EU,,PT,PRT,,41.248,-8.681,1337000,1440
+G-OPS,Sinop,,,gleam_basin,,W-SA,,BR,BRA,,-11.885,-55.586,35000,2031
 G-OPU,Balimo,,,gleam_basin,,W-OC,,PG,PNG,,-8.05,142.933,,2998
-G-ORB,Orebro,,,gleam_basin,,W-EU,,SE,SWE,,59.224,15.038,99000.0,2543
-G-ORD,Chicago,,,gleam_basin,,W-NA,,US,USA,US-IL,41.979,-87.905,8676000.0,2217
-G-ORF,Norfolk,,,gleam_basin,,W-NA,,US,USA,US-VA,36.895,-76.201,245000.0,2437
-G-ORH,Worcester,,,gleam_basin,,W-NA,,US,USA,US-MA,42.267,-71.876,499000.0,2172
-G-ORK,Cork,,,gleam_basin,,W-EU,,IE,IRL,,51.841,-8.491,189000.0,2923
-G-ORN,Oran,,,gleam_basin,,W-AF,,DZ,DZA,,35.624,-0.621,798000.0,20
-G-ORU,Oruro,,,gleam_basin,,W-SA,,BO,BOL,,-17.963,-67.076,247000.0,91
+G-ORB,Orebro,,,gleam_basin,,W-EU,,SE,SWE,,59.224,15.038,99000,2543
+G-ORD,Chicago,,,gleam_basin,,W-NA,,US,USA,US-IL,41.979,-87.905,8676000,2217
+G-ORF,Norfolk,,,gleam_basin,,W-NA,,US,USA,US-VA,36.895,-76.201,245000,2437
+G-ORH,Worcester,,,gleam_basin,,W-NA,,US,USA,US-MA,42.267,-71.876,499000,2172
+G-ORK,Cork,,,gleam_basin,,W-EU,,IE,IRL,,51.841,-8.491,189000,2923
+G-ORN,Oran,,,gleam_basin,,W-AF,,DZ,DZA,,35.624,-0.621,798000,20
+G-ORU,Oruro,,,gleam_basin,,W-SA,,BO,BOL,,-17.963,-67.076,247000,91
 G-OSD,Are,,,gleam_basin,,W-EU,,SE,SWE,,63.194,14.5,,2563
-G-OSI,Osijek,,,gleam_basin,,W-EU,,HR,HRV,,45.463,18.81,95000.0,289
-G-OSK,Oskarshamn,,,gleam_basin,,W-EU,,SE,SWE,,57.35,16.498,18000.0,2562
-G-OSL,Oslo,,,gleam_basin,,W-EU,,NO,NOR,,60.121,11.05,835000.0,1173
-G-OSM,Mosul,,,gleam_basin,,W-AS,,IQ,IRQ,,36.306,43.147,1316000.0,2916
-G-OSR,Ostrava,,,gleam_basin,,W-EU,,CZ,CZE,,49.696,18.111,479000.0,1179
-G-OSS,Osh,,,gleam_basin,,W-AS,,KG,KGZ,,40.609,72.793,391000.0,3162
+G-OSI,Osijek,,,gleam_basin,,W-EU,,HR,HRV,,45.463,18.81,95000,289
+G-OSK,Oskarshamn,,,gleam_basin,,W-EU,,SE,SWE,,57.35,16.498,18000,2562
+G-OSL,Oslo,,,gleam_basin,,W-EU,,NO,NOR,,60.121,11.05,835000,1173
+G-OSM,Mosul,,,gleam_basin,,W-AS,,IQ,IRQ,,36.306,43.147,1316000,2916
+G-OSR,Ostrava,,,gleam_basin,,W-EU,,CZ,CZE,,49.696,18.111,479000,1179
+G-OSS,Osh,,,gleam_basin,,W-AS,,KG,KGZ,,40.609,72.793,391000,3162
 G-OST,Oostende,,,gleam_basin,,W-EU,,BE,BEL,,51.199,2.862,,721
-G-OSW,Orsk,,,gleam_basin,,W-EU,,RU,RUS,,51.072,58.596,247000.0,1896
-G-OSY,Namsos,,,gleam_basin,,W-EU,,NO,NOR,,64.472,11.579,9000.0,1172
+G-OSW,Orsk,,,gleam_basin,,W-EU,,RU,RUS,,51.072,58.596,247000,1896
+G-OSY,Namsos,,,gleam_basin,,W-EU,,NO,NOR,,64.472,11.579,9000,1172
 G-OTD,Contadora,,,gleam_basin,,W-NA,,PA,PAN,,,,,3007
-G-OTH,North Bend,,,gleam_basin,,W-NA,,US,USA,US-OR,43.417,-124.246,10000.0,2330
-G-OTP,Bucharest,,,gleam_basin,,W-EU,,RO,ROU,,44.571,26.085,1942000.0,146
+G-OTH,North Bend,,,gleam_basin,,W-NA,,US,USA,US-OR,43.417,-124.246,10000,2330
+G-OTP,Bucharest,,,gleam_basin,,W-EU,,RO,ROU,,44.571,26.085,1942000,146
 G-OTZ,Kotzebue,,,gleam_basin,,W-NA,,US,USA,US-AK,66.885,-162.599,,2331
-G-OUA,Ouagadougou,,,gleam_basin,,W-AF,,BF,BFA,,12.353,-1.512,1149000.0,274
+G-OUA,Ouagadougou,,,gleam_basin,,W-AF,,BF,BFA,,12.353,-1.512,1149000,274
 G-OUD,Oujda,,,gleam_basin,,W-AF,,MA,MAR,,34.787,-1.924,,819
-G-OUL,Oulu,,,gleam_basin,,W-EU,,FI,FIN,,64.93,25.355,137000.0,509
-G-OUZ,Zouerate,,,gleam_basin,,W-AF,,MR,MRT,,22.756,-12.484,56000.0,280
-G-OVB,Novosibirsk,,,gleam_basin,,W-EU,,RU,RUS,,55.013,82.651,1389000.0,1870
+G-OUL,Oulu,,,gleam_basin,,W-EU,,FI,FIN,,64.93,25.355,137000,509
+G-OUZ,Zouerate,,,gleam_basin,,W-AF,,MR,MRT,,22.756,-12.484,56000,280
+G-OVB,Novosibirsk,,,gleam_basin,,W-EU,,RU,RUS,,55.013,82.651,1389000,1870
 G-OVD,Asturias,,,gleam_basin,,W-EU,,ES,ESP,,43.564,-6.035,,2903
 G-OVS,Sovetsky,,,gleam_basin,,W-EU,,RU,RUS,,61.327,63.602,,1865
-G-OXB,Bissau,,,gleam_basin,,W-AF,,GW,GNB,,11.895,-15.654,403000.0,2579
-G-OXF,Oxford,,,gleam_basin,,W-EU,,GB,GBR,,51.837,-1.32,193000.0,771
-G-OZC,Ozamis,,,gleam_basin,,W-AS,,PH,PHL,,8.179,123.842,132000.0,603
-G-OZH,Zaporizhia,,,gleam_basin,,W-EU,,UA,UKR,,47.867,35.316,796000.0,2795
+G-OXB,Bissau,,,gleam_basin,,W-AF,,GW,GNB,,11.895,-15.654,403000,2579
+G-OXF,Oxford,,,gleam_basin,,W-EU,,GB,GBR,,51.837,-1.32,193000,771
+G-OZC,Ozamis,,,gleam_basin,,W-AS,,PH,PHL,,8.179,123.842,132000,603
+G-OZH,Zaporizhia,,,gleam_basin,,W-EU,,UA,UKR,,47.867,35.316,796000,2795
 G-OZZ,Ouarzazate,,,gleam_basin,,W-AF,,MA,MAR,,30.939,-6.909,,817
-G-PAD,Paderborn,,,gleam_basin,,W-EU,,DE,DEU,,51.614,8.616,142000.0,726
+G-PAD,Paderborn,,,gleam_basin,,W-EU,,DE,DEU,,51.614,8.616,142000,726
 G-PAF,Pakuba,,,gleam_basin,,W-AF,,UG,UGA,,,,,3166
-G-PAG,Pagadian,,,gleam_basin,,W-AS,,PH,PHL,,7.831,123.461,160000.0,594
-G-PAH,Paducah,,,gleam_basin,,W-NA,,US,USA,US-KY,37.061,-88.774,49000.0,2106
-G-PAP,Port au Prince,,,gleam_basin,,W-NA,,HT,HTI,,18.58,-72.293,1998000.0,978
-G-PAT,Patna,,,gleam_basin,,W-AS,,IN,IND,,25.591,85.088,2158000.0,1059
-G-PAV,Paulo Afonso,,,gleam_basin,,W-SA,,BR,BRA,,-9.401,-38.251,85000.0,1948
+G-PAG,Pagadian,,,gleam_basin,,W-AS,,PH,PHL,,7.831,123.461,160000,594
+G-PAH,Paducah,,,gleam_basin,,W-NA,,US,USA,US-KY,37.061,-88.774,49000,2106
+G-PAP,Port au Prince,,,gleam_basin,,W-NA,,HT,HTI,,18.58,-72.293,1998000,978
+G-PAT,Patna,,,gleam_basin,,W-AS,,IN,IND,,25.591,85.088,2158000,1059
+G-PAV,Paulo Afonso,,,gleam_basin,,W-SA,,BR,BRA,,-9.401,-38.251,85000,1948
 G-PAZ,Poza Rica,,,gleam_basin,,W-NA,,MX,MEX,,20.603,-97.461,,985
-G-PBC,Puebla,,,gleam_basin,,W-NA,,MX,MEX,,19.158,-98.371,2195000.0,995
-G-PBD,Porbandar,,,gleam_basin,,W-AS,,IN,IND,,21.649,69.657,235000.0,1064
-G-PBH,Paro,,,gleam_basin,,W-AS,,BT,BTN,,27.403,89.425,15000.0,1117
-G-PBI,West Palm Beach,,,gleam_basin,,W-NA,,US,USA,US-FL,26.683,-80.096,110000.0,2141
-G-PBM,Paramaribo,,,gleam_basin,,W-SA,,SR,SUR,,5.453,-55.188,254000.0,834
+G-PBC,Puebla,,,gleam_basin,,W-NA,,MX,MEX,,19.158,-98.371,2195000,995
+G-PBD,Porbandar,,,gleam_basin,,W-AS,,IN,IND,,21.649,69.657,235000,1064
+G-PBH,Paro,,,gleam_basin,,W-AS,,BT,BTN,,27.403,89.425,15000,1117
+G-PBI,West Palm Beach,,,gleam_basin,,W-NA,,US,USA,US-FL,26.683,-80.096,110000,2141
+G-PBM,Paramaribo,,,gleam_basin,,W-SA,,SR,SUR,,5.453,-55.188,254000,834
 G-PBO,Paraburdoo,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-23.171,117.745,,1593
 G-PBU,Putao,,,gleam_basin,,W-AS,,MM,MMR,,27.33,97.426,,882
-G-PCL,Pucallpa,,,gleam_basin,,W-SA,,PE,PER,,-8.378,-74.574,311000.0,1215
-G-PCR,Puerto Carreno,,,gleam_basin,,W-SA,,CO,COL,,6.185,-67.493,10000.0,1383
+G-PCL,Pucallpa,,,gleam_basin,,W-SA,,PE,PER,,-8.378,-74.574,311000,1215
+G-PCR,Puerto Carreno,,,gleam_basin,,W-SA,,CO,COL,,6.185,-67.493,10000,1383
 G-PDA,Puerto Inirida,,,gleam_basin,,W-SA,,CO,COL,,3.854,-67.906,,1375
-G-PDG,Padang,,,gleam_basin,,W-AS,,ID,IDN,,-0.787,100.281,855000.0,1243
-G-PDL,Ponta Delgada,,,gleam_basin,,W-EU,,PT,PRT,,37.741,-25.698,62000.0,1432
-G-PDP,Punta del Este,,,gleam_basin,,W-SA,,UY,URY,,-34.855,-55.094,159000.0,518
-G-PDS,Piedras Negras,,,gleam_basin,,W-NA,,MX,MEX,,28.627,-100.535,140000.0,984
-G-PDT,Pendleton,,,gleam_basin,,W-NA,,US,USA,US-OR,45.695,-118.841,17000.0,2213
-G-PDV,Plovdiv,,,gleam_basin,,W-EU,,BG,BGR,,42.068,24.851,340000.0,81
+G-PDG,Padang,,,gleam_basin,,W-AS,,ID,IDN,,-0.787,100.281,855000,1243
+G-PDL,Ponta Delgada,,,gleam_basin,,W-EU,,PT,PRT,,37.741,-25.698,62000,1432
+G-PDP,Punta del Este,,,gleam_basin,,W-SA,,UY,URY,,-34.855,-55.094,159000,518
+G-PDS,Piedras Negras,,,gleam_basin,,W-NA,,MX,MEX,,28.627,-100.535,140000,984
+G-PDT,Pendleton,,,gleam_basin,,W-NA,,US,USA,US-OR,45.695,-118.841,17000,2213
+G-PDV,Plovdiv,,,gleam_basin,,W-EU,,BG,BGR,,42.068,24.851,340000,81
 G-PDX,Portland (US-OR),,,gleam_basin,,W-NA,,US,USA,US-OR,45.589,-122.598,,2299
-G-PED,Pardubice,,,gleam_basin,,W-EU,,CZ,CZE,,50.013,15.739,107000.0,1178
-G-PEE,Perm,,,gleam_basin,,W-EU,,RU,RUS,,57.915,56.021,982000.0,1842
-G-PEG,Perugia,,,gleam_basin,,W-EU,,IT,ITA,,43.096,12.513,149000.0,3080
-G-PEI,Pereira,,,gleam_basin,,W-SA,,CO,COL,,4.813,-75.74,569000.0,1402
-G-PEK,Beijing,,,gleam_basin,,W-AS,,CN,CHN,CN-BJ,40.08,116.585,11106000.0,420
-G-PEM,Puerto Maldonado,,,gleam_basin,,W-SA,,PE,PER,,-12.614,-69.229,67000.0,1219
+G-PED,Pardubice,,,gleam_basin,,W-EU,,CZ,CZE,,50.013,15.739,107000,1178
+G-PEE,Perm,,,gleam_basin,,W-EU,,RU,RUS,,57.915,56.021,982000,1842
+G-PEG,Perugia,,,gleam_basin,,W-EU,,IT,ITA,,43.096,12.513,149000,3080
+G-PEI,Pereira,,,gleam_basin,,W-SA,,CO,COL,,4.813,-75.74,569000,1402
+G-PEK,Beijing,,,gleam_basin,,W-AS,,CN,CHN,CN-BJ,40.08,116.585,11106000,420
+G-PEM,Puerto Maldonado,,,gleam_basin,,W-SA,,PE,PER,,-12.614,-69.229,67000,1219
 G-PEN,Penang,,,gleam_basin,,W-AS,,MY,MYS,,5.297,100.277,,173
-G-PER,Perth,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-31.94,115.967,1532000.0,1615
-G-PES,Petrozavodsk,,,gleam_basin,,W-EU,,RU,RUS,,61.885,34.155,265000.0,1850
-G-PET,Pelotas,,,gleam_basin,,W-SA,,BR,BRA,,-31.718,-52.328,321000.0,1981
-G-PEU,Puerto Lempira,,,gleam_basin,,W-NA,,HN,HND,,15.262,-83.781,5000.0,1193
-G-PEW,Peshawar,,,gleam_basin,,W-AS,,PK,PAK,,33.994,71.515,12300000.0,119
-G-PEX,Pechora,,,gleam_basin,,W-EU,,RU,RUS,,65.121,57.131,46000.0,1930
-G-PEZ,Penza,,,gleam_basin,,W-EU,,RU,RUS,,53.111,45.021,513000.0,1841
-G-PFB,Passo Fundo,,,gleam_basin,,W-SA,,BR,BRA,,-28.244,-52.327,180000.0,1989
-G-PFO,Paphos,,,gleam_basin,,W-AS,,CY,CYP,,34.718,32.486,36000.0,2816
-G-PFQ,Parsabad,,,gleam_basin,,W-AS,,IR,IRN,,39.604,47.882,102000.0,2945
-G-PGA,Page,,,gleam_basin,,W-NA,,US,USA,US-AZ,36.926,-111.448,7000.0,2296
-G-PGF,Perpignan,,,gleam_basin,,W-EU,,FR,FRA,,42.74,2.871,147000.0,1517
-G-PGK,Pangkalpinang,,,gleam_basin,,W-AS,,ID,IDN,,-2.162,106.139,126000.0,1273
+G-PER,Perth,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-31.94,115.967,1532000,1615
+G-PES,Petrozavodsk,,,gleam_basin,,W-EU,,RU,RUS,,61.885,34.155,265000,1850
+G-PET,Pelotas,,,gleam_basin,,W-SA,,BR,BRA,,-31.718,-52.328,321000,1981
+G-PEU,Puerto Lempira,,,gleam_basin,,W-NA,,HN,HND,,15.262,-83.781,5000,1193
+G-PEW,Peshawar,,,gleam_basin,,W-AS,,PK,PAK,,33.994,71.515,12300000,119
+G-PEX,Pechora,,,gleam_basin,,W-EU,,RU,RUS,,65.121,57.131,46000,1930
+G-PEZ,Penza,,,gleam_basin,,W-EU,,RU,RUS,,53.111,45.021,513000,1841
+G-PFB,Passo Fundo,,,gleam_basin,,W-SA,,BR,BRA,,-28.244,-52.327,180000,1989
+G-PFO,Paphos,,,gleam_basin,,W-AS,,CY,CYP,,34.718,32.486,36000,2816
+G-PFQ,Parsabad,,,gleam_basin,,W-AS,,IR,IRN,,39.604,47.882,102000,2945
+G-PGA,Page,,,gleam_basin,,W-NA,,US,USA,US-AZ,36.926,-111.448,7000,2296
+G-PGF,Perpignan,,,gleam_basin,,W-EU,,FR,FRA,,42.74,2.871,147000,1517
+G-PGK,Pangkalpinang,,,gleam_basin,,W-AS,,ID,IDN,,-2.162,106.139,126000,1273
 G-PGU,Asaloyeh,,,gleam_basin,,W-AS,,IR,IRN,,27.38,52.738,,2947
 G-PGV,Greenville (US-NC),,,gleam_basin,,W-NA,,US,USA,US-NC,35.635,-77.385,,2298
-G-PHC,Port Harcourt,,,gleam_basin,,W-AF,,NG,NGA,,5.015,6.95,1020000.0,1421
-G-PHE,Port Hedland,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-20.378,118.626,14000.0,1640
-G-PHL,Philadelphia,,,gleam_basin,,W-NA,,US,USA,US-PA,39.872,-75.241,5638000.0,2432
-G-PHO,Point Hope,,,gleam_basin,,W-NA,,US,USA,US-TX,,,700.0,2337
-G-PHS,Phitsanulok,,,gleam_basin,,W-AS,,TH,THA,,16.783,100.279,164000.0,546
-G-PHW,Phalaborwa,,,gleam_basin,,W-AF,,ZA,ZAF,,-23.937,31.155,109000.0,638
-G-PHX,Phoenix,,,gleam_basin,,W-NA,,US,USA,US-AZ,33.434,-112.012,4082000.0,2441
-G-PIA,Peoria,,,gleam_basin,,W-NA,,US,USA,US-IL,40.664,-89.693,262000.0,2359
-G-PIB,Laurel,,,gleam_basin,,W-NA,,US,USA,US-MS,31.467,-89.337,26000.0,2360
-G-PIH,Pocatello,,,gleam_basin,,W-NA,,US,USA,US-ID,42.91,-112.596,71000.0,2115
-G-PIN,Parintins,,,gleam_basin,,W-SA,,BR,BRA,,-2.673,-56.777,64000.0,2006
-G-PIR,Pierre,,,gleam_basin,,W-NA,,US,USA,US-SD,44.383,-100.286,15000.0,2363
-G-PIS,Poitiers,,,gleam_basin,,W-EU,,FR,FRA,,46.588,0.307,86000.0,1522
-G-PIT,Pittsburgh,,,gleam_basin,,W-NA,,US,USA,US-PA,40.492,-80.233,1715000.0,2125
-G-PIU,Piura,,,gleam_basin,,W-SA,,PE,PER,,-5.206,-80.616,397000.0,1213
+G-PHC,Port Harcourt,,,gleam_basin,,W-AF,,NG,NGA,,5.015,6.95,1020000,1421
+G-PHE,Port Hedland,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-20.378,118.626,14000,1640
+G-PHL,Philadelphia,,,gleam_basin,,W-NA,,US,USA,US-PA,39.872,-75.241,5638000,2432
+G-PHO,Point Hope,,,gleam_basin,,W-NA,,US,USA,US-TX,,,700,2337
+G-PHS,Phitsanulok,,,gleam_basin,,W-AS,,TH,THA,,16.783,100.279,164000,546
+G-PHW,Phalaborwa,,,gleam_basin,,W-AF,,ZA,ZAF,,-23.937,31.155,109000,638
+G-PHX,Phoenix,,,gleam_basin,,W-NA,,US,USA,US-AZ,33.434,-112.012,4082000,2441
+G-PIA,Peoria,,,gleam_basin,,W-NA,,US,USA,US-IL,40.664,-89.693,262000,2359
+G-PIB,Laurel,,,gleam_basin,,W-NA,,US,USA,US-MS,31.467,-89.337,26000,2360
+G-PIH,Pocatello,,,gleam_basin,,W-NA,,US,USA,US-ID,42.91,-112.596,71000,2115
+G-PIN,Parintins,,,gleam_basin,,W-SA,,BR,BRA,,-2.673,-56.777,64000,2006
+G-PIR,Pierre,,,gleam_basin,,W-NA,,US,USA,US-SD,44.383,-100.286,15000,2363
+G-PIS,Poitiers,,,gleam_basin,,W-EU,,FR,FRA,,46.588,0.307,86000,1522
+G-PIT,Pittsburgh,,,gleam_basin,,W-NA,,US,USA,US-PA,40.492,-80.233,1715000,2125
+G-PIU,Piura,,,gleam_basin,,W-SA,,PE,PER,,-5.206,-80.616,397000,1213
 G-PIZ,Point Lay,,,gleam_basin,,W-NA,,US,USA,US-AK,69.733,-163.005,,2362
 G-PJA,Pajala,,,gleam_basin,,W-EU,,SE,SWE,,67.246,23.069,,2565
-G-PJG,Panjgur,,,gleam_basin,,W-AS,,PK,PAK,,26.955,64.132,723000.0,113
+G-PJG,Panjgur,,,gleam_basin,,W-AS,,PK,PAK,,26.955,64.132,723000,113
 G-PJM,Puerto Jimenez,,,gleam_basin,,W-NA,,CR,CRI,,8.533,-83.3,,804
-G-PKB,Parkersburg,,,gleam_basin,,W-NA,,US,USA,US-WV,39.345,-81.439,64000.0,2440
+G-PKB,Parkersburg,,,gleam_basin,,W-NA,,US,USA,US-WV,39.345,-81.439,64000,2440
 G-PKC,Petropavlovsk (RU),,,gleam_basin,,W-EU,,RU,RUS,,53.168,158.454,,1907
-G-PKE,Parkes,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.131,148.239,11000.0,1665
+G-PKE,Parkes,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.131,148.239,11000,1665
 G-PKG,Pangkor,,,gleam_basin,,W-AS,,MY,MYS,,4.245,100.553,,166
 G-PKN,Pangkalanbun,,,gleam_basin,,W-AS,,ID,IDN,,-2.705,111.673,,1303
 G-PKP,Puka Puka,,,gleam_basin,,W-OC,,PF,PYF,,-14.809,-138.813,,714
-G-PKR,Pokhara,,,gleam_basin,,W-AS,,NP,NPL,,28.201,83.982,200000.0,569
-G-PKU,Pekanbaru,,,gleam_basin,,W-AS,,ID,IDN,,0.461,101.445,799000.0,1301
-G-PKY,Palangkaraya,,,gleam_basin,,W-AS,,ID,IDN,,-2.225,113.943,148000.0,1302
-G-PKZ,Pakse,,,gleam_basin,,W-AS,,LA,LAO,,15.132,105.781,88000.0,578
-G-PLM,Palembang,,,gleam_basin,,W-AS,,ID,IDN,,-2.898,104.7,1749000.0,1306
+G-PKR,Pokhara,,,gleam_basin,,W-AS,,NP,NPL,,28.201,83.982,200000,569
+G-PKU,Pekanbaru,,,gleam_basin,,W-AS,,ID,IDN,,0.461,101.445,799000,1301
+G-PKY,Palangkaraya,,,gleam_basin,,W-AS,,ID,IDN,,-2.225,113.943,148000,1302
+G-PKZ,Pakse,,,gleam_basin,,W-AS,,LA,LAO,,15.132,105.781,88000,578
+G-PLM,Palembang,,,gleam_basin,,W-AS,,ID,IDN,,-2.898,104.7,1749000,1306
 G-PLN,Pellston,,,gleam_basin,,W-NA,,US,USA,US-MI,45.571,-84.797,,2493
-G-PLO,Port Lincoln,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-34.605,135.88,14000.0,1678
-G-PLQ,Klaipeda,,,gleam_basin,,W-EU,,LT,LTU,,55.973,21.094,192000.0,1540
+G-PLO,Port Lincoln,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-34.605,135.88,14000,1678
+G-PLQ,Klaipeda,,,gleam_basin,,W-EU,,LT,LTU,,55.973,21.094,192000,1540
 G-PLS,Providenciales,,,gleam_basin,,W-NA,,TC,TCA,,21.774,-72.266,,675
-G-PLW,Palu,,,gleam_basin,,W-AS,,ID,IDN,,-0.919,119.91,612000.0,1305
-G-PLX,Semey,,,gleam_basin,,W-AS,,KZ,KAZ,,50.351,80.234,311000.0,671
-G-PLZ,Port Elizabeth,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.985,25.617,1020999.0,641
-G-PMC,Puerto Montt,,,gleam_basin,,W-SA,,CL,CHL,,-41.439,-73.094,175000.0,309
-G-PMF,Parma,,,gleam_basin,,W-EU,,IT,ITA,,44.825,10.296,166000.0,3097
-G-PMI,Palma de Mallorca,,,gleam_basin,,W-EU,,ES,ESP,,39.552,2.739,403000.0,2911
+G-PLW,Palu,,,gleam_basin,,W-AS,,ID,IDN,,-0.919,119.91,612000,1305
+G-PLX,Semey,,,gleam_basin,,W-AS,,KZ,KAZ,,50.351,80.234,311000,671
+G-PLZ,Port Elizabeth,,,gleam_basin,,W-AF,,ZA,ZAF,,-33.985,25.617,1020999,641
+G-PMC,Puerto Montt,,,gleam_basin,,W-SA,,CL,CHL,,-41.439,-73.094,175000,309
+G-PMF,Parma,,,gleam_basin,,W-EU,,IT,ITA,,44.825,10.296,166000,3097
+G-PMI,Palma de Mallorca,,,gleam_basin,,W-EU,,ES,ESP,,39.552,2.739,403000,2911
 G-PML,Port Moller,,,gleam_basin,,W-NA,,US,USA,US-AK,56.006,-160.561,,2450
-G-PMO,Palermo,,,gleam_basin,,W-EU,,IT,ITA,,38.176,13.091,863000.0,3090
-G-PMQ,Perito Moreno,,,gleam_basin,,W-SA,,AR,ARG,,-46.538,-70.979,4000.0,3218
-G-PMR,Palmerston North,,,gleam_basin,,W-OC,,NZ,NZL,,-40.321,175.617,82000.0,3060
-G-PMV,Porlamar,,,gleam_basin,,W-SA,,VE,VEN,,10.913,-63.967,197000.0,1718
-G-PMW,Palmas,,,gleam_basin,,W-SA,,BR,BRA,,-10.292,-48.357,235000.0,2043
-G-PMY,Puerto Madryn,,,gleam_basin,,W-SA,,AR,ARG,,-42.759,-65.103,65000.0,3213
-G-PNA,Pamplona,,,gleam_basin,,W-EU,,ES,ESP,,42.77,-1.646,275000.0,2879
-G-PND,Punta Gorda,,,gleam_basin,,W-NA,,BZ,BLZ,,,,20000.0,861
-G-PNH,Phnom Penh,,,gleam_basin,,W-AS,,KH,KHM,,11.547,104.844,1466000.0,221
+G-PMO,Palermo,,,gleam_basin,,W-EU,,IT,ITA,,38.176,13.091,863000,3090
+G-PMQ,Perito Moreno,,,gleam_basin,,W-SA,,AR,ARG,,-46.538,-70.979,4000,3218
+G-PMR,Palmerston North,,,gleam_basin,,W-OC,,NZ,NZL,,-40.321,175.617,82000,3060
+G-PMV,Porlamar,,,gleam_basin,,W-SA,,VE,VEN,,10.913,-63.967,197000,1718
+G-PMW,Palmas,,,gleam_basin,,W-SA,,BR,BRA,,-10.292,-48.357,235000,2043
+G-PMY,Puerto Madryn,,,gleam_basin,,W-SA,,AR,ARG,,-42.759,-65.103,65000,3213
+G-PNA,Pamplona,,,gleam_basin,,W-EU,,ES,ESP,,42.77,-1.646,275000,2879
+G-PND,Punta Gorda,,,gleam_basin,,W-NA,,BZ,BLZ,,,,20000,861
+G-PNH,Phnom Penh,,,gleam_basin,,W-AS,,KH,KHM,,11.547,104.844,1466000,221
 G-PNI,Pohnpei,,,gleam_basin,,W-OC,,FM,FSM,,6.985,158.209,,1208
-G-PNK,Pontianak,,,gleam_basin,,W-AS,,ID,IDN,,-0.151,109.404,607000.0,1239
-G-PNL,Pantelleria,,,gleam_basin,,W-EU,,IT,ITA,,36.817,11.969,6100.0,3067
-G-PNP,Popondetta,,,gleam_basin,,W-OC,,PG,PNG,,-8.805,148.309,28000.0,2986
-G-PNQ,Pune,,,gleam_basin,,W-AS,,IN,IND,,18.582,73.92,4672000.0,1055
+G-PNK,Pontianak,,,gleam_basin,,W-AS,,ID,IDN,,-0.151,109.404,607000,1239
+G-PNL,Pantelleria,,,gleam_basin,,W-EU,,IT,ITA,,36.817,11.969,6100,3067
+G-PNP,Popondetta,,,gleam_basin,,W-OC,,PG,PNG,,-8.805,148.309,28000,2986
+G-PNQ,Pune,,,gleam_basin,,W-AS,,IN,IND,,18.582,73.92,4672000,1055
 G-PNR,Pointe-Noire,,,gleam_basin,,W-AF,,CG,COG,,-4.816,11.887,,1345
-G-PNS,Pensacola,,,gleam_basin,,W-NA,,US,USA,US-FL,30.473,-87.187,344000.0,2071
-G-PNT,Puerto Natales,,,gleam_basin,,W-SA,,CL,CHL,,-51.672,-72.528,20000.0,293
-G-PNY,Pondicherry,,,gleam_basin,,W-AS,,IN,IND,,11.968,79.812,506000.0,1108
-G-PNZ,Petrolina,,,gleam_basin,,W-SA,,BR,BRA,,-9.362,-40.569,261000.0,1938
-G-POA,Porto Alegre,,,gleam_basin,,W-SA,,BR,BRA,,-29.994,-51.171,3917000.0,1946
-G-POG,Port Gentil,,,gleam_basin,,W-AF,,GA,GAB,,-0.712,8.754,117000.0,646
-G-POI,Potosi,,,gleam_basin,,W-SA,,BO,BOL,,-19.543,-65.724,180000.0,94
-G-POJ,Patos de Minas,,,gleam_basin,,W-SA,,BR,BRA,,-18.673,-46.491,126000.0,1945
-G-POL,Pemba,,,gleam_basin,,W-AF,,MZ,MOZ,,-12.992,40.524,111000.0,964
-G-POM,Port Moresby,,,gleam_basin,,W-OC,,PG,PNG,,-9.443,147.22,284000.0,2979
-G-POR,Pori,,,gleam_basin,,W-EU,,FI,FIN,,61.462,21.8,77000.0,497
-G-POS,Port of Spain,,,gleam_basin,,W-NA,,TT,TTO,,10.595,-61.337,295000.0,224
-G-POZ,Poznan,,,gleam_basin,,W-EU,,PL,POL,,52.421,16.826,624000.0,2851
+G-PNS,Pensacola,,,gleam_basin,,W-NA,,US,USA,US-FL,30.473,-87.187,344000,2071
+G-PNT,Puerto Natales,,,gleam_basin,,W-SA,,CL,CHL,,-51.672,-72.528,20000,293
+G-PNY,Pondicherry,,,gleam_basin,,W-AS,,IN,IND,,11.968,79.812,506000,1108
+G-PNZ,Petrolina,,,gleam_basin,,W-SA,,BR,BRA,,-9.362,-40.569,261000,1938
+G-POA,Porto Alegre,,,gleam_basin,,W-SA,,BR,BRA,,-29.994,-51.171,3917000,1946
+G-POG,Port Gentil,,,gleam_basin,,W-AF,,GA,GAB,,-0.712,8.754,117000,646
+G-POI,Potosi,,,gleam_basin,,W-SA,,BO,BOL,,-19.543,-65.724,180000,94
+G-POJ,Patos de Minas,,,gleam_basin,,W-SA,,BR,BRA,,-18.673,-46.491,126000,1945
+G-POL,Pemba,,,gleam_basin,,W-AF,,MZ,MOZ,,-12.992,40.524,111000,964
+G-POM,Port Moresby,,,gleam_basin,,W-OC,,PG,PNG,,-9.443,147.22,284000,2979
+G-POR,Pori,,,gleam_basin,,W-EU,,FI,FIN,,61.462,21.8,77000,497
+G-POS,Port of Spain,,,gleam_basin,,W-NA,,TT,TTO,,10.595,-61.337,295000,224
+G-POZ,Poznan,,,gleam_basin,,W-EU,,PL,POL,,52.421,16.826,624000,2851
 G-PPB,President Prudente,,,gleam_basin,,W-SA,,BR,BRA,,-22.175,-51.425,,2035
-G-PPE,Puerto Penasco,,,gleam_basin,,W-NA,,MX,MEX,,31.352,-113.305,34000.0,993
-G-PPG,Pago Pago,,,gleam_basin,,W-OC,,AS,ASM,,-14.331,-170.71,13000.0,1486
+G-PPE,Puerto Penasco,,,gleam_basin,,W-NA,,MX,MEX,,31.352,-113.305,34000,993
+G-PPG,Pago Pago,,,gleam_basin,,W-OC,,AS,ASM,,-14.331,-170.71,13000,1486
 G-PPK,Petropavlovsk (KZ),,,gleam_basin,,W-AS,,KZ,KAZ,,54.775,69.184,,672
-G-PPN,Popayan,,,gleam_basin,,W-SA,,CO,COL,,2.454,-76.609,259000.0,1380
-G-PPS,Puerto Princesa,,,gleam_basin,,W-AS,,PH,PHL,,9.742,118.759,157000.0,608
+G-PPN,Popayan,,,gleam_basin,,W-SA,,CO,COL,,2.454,-76.609,259000,1380
+G-PPS,Puerto Princesa,,,gleam_basin,,W-AS,,PH,PHL,,9.742,118.759,157000,608
 G-PPT,Tahiti,,,gleam_basin,,W-OC,,PF,PYF,,-17.554,-149.607,,712
 G-PQC,Phuquoc,,,gleam_basin,,W-AS,,VN,VNM,,10.17,103.993,,1124
-G-PQI,Presque Isle,,,gleam_basin,,W-NA,,US,USA,US-ME,46.689,-68.045,6000.0,2081
-G-PQQ,Port Macquarie,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.436,152.863,49000.0,1630
-G-PRC,Prescott,,,gleam_basin,,W-NA,,US,USA,US-AZ,34.654,-112.42,43000.0,2073
-G-PRG,Prague,,,gleam_basin,,W-EU,,CZ,CZE,,50.101,14.26,1162000.0,1175
-G-PRH,Phrae,,,gleam_basin,,W-AS,,TH,THA,,18.132,100.165,39000.0,522
-G-PSA,Pisa,,,gleam_basin,,W-EU,,IT,ITA,,43.684,10.393,203000.0,3068
-G-PSC,Pasco,,,gleam_basin,,W-NA,,US,USA,US-WA,46.265,-119.119,73000.0,2116
-G-PSE,Ponce,,,gleam_basin,,W-NA,,PR,PRI,,18.008,-66.563,120000.0,198
-G-PSG,Petersburg,,,gleam_basin,,W-NA,,US,USA,US-VA,56.802,-132.945,2400.0,2496
-G-PSJ,Poso,,,gleam_basin,,W-AS,,ID,IDN,,-1.417,120.658,47000.0,1246
-G-PSO,Pasto,,,gleam_basin,,W-SA,,CO,COL,,1.396,-77.291,382000.0,1366
-G-PSP,Palm Springs,,,gleam_basin,,W-NA,,US,USA,US-CA,33.83,-116.507,48000.0,2503
-G-PSR,Pescara,,,gleam_basin,,W-EU,,IT,ITA,,42.432,14.181,315000.0,3095
-G-PSS,Posadas,,,gleam_basin,,W-SA,,AR,ARG,,-27.386,-55.971,357000.0,3211
+G-PQI,Presque Isle,,,gleam_basin,,W-NA,,US,USA,US-ME,46.689,-68.045,6000,2081
+G-PQQ,Port Macquarie,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.436,152.863,49000,1630
+G-PRC,Prescott,,,gleam_basin,,W-NA,,US,USA,US-AZ,34.654,-112.42,43000,2073
+G-PRG,Prague,,,gleam_basin,,W-EU,,CZ,CZE,,50.101,14.26,1162000,1175
+G-PRH,Phrae,,,gleam_basin,,W-AS,,TH,THA,,18.132,100.165,39000,522
+G-PSA,Pisa,,,gleam_basin,,W-EU,,IT,ITA,,43.684,10.393,203000,3068
+G-PSC,Pasco,,,gleam_basin,,W-NA,,US,USA,US-WA,46.265,-119.119,73000,2116
+G-PSE,Ponce,,,gleam_basin,,W-NA,,PR,PRI,,18.008,-66.563,120000,198
+G-PSG,Petersburg,,,gleam_basin,,W-NA,,US,USA,US-VA,56.802,-132.945,2400,2496
+G-PSJ,Poso,,,gleam_basin,,W-AS,,ID,IDN,,-1.417,120.658,47000,1246
+G-PSO,Pasto,,,gleam_basin,,W-SA,,CO,COL,,1.396,-77.291,382000,1366
+G-PSP,Palm Springs,,,gleam_basin,,W-NA,,US,USA,US-CA,33.83,-116.507,48000,2503
+G-PSR,Pescara,,,gleam_basin,,W-EU,,IT,ITA,,42.432,14.181,315000,3095
+G-PSS,Posadas,,,gleam_basin,,W-SA,,AR,ARG,,-27.386,-55.971,357000,3211
 G-PSU,Putussibau,,,gleam_basin,,W-AS,,ID,IDN,,0.836,112.937,,1299
-G-PSZ,Puerto Suarez,,,gleam_basin,,W-SA,,BO,BOL,,-18.975,-57.821,22000.0,89
-G-PTG,Polokwane,,,gleam_basin,,W-AF,,ZA,ZAF,,-23.845,29.459,220000.0,629
+G-PSZ,Puerto Suarez,,,gleam_basin,,W-SA,,BO,BOL,,-18.975,-57.821,22000,89
+G-PTG,Polokwane,,,gleam_basin,,W-AF,,ZA,ZAF,,-23.845,29.459,220000,629
 G-PTH,Port Heiden,,,gleam_basin,,W-NA,,US,USA,US-AK,56.959,-158.633,,2136
 G-PTJ,Portland (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-38.318,141.471,,1591
-G-PTP,Pointe-a-Pitre,,,gleam_basin,,W-NA,,GP,GLP,,16.265,-61.532,146000.0,1354
+G-PTP,Pointe-a-Pitre,,,gleam_basin,,W-NA,,GP,GLP,,16.265,-61.532,146000,1354
 G-PTY,Panama City (PA),,,gleam_basin,,W-NA,,PA,PAN,,9.071,-79.383,,3004
-G-PUB,Pueblo,,,gleam_basin,,W-NA,,US,USA,US-CO,38.289,-104.497,142000.0,2182
+G-PUB,Pueblo,,,gleam_basin,,W-NA,,US,USA,US-CO,38.289,-104.497,142000,2182
 G-PUE,Puerto Obaldia,,,gleam_basin,,W-NA,,PA,PAN,,8.667,-77.418,,3006
-G-PUF,Pau,,,gleam_basin,,W-EU,,FR,FRA,,43.38,-0.419,83000.0,1518
-G-PUG,Port Augusta,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-32.507,137.717,14000.0,1652
-G-PUJ,Punta Cana,,,gleam_basin,,W-NA,,DO,DOM,,18.567,-68.363,100000.0,1198
+G-PUF,Pau,,,gleam_basin,,W-EU,,FR,FRA,,43.38,-0.419,83000,1518
+G-PUG,Port Augusta,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-32.507,137.717,14000,1652
+G-PUJ,Punta Cana,,,gleam_basin,,W-NA,,DO,DOM,,18.567,-68.363,100000,1198
 G-PUK,Pukarua,,,gleam_basin,,W-OC,,PF,PYF,,-18.296,-137.017,,706
 G-PUM,Kolaka,,,gleam_basin,,W-AS,,ID,IDN,,,,,1257
-G-PUQ,Punta Arenas,,,gleam_basin,,W-SA,,CL,CHL,,-53.003,-70.855,117000.0,306
+G-PUQ,Punta Arenas,,,gleam_basin,,W-SA,,CL,CHL,,-53.003,-70.855,117000,306
 G-PUS,Pusan,,,gleam_basin,,W-AS,,KR,KOR,,35.18,128.938,,2806
-G-PUU,Puerto Asis,,,gleam_basin,,W-SA,,CO,COL,,0.505,-76.501,30000.0,1372
-G-PUY,Pula,,,gleam_basin,,W-EU,,HR,HRV,,44.894,13.922,62000.0,290
+G-PUU,Puerto Asis,,,gleam_basin,,W-SA,,CO,COL,,0.505,-76.501,30000,1372
+G-PUY,Pula,,,gleam_basin,,W-EU,,HR,HRV,,44.894,13.922,62000,290
 G-PVA,Providencia,,,gleam_basin,,W-SA,,CO,COL,,13.357,-81.358,,1364
-G-PVD,Providence,,,gleam_basin,,W-NA,,US,USA,US-RI,41.733,-71.42,180000.0,2517
-G-PVG,Shanghai,,,gleam_basin,,W-AS,,CN,CHN,CN-SH,31.143,121.805,14987000.0,412
-G-PVH,Porto Velho,,,gleam_basin,,W-SA,,BR,BRA,,-8.709,-63.902,306000.0,1971
-G-PVK,Preveza,,,gleam_basin,,W-EU,,GR,GRC,,38.925,20.765,17000.0,917
-G-PVR,Puerto Vallarta,,,gleam_basin,,W-NA,,MX,MEX,,20.68,-105.254,187000.0,997
-G-PVU,Provo,,,gleam_basin,,W-NA,,US,USA,US-UT,40.219,-111.723,504000.0,2209
-G-PWE,Pevek,,,gleam_basin,,W-EU,,RU,RUS,,69.783,170.597,5000.0,1875
+G-PVD,Providence,,,gleam_basin,,W-NA,,US,USA,US-RI,41.733,-71.42,180000,2517
+G-PVG,Shanghai,,,gleam_basin,,W-AS,,CN,CHN,CN-SH,31.143,121.805,14987000,412
+G-PVH,Porto Velho,,,gleam_basin,,W-SA,,BR,BRA,,-8.709,-63.902,306000,1971
+G-PVK,Preveza,,,gleam_basin,,W-EU,,GR,GRC,,38.925,20.765,17000,917
+G-PVR,Puerto Vallarta,,,gleam_basin,,W-NA,,MX,MEX,,20.68,-105.254,187000,997
+G-PVU,Provo,,,gleam_basin,,W-NA,,US,USA,US-UT,40.219,-111.723,504000,2209
+G-PWE,Pevek,,,gleam_basin,,W-EU,,RU,RUS,,69.783,170.597,5000,1875
 G-PWM,Portland (US-ME),,,gleam_basin,,W-NA,,US,USA,US-ME,43.646,-70.309,,2242
-G-PWQ,Pavlodar,,,gleam_basin,,W-AS,,KZ,KAZ,,52.195,77.074,329000.0,660
-G-PXM,Puerto Escondido,,,gleam_basin,,W-NA,,MX,MEX,,15.877,-97.089,19000.0,1005
+G-PWQ,Pavlodar,,,gleam_basin,,W-AS,,KZ,KAZ,,52.195,77.074,329000,660
+G-PXM,Puerto Escondido,,,gleam_basin,,W-NA,,MX,MEX,,15.877,-97.089,19000,1005
 G-PXO,Porto Santo,,,gleam_basin,,W-EU,,PT,PRT,,33.073,-16.35,,1434
-G-PXU,Pleiku,,,gleam_basin,,W-AS,,VN,VNM,,14.005,108.017,143000.0,1128
-G-PYH,Puerto Ayacucho,,,gleam_basin,,W-SA,,VE,VEN,,5.62,-67.606,53000.0,1712
+G-PXU,Pleiku,,,gleam_basin,,W-AS,,VN,VNM,,14.005,108.017,143000,1128
+G-PYH,Puerto Ayacucho,,,gleam_basin,,W-SA,,VE,VEN,,5.62,-67.606,53000,1712
 G-PYJ,Polyarny,,,gleam_basin,,W-EU,,RU,RUS,,66.4,112.03,,1868
-G-PZB,Pietermaritzburg,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.649,30.399,751000.0,634
-G-PZH,Zhob,,,gleam_basin,,W-AS,,PK,PAK,,31.358,69.464,2000000.0,124
-G-PZI,Panzhihua,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,26.54,101.799,691000.0,417
+G-PZB,Pietermaritzburg,,,gleam_basin,,W-AF,,ZA,ZAF,,-29.649,30.399,751000,634
+G-PZH,Zhob,,,gleam_basin,,W-AS,,PK,PAK,,31.358,69.464,2000000,124
+G-PZI,Panzhihua,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,26.54,101.799,691000,417
 G-PZO,Puerto Ordaz,,,gleam_basin,,W-SA,,VE,VEN,,8.289,-62.76,,1713
-G-PZU,Port Sudan,,,gleam_basin,,W-AF,,SD,SDN,,19.434,37.234,490000.0,3016
+G-PZU,Port Sudan,,,gleam_basin,,W-AF,,SD,SDN,,19.434,37.234,490000,3016
 G-QBC,Bella Coola,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,52.388,-126.596,,2640
 G-QJH,Qassumiut Heliport,,,gleam_basin,,W-NA,,GL,GRL,,,,,953
-G-QOW,Owerri,,,gleam_basin,,W-AF,,NG,NGA,,5.427,7.206,215000.0,1408
+G-QOW,Owerri,,,gleam_basin,,W-AF,,NG,NGA,,5.427,7.206,215000,1408
 G-QPW,Kangaatsiaq,,,gleam_basin,,W-NA,,GL,GRL,,68.313,-53.46,,947
-G-QRO,Queretaro,,,gleam_basin,,W-NA,,MX,MEX,,20.617,-100.186,961000.0,988
-G-QRW,Warri,,,gleam_basin,,W-AF,,NG,NGA,,5.596,5.818,830000.0,1410
-G-QSF,Setif,,,gleam_basin,,W-AF,,DZ,DZA,,36.178,5.324,275000.0,16
+G-QRO,Queretaro,,,gleam_basin,,W-NA,,MX,MEX,,20.617,-100.186,961000,988
+G-QRW,Warri,,,gleam_basin,,W-AF,,NG,NGA,,5.596,5.818,830000,1410
+G-QSF,Setif,,,gleam_basin,,W-AF,,DZ,DZA,,36.178,5.324,275000,16
 G-QUB,Ubari,,,gleam_basin,,W-AF,,LY,LBY,,,,,160
 G-QUP,Saqqaq,,,gleam_basin,,W-NA,,GL,GRL,,,,,940
-G-RAB,Rabaul,,,gleam_basin,,W-OC,,PG,PNG,,-4.34,152.38,8000.0,2997
-G-RAE,Arar,,,gleam_basin,,W-AS,,SA,SAU,,30.907,41.138,149000.0,266
-G-RAH,Rafha,,,gleam_basin,,W-AS,,SA,SAU,,29.626,43.491,65000.0,265
-G-RAI,Praia,,,gleam_basin,,W-AF,,CV,CPV,,14.925,-23.493,113000.0,137
-G-RAJ,Rajkot,,,gleam_basin,,W-AS,,IN,IND,,22.309,70.78,1260000.0,1106
-G-RAK,Marrakech,,,gleam_basin,,W-AF,,MA,MAR,,31.607,-8.036,872000.0,824
-G-RAO,Ribeirao Preto,,,gleam_basin,,W-SA,,BR,BRA,,-21.136,-47.777,551000.0,1998
-G-RAP,Rapid City,,,gleam_basin,,W-NA,,US,USA,US-SD,44.045,-103.057,89000.0,2485
+G-RAB,Rabaul,,,gleam_basin,,W-OC,,PG,PNG,,-4.34,152.38,8000,2997
+G-RAE,Arar,,,gleam_basin,,W-AS,,SA,SAU,,30.907,41.138,149000,266
+G-RAH,Rafha,,,gleam_basin,,W-AS,,SA,SAU,,29.626,43.491,65000,265
+G-RAI,Praia,,,gleam_basin,,W-AF,,CV,CPV,,14.925,-23.493,113000,137
+G-RAJ,Rajkot,,,gleam_basin,,W-AS,,IN,IND,,22.309,70.78,1260000,1106
+G-RAK,Marrakech,,,gleam_basin,,W-AF,,MA,MAR,,31.607,-8.036,872000,824
+G-RAO,Ribeirao Preto,,,gleam_basin,,W-SA,,BR,BRA,,-21.136,-47.777,551000,1998
+G-RAP,Rapid City,,,gleam_basin,,W-NA,,US,USA,US-SD,44.045,-103.057,89000,2485
 G-RAR,Rarotonga Island,,,gleam_basin,,W-OC,,CK,COK,,-21.203,-159.806,,1358
-G-RAS,Rasht,,,gleam_basin,,W-AS,,IR,IRN,,37.323,49.618,595000.0,2953
-G-RBA,Rabat,,,gleam_basin,,W-AF,,MA,MAR,,34.051,-6.752,1705000.0,820
-G-RBQ,Rurrenabaque,,,gleam_basin,,W-SA,,BO,BOL,,-14.428,-67.497,12000.0,93
-G-RBR,Rio Branco,,,gleam_basin,,W-SA,,BR,BRA,,-9.869,-67.898,258000.0,2009
-G-RBX,Rumbek,,,gleam_basin,,W-AF,,SS,SSD,,6.825,29.669,32000.0,2539
+G-RAS,Rasht,,,gleam_basin,,W-AS,,IR,IRN,,37.323,49.618,595000,2953
+G-RBA,Rabat,,,gleam_basin,,W-AF,,MA,MAR,,34.051,-6.752,1705000,820
+G-RBQ,Rurrenabaque,,,gleam_basin,,W-SA,,BO,BOL,,-14.428,-67.497,12000,93
+G-RBR,Rio Branco,,,gleam_basin,,W-SA,,BR,BRA,,-9.869,-67.898,258000,2009
+G-RBX,Rumbek,,,gleam_basin,,W-AF,,SS,SSD,,6.825,29.669,32000,2539
 G-RBY,Ruby,,,gleam_basin,,W-NA,,US,USA,US-AK,64.727,-155.47,,2329
-G-RCB,Richards Bay,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.741,32.092,253000.0,627
-G-RCH,Riohacha,,,gleam_basin,,W-SA,,CO,COL,,11.526,-72.926,133000.0,1389
-G-RCM,Richmond (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-20.702,143.115,1700.0,1643
-G-RDD,Redding,,,gleam_basin,,W-NA,,US,USA,US-CA,40.509,-122.293,120000.0,2260
-G-RDM,Redmond,,,gleam_basin,,W-NA,,US,USA,US-WA,44.254,-121.15,64000.0,2262
-G-RDU,Raleigh,,,gleam_basin,,W-NA,,US,USA,US-NC,35.878,-78.787,1018000.0,2257
-G-RDZ,Rodez,,,gleam_basin,,W-EU,,FR,FRA,,44.408,2.483,28000.0,1514
+G-RCB,Richards Bay,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.741,32.092,253000,627
+G-RCH,Riohacha,,,gleam_basin,,W-SA,,CO,COL,,11.526,-72.926,133000,1389
+G-RCM,Richmond (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-VIC,-20.702,143.115,1700,1643
+G-RDD,Redding,,,gleam_basin,,W-NA,,US,USA,US-CA,40.509,-122.293,120000,2260
+G-RDM,Redmond,,,gleam_basin,,W-NA,,US,USA,US-WA,44.254,-121.15,64000,2262
+G-RDU,Raleigh,,,gleam_basin,,W-NA,,US,USA,US-NC,35.878,-78.787,1018000,2257
+G-RDZ,Rodez,,,gleam_basin,,W-EU,,FR,FRA,,44.408,2.483,28000,1514
 G-REA,Reao,,,gleam_basin,,W-OC,,PF,PYF,,-18.466,-136.44,,693
-G-REC,Recife,,,gleam_basin,,W-SA,,BR,BRA,,-8.126,-34.924,3651000.0,1992
-G-REG,Reggio Di Calabria,,,gleam_basin,,W-EU,,IT,ITA,,38.071,15.652,180000.0,3087
-G-REL,Trelew,,,gleam_basin,,W-SA,,AR,ARG,,-43.211,-65.27,93000.0,3197
-G-REN,Orenburg,,,gleam_basin,,W-EU,,RU,RUS,,51.796,55.457,550000.0,1858
-G-REP,Siem Reap,,,gleam_basin,,W-AS,,KH,KHM,,13.411,103.813,109000.0,222
-G-RES,Resistencia,,,gleam_basin,,W-SA,,AR,ARG,,-27.45,-59.056,387000.0,3196
+G-REC,Recife,,,gleam_basin,,W-SA,,BR,BRA,,-8.126,-34.924,3651000,1992
+G-REG,Reggio Di Calabria,,,gleam_basin,,W-EU,,IT,ITA,,38.071,15.652,180000,3087
+G-REL,Trelew,,,gleam_basin,,W-SA,,AR,ARG,,-43.211,-65.27,93000,3197
+G-REN,Orenburg,,,gleam_basin,,W-EU,,RU,RUS,,51.796,55.457,550000,1858
+G-REP,Siem Reap,,,gleam_basin,,W-AS,,KH,KHM,,13.411,103.813,109000,222
+G-RES,Resistencia,,,gleam_basin,,W-SA,,AR,ARG,,-27.45,-59.056,387000,3196
 G-RET,Rost,,,gleam_basin,,W-EU,,NO,NOR,,67.528,12.103,,1153
-G-REU,Reus,,,gleam_basin,,W-EU,,ES,ESP,,41.147,1.167,107000.0,2898
-G-REX,Reynosa,,,gleam_basin,,W-NA,,MX,MEX,,26.009,-98.228,499000.0,1012
-G-REZ,Resende,,,gleam_basin,,W-SA,,BR,BRA,,-22.479,-44.48,112000.0,1952
-G-RFD,Rockford,,,gleam_basin,,W-NA,,US,USA,US-IL,42.195,-89.097,286000.0,2203
-G-RGA,Rio Grande,,,gleam_basin,,W-SA,,AR,ARG,,-53.778,-67.749,188000.0,3188
+G-REU,Reus,,,gleam_basin,,W-EU,,ES,ESP,,41.147,1.167,107000,2898
+G-REX,Reynosa,,,gleam_basin,,W-NA,,MX,MEX,,26.009,-98.228,499000,1012
+G-REZ,Resende,,,gleam_basin,,W-SA,,BR,BRA,,-22.479,-44.48,112000,1952
+G-RFD,Rockford,,,gleam_basin,,W-NA,,US,USA,US-IL,42.195,-89.097,286000,2203
+G-RGA,Rio Grande,,,gleam_basin,,W-SA,,AR,ARG,,-53.778,-67.749,188000,3188
 G-RGI,Rangiroa Island,,,gleam_basin,,W-OC,,PF,PYF,,-14.954,-147.661,,687
-G-RGK,Gorno-Altaysk,,,gleam_basin,,W-EU,,RU,RUS,,51.967,85.833,60000.0,1838
-G-RGL,Rio Gallegos,,,gleam_basin,,W-SA,,AR,ARG,,-51.609,-69.313,86000.0,3189
-G-RGN,Yangon,,,gleam_basin,,W-AS,,MM,MMR,,16.907,96.133,4478000.0,875
-G-RGS,Burgos,,,gleam_basin,,W-EU,,ES,ESP,,42.358,-3.621,170000.0,2887
-G-RHD,Rio Hondo,,,gleam_basin,,W-SA,,AR,ARG,,-27.497,-64.936,5000.0,3217
-G-RHI,Rhinelander,,,gleam_basin,,W-NA,,US,USA,US-WI,45.631,-89.467,9000.0,2513
+G-RGK,Gorno-Altaysk,,,gleam_basin,,W-EU,,RU,RUS,,51.967,85.833,60000,1838
+G-RGL,Rio Gallegos,,,gleam_basin,,W-SA,,AR,ARG,,-51.609,-69.313,86000,3189
+G-RGN,Yangon,,,gleam_basin,,W-AS,,MM,MMR,,16.907,96.133,4478000,875
+G-RGS,Burgos,,,gleam_basin,,W-EU,,ES,ESP,,42.358,-3.621,170000,2887
+G-RHD,Rio Hondo,,,gleam_basin,,W-SA,,AR,ARG,,-27.497,-64.936,5000,3217
+G-RHI,Rhinelander,,,gleam_basin,,W-NA,,US,USA,US-WI,45.631,-89.467,9000,2513
 G-RHO,Rhodes,,,gleam_basin,,W-EU,,GR,GRC,,36.405,28.086,,914
-G-RIA,Santa Maria,,,gleam_basin,,W-SA,,BR,BRA,,-29.711,-53.688,249000.0,1979
-G-RIB,Riberalta,,,gleam_basin,,W-SA,,BO,BOL,,-11,-66,74000.0,92
+G-RIA,Santa Maria,,,gleam_basin,,W-SA,,BR,BRA,,-29.711,-53.688,249000,1979
+G-RIB,Riberalta,,,gleam_basin,,W-SA,,BO,BOL,,-11,-66,74000,92
 G-RIC,Richmond (US),,,gleam_basin,,W-NA,,US,USA,US-VA,37.505,-77.32,,2223
 G-RIS,Rishiri,,,gleam_basin,,W-AS,,JP,JPN,,45.242,141.186,,3118
-G-RIW,Riverton,,,gleam_basin,,W-NA,,US,USA,US-UT,43.064,-108.46,43000.0,2220
-G-RIX,Riga,,,gleam_basin,,W-EU,,LV,LVA,,56.924,23.971,743000.0,1116
+G-RIW,Riverton,,,gleam_basin,,W-NA,,US,USA,US-UT,43.064,-108.46,43000,2220
+G-RIX,Riga,,,gleam_basin,,W-EU,,LV,LVA,,56.924,23.971,743000,1116
 G-RIY,Mukalla,,,gleam_basin,,W-AS,,YE,YEM,,14.663,49.375,,581
-G-RJA,Rajahmundry,,,gleam_basin,,W-AS,,IN,IND,,17.11,81.818,305000.0,1062
-G-RJH,Rajshahi,,,gleam_basin,,W-AS,,BD,BGD,,24.437,88.617,810000.0,63
-G-RJK,Rijeka,,,gleam_basin,,W-EU,,HR,HRV,,45.217,14.57,171000.0,286
-G-RJL,Logrono,,,gleam_basin,,W-EU,,ES,ESP,,42.461,-2.322,144000.0,2881
+G-RJA,Rajahmundry,,,gleam_basin,,W-AS,,IN,IND,,17.11,81.818,305000,1062
+G-RJH,Rajshahi,,,gleam_basin,,W-AS,,BD,BGD,,24.437,88.617,810000,63
+G-RJK,Rijeka,,,gleam_basin,,W-EU,,HR,HRV,,45.217,14.57,171000,286
+G-RJL,Logrono,,,gleam_basin,,W-EU,,ES,ESP,,42.461,-2.322,144000,2881
 G-RKA,Aratika,,,gleam_basin,,W-OC,,PF,PYF,,,,,713
-G-RKD,Rockland,,,gleam_basin,,W-NA,,US,USA,US-MA,44.06,-69.099,18000.0,2158
-G-RKS,Rock Springs,,,gleam_basin,,W-NA,,US,USA,US-WY,41.594,-109.065,27000.0,2156
+G-RKD,Rockland,,,gleam_basin,,W-NA,,US,USA,US-MA,44.06,-69.099,18000,2158
+G-RKS,Rock Springs,,,gleam_basin,,W-NA,,US,USA,US-WY,41.594,-109.065,27000,2156
 G-RKT,Ras al Khaimah,,,gleam_basin,,W-AS,,AE,ARE,,25.614,55.939,,3178
-G-RKZ,Xigaze,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,29.352,89.311,80000.0,342
-G-RLG,Rostock,,,gleam_basin,,W-EU,,DE,DEU,,53.918,12.278,203000.0,729
+G-RKZ,Xigaze,,,gleam_basin,,W-AS,,CN,CHN,CN-XZ,29.352,89.311,80000,342
+G-RLG,Rostock,,,gleam_basin,,W-EU,,DE,DEU,,53.918,12.278,203000,729
 G-RLK,Bayannur,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,40.926,107.743,,317
 G-RLR,Ranohira,,,gleam_basin,,W-AF,,MG,MDG,,,,,1443
-G-RMA,Roma,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.545,148.775,11000.0,1581
+G-RMA,Roma,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.545,148.775,11000,1581
 G-RMF,Marsa Alam,,,gleam_basin,,W-AF,,EG,EGY,,25.557,34.584,,51
-G-RMI,Rimini,,,gleam_basin,,W-EU,,IT,ITA,,44.02,12.612,119000.0,3076
+G-RMI,Rimini,,,gleam_basin,,W-EU,,IT,ITA,,44.02,12.612,119000,3076
 G-RMP,Rampart,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2092
 G-RMQ,Taichung Cingcyuangang,,,gleam_basin,,W-AS,,TW,TWN,,24.265,120.621,,2822
 G-RMT,Rimatara,,,gleam_basin,,W-OC,,PF,PYF,,-22.637,-152.806,,677
-G-RNA,Arona,,,gleam_basin,,W-OC,,SB,SLB,,-9.861,161.98,79000.0,3036
+G-RNA,Arona,,,gleam_basin,,W-OC,,SB,SLB,,-9.861,161.98,79000,3036
 G-RNB,Ronneby,,,gleam_basin,,W-EU,,SE,SWE,,56.267,15.265,,2569
 G-RNL,Rennell Island,,,gleam_basin,,W-OC,,SB,SLB,,-11.534,160.063,,3027
 G-RNN,Bornholm,,,gleam_basin,,W-EU,,DK,DNK,,55.063,14.76,,1567
-G-RNO,Reno,,,gleam_basin,,W-NA,,US,USA,US-NV,39.499,-119.768,433000.0,2234
-G-RNS,Rennes,,,gleam_basin,,W-EU,,FR,FRA,,48.069,-1.735,209000.0,1532
-G-ROA,Roanoke,,,gleam_basin,,W-NA,,US,USA,US-VA,37.325,-79.975,216000.0,2514
-G-ROB,Monrovia,,,gleam_basin,,W-AF,,LR,LBR,,6.234,-10.362,1040999.0,153
+G-RNO,Reno,,,gleam_basin,,W-NA,,US,USA,US-NV,39.499,-119.768,433000,2234
+G-RNS,Rennes,,,gleam_basin,,W-EU,,FR,FRA,,48.069,-1.735,209000,1532
+G-ROA,Roanoke,,,gleam_basin,,W-NA,,US,USA,US-VA,37.325,-79.975,216000,2514
+G-ROB,Monrovia,,,gleam_basin,,W-AF,,LR,LBR,,6.234,-10.362,1040999,153
 G-ROC,Rochester (US-NY),,,gleam_basin,,W-NA,,US,USA,US-NY,43.119,-77.672,,2387
-G-ROI,Roi Et,,,gleam_basin,,W-AS,,TH,THA,,16.117,103.774,39000.0,539
-G-ROK,Rockhampton,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.382,150.475,66000.0,1685
-G-ROO,Rondonopolis,,,gleam_basin,,W-SA,,BR,BRA,,-16.586,-54.725,153000.0,2041
-G-ROP,Rota,,,gleam_basin,,W-OC,,MP,MNP,,14.174,145.243,3000.0,828
-G-ROR,Koror,,,gleam_basin,,W-OC,,PW,PLW,,7.367,134.544,11000.0,1722
-G-ROS,Rosario,,,gleam_basin,,W-SA,,AR,ARG,,-32.904,-60.785,1203000.0,3216
-G-ROV,Rostov,,,gleam_basin,,W-EU,,RU,RUS,,47.494,39.925,34000.0,1924
-G-ROW,Roswell,,,gleam_basin,,W-NA,,US,USA,US-GA,33.302,-104.531,95000.0,2515
-G-RPR,Raipur,,,gleam_basin,,W-AS,,IN,IND,,21.18,81.739,875000.0,1089
+G-ROI,Roi Et,,,gleam_basin,,W-AS,,TH,THA,,16.117,103.774,39000,539
+G-ROK,Rockhampton,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-23.382,150.475,66000,1685
+G-ROO,Rondonopolis,,,gleam_basin,,W-SA,,BR,BRA,,-16.586,-54.725,153000,2041
+G-ROP,Rota,,,gleam_basin,,W-OC,,MP,MNP,,14.174,145.243,3000,828
+G-ROR,Koror,,,gleam_basin,,W-OC,,PW,PLW,,7.367,134.544,11000,1722
+G-ROS,Rosario,,,gleam_basin,,W-SA,,AR,ARG,,-32.904,-60.785,1203000,3216
+G-ROV,Rostov,,,gleam_basin,,W-EU,,RU,RUS,,47.494,39.925,34000,1924
+G-ROW,Roswell,,,gleam_basin,,W-NA,,US,USA,US-GA,33.302,-104.531,95000,2515
+G-RPR,Raipur,,,gleam_basin,,W-AS,,IN,IND,,21.18,81.739,875000,1089
 G-RRG,Rodrigues Island,,,gleam_basin,,W-AF,,MU,MUS,,-19.758,63.361,,1197
 G-RRR,Raroia,,,gleam_basin,,W-OC,,PF,PYF,,-16.045,-142.477,,703
 G-RRS,Roros,,,gleam_basin,,W-EU,,NO,NOR,,62.578,11.342,,1150
 G-RSA,Santa Rosa (AR),,,gleam_basin,,W-SA,,AR,ARG,,-36.588,-64.276,,3199
 G-RST,Rochester (US-MN),,,gleam_basin,,W-NA,,US,USA,US-MN,43.908,-92.5,,2302
-G-RSU,Yeosu,,,gleam_basin,,W-AS,,KR,KOR,,34.842,127.617,342000.0,2807
-G-RSW,Fort Myers,,,gleam_basin,,W-NA,,US,USA,US-FL,26.536,-81.755,80000.0,2304
+G-RSU,Yeosu,,,gleam_basin,,W-AS,,KR,KOR,,34.842,127.617,342000,2807
+G-RSW,Fort Myers,,,gleam_basin,,W-NA,,US,USA,US-FL,26.536,-81.755,80000,2304
 G-RTA,Rotuma Island,,,gleam_basin,,W-OC,,FJ,FJI,,-12.483,177.071,,1185
-G-RTB,Roatan,,,gleam_basin,,W-NA,,HN,HND,,16.317,-86.523,8000.0,1195
-G-RTW,Saratov,,,gleam_basin,,W-EU,,RU,RUS,,51.565,46.047,843000.0,1829
-G-RUA,Arua,,,gleam_basin,,W-AF,,UG,UGA,,3.05,30.917,250000.0,3165
-G-RUD,Shahrud,,,gleam_basin,,W-AS,,IR,IRN,,36.425,55.104,132000.0,2942
-G-RUH,Riyadh,,,gleam_basin,,W-AS,,SA,SAU,,24.958,46.699,4465000.0,256
+G-RTB,Roatan,,,gleam_basin,,W-NA,,HN,HND,,16.317,-86.523,8000,1195
+G-RTW,Saratov,,,gleam_basin,,W-EU,,RU,RUS,,51.565,46.047,843000,1829
+G-RUA,Arua,,,gleam_basin,,W-AF,,UG,UGA,,3.05,30.917,250000,3165
+G-RUD,Shahrud,,,gleam_basin,,W-AS,,IR,IRN,,36.425,55.104,132000,2942
+G-RUH,Riyadh,,,gleam_basin,,W-AS,,SA,SAU,,24.958,46.699,4465000,256
 G-RUN,St-denis,,,gleam_basin,,W-AF,,RE,REU,,-20.887,55.51,,1232
 G-RUP,Rupsi,,,gleam_basin,,W-AS,,IN,IND,,,,,1076
 G-RUR,Rurutu,,,gleam_basin,,W-OC,,PF,PYF,,-22.434,-151.361,,689
-G-RUS,Marau,,,gleam_basin,,W-OC,,SB,SLB,,-9.862,160.825,27000.0,3028
-G-RUT,Rutland,,,gleam_basin,,W-NA,,US,USA,US-VT,43.529,-72.95,19000.0,2235
-G-RVD,Rio Verde,,,gleam_basin,,W-SA,,BR,BRA,,-17.835,-50.956,48000.0,1953
+G-RUS,Marau,,,gleam_basin,,W-OC,,SB,SLB,,-9.862,160.825,27000,3028
+G-RUT,Rutland,,,gleam_basin,,W-NA,,US,USA,US-VT,43.529,-72.95,19000,2235
+G-RVD,Rio Verde,,,gleam_basin,,W-SA,,BR,BRA,,-17.835,-50.956,48000,1953
 G-RVE,Saravena,,,gleam_basin,,W-SA,,CO,COL,,6.952,-71.857,,1368
-G-RVN,Rovaniemi,,,gleam_basin,,W-EU,,FI,FIN,,66.565,25.83,35000.0,499
-G-RVT,Ravensthorpe,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.797,120.208,1000.0,1590
+G-RVN,Rovaniemi,,,gleam_basin,,W-EU,,FI,FIN,,66.565,25.83,35000,499
+G-RVT,Ravensthorpe,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-33.797,120.208,1000,1590
 G-RVV,Raivavae,,,gleam_basin,,W-OC,,PF,PYF,,-23.885,-147.662,,681
-G-RYG,Moss,,,gleam_basin,,W-EU,,NO,NOR,,59.379,10.785,37000.0,1158
-G-RYK,Rahim Yar Khan,,,gleam_basin,,W-AS,,PK,PAK,,28.384,70.28,6800000.0,114
-G-RZE,Rzeszow,,,gleam_basin,,W-EU,,PL,POL,,50.11,22.019,246000.0,2850
+G-RYG,Moss,,,gleam_basin,,W-EU,,NO,NOR,,59.379,10.785,37000,1158
+G-RYK,Rahim Yar Khan,,,gleam_basin,,W-AS,,PK,PAK,,28.384,70.28,6800000,114
+G-RZE,Rzeszow,,,gleam_basin,,W-EU,,PL,POL,,50.11,22.019,246000,2850
 G-RZR,Ramsar,,,gleam_basin,,W-AS,,IR,IRN,,36.91,50.68,,2928
 G-SAF,Santa Fe (US),,,gleam_basin,,W-NA,,US,USA,US-NM,35.617,-106.089,,2391
-G-SAH,Sanaa,,,gleam_basin,,W-AS,,YE,YEM,,15.476,44.22,2008000.0,583
+G-SAH,Sanaa,,,gleam_basin,,W-AS,,YE,YEM,,15.476,44.22,2008000,583
 G-SAL,San Salvador (SV),,,gleam_basin,,W-NA,,SV,SLV,,13.441,-89.056,,2918
-G-SAN,San Diego,,,gleam_basin,,W-NA,,US,USA,US-CA,32.734,-117.19,3210000.0,2272
-G-SAP,San Pedro Sula,,,gleam_basin,,W-NA,,HN,HND,,15.453,-87.924,680000.0,1192
-G-SAT,San Antonio,,,gleam_basin,,W-NA,,US,USA,US-TX,29.534,-98.47,2003000.0,2341
-G-SAV,Savannah,,,gleam_basin,,W-NA,,US,USA,US-GA,32.128,-81.202,280000.0,2386
-G-SBA,Santa Barbara,,,gleam_basin,,W-NA,,US,USA,US-CA,34.426,-119.84,204000.0,2183
+G-SAN,San Diego,,,gleam_basin,,W-NA,,US,USA,US-CA,32.734,-117.19,3210000,2272
+G-SAP,San Pedro Sula,,,gleam_basin,,W-NA,,HN,HND,,15.453,-87.924,680000,1192
+G-SAT,San Antonio,,,gleam_basin,,W-NA,,US,USA,US-TX,29.534,-98.47,2003000,2341
+G-SAV,Savannah,,,gleam_basin,,W-NA,,US,USA,US-GA,32.128,-81.202,280000,2386
+G-SBA,Santa Barbara,,,gleam_basin,,W-NA,,US,USA,US-CA,34.426,-119.84,204000,2183
 G-SBH,St Barthelemy,,,gleam_basin,,W-NA,,BL,BLM,,,,,906
-G-SBN,South Bend,,,gleam_basin,,W-NA,,US,USA,US-IN,41.709,-86.317,281000.0,2185
-G-SBP,San Luis Obispo,,,gleam_basin,,W-NA,,US,USA,US-CA,35.237,-120.642,62000.0,2401
-G-SBW,Sibu,,,gleam_basin,,W-AS,,MY,MYS,,2.262,111.985,204000.0,188
-G-SBY,Salisbury,,,gleam_basin,,W-NA,,US,USA,US-MD,38.34,-75.51,106000.0,2384
-G-SBZ,Sibiu,,,gleam_basin,,W-EU,,RO,ROU,,45.786,24.091,156000.0,145
+G-SBN,South Bend,,,gleam_basin,,W-NA,,US,USA,US-IN,41.709,-86.317,281000,2185
+G-SBP,San Luis Obispo,,,gleam_basin,,W-NA,,US,USA,US-CA,35.237,-120.642,62000,2401
+G-SBW,Sibu,,,gleam_basin,,W-AS,,MY,MYS,,2.262,111.985,204000,188
+G-SBY,Salisbury,,,gleam_basin,,W-NA,,US,USA,US-MD,38.34,-75.51,106000,2384
+G-SBZ,Sibiu,,,gleam_basin,,W-EU,,RO,ROU,,45.786,24.091,156000,145
 G-SCC,Prudhoe Bay,,,gleam_basin,,W-NA,,US,USA,US-AK,70.195,-148.465,,2167
-G-SCE,State College,,,gleam_basin,,W-NA,,US,USA,US-PA,40.849,-77.849,88000.0,2165
-G-SCG,Spring Creek,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,,,13000.0,1598
-G-SCK,Stockton,,,gleam_basin,,W-NA,,US,USA,US-CA,37.894,-121.238,394000.0,2135
+G-SCE,State College,,,gleam_basin,,W-NA,,US,USA,US-PA,40.849,-77.849,88000,2165
+G-SCG,Spring Creek,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,,,13000,1598
+G-SCK,Stockton,,,gleam_basin,,W-NA,,US,USA,US-CA,37.894,-121.238,394000,2135
 G-SCL,Santiago (CL),,,gleam_basin,,W-SA,,CL,CHL,,-33.393,-70.786,,296
-G-SCN,Saarbrucken,,,gleam_basin,,W-EU,,DE,DEU,,49.215,7.11,770000.0,744
-G-SCO,Aktau,,,gleam_basin,,W-AS,,KZ,KAZ,,43.86,51.092,147000.0,657
-G-SCQ,Santiago de Compostela,,,gleam_basin,,W-EU,,ES,ESP,,42.896,-8.415,92000.0,2909
+G-SCN,Saarbrucken,,,gleam_basin,,W-EU,,DE,DEU,,49.215,7.11,770000,744
+G-SCO,Aktau,,,gleam_basin,,W-AS,,KZ,KAZ,,43.86,51.092,147000,657
+G-SCQ,Santiago de Compostela,,,gleam_basin,,W-EU,,ES,ESP,,42.896,-8.415,92000,2909
 G-SCT,Socotra,,,gleam_basin,,W-AS,,YE,YEM,,12.631,53.906,,584
 G-SCU,Santiago (CU),,,gleam_basin,,W-NA,,CU,CUB,,19.97,-75.835,,3243
-G-SCV,Suceava,,,gleam_basin,,W-EU,,RO,ROU,,47.688,26.354,106000.0,141
-G-SCW,Syktyvkar,,,gleam_basin,,W-EU,,RU,RUS,,61.647,50.845,231000.0,1821
+G-SCV,Suceava,,,gleam_basin,,W-EU,,RO,ROU,,47.688,26.354,106000,141
+G-SCW,Syktyvkar,,,gleam_basin,,W-EU,,RU,RUS,,61.647,50.845,231000,1821
 G-SCY,San Cristobal Island,,,gleam_basin,,W-SA,,EC,ECU,,-0.91,-89.617,,1464
 G-SCZ,Santa Cruz Island,,,gleam_basin,,W-OC,,SB,SLB,,-10.72,165.795,,3022
-G-SDD,Lubango,,,gleam_basin,,W-AF,,AO,AGO,,-14.925,13.575,126000.0,4
-G-SDE,Santiago del Estero,,,gleam_basin,,W-SA,,AR,ARG,,-27.766,-64.31,355000.0,3191
-G-SDF,Louisville,,,gleam_basin,,W-NA,,US,USA,US-KY,38.174,-85.736,1012000.0,2241
-G-SDG,Sanandaj,,,gleam_basin,,W-AS,,IR,IRN,,35.246,47.009,349000.0,2952
-G-SDJ,Sendai,,,gleam_basin,,W-AS,,JP,JPN,,38.14,140.917,2250000.0,3122
-G-SDK,Sandakan,,,gleam_basin,,W-AS,,MY,MYS,,5.901,118.059,392000.0,176
-G-SDL,Sundsvall,,,gleam_basin,,W-EU,,SE,SWE,,62.528,17.444,73000.0,2554
+G-SDD,Lubango,,,gleam_basin,,W-AF,,AO,AGO,,-14.925,13.575,126000,4
+G-SDE,Santiago del Estero,,,gleam_basin,,W-SA,,AR,ARG,,-27.766,-64.31,355000,3191
+G-SDF,Louisville,,,gleam_basin,,W-NA,,US,USA,US-KY,38.174,-85.736,1012000,2241
+G-SDG,Sanandaj,,,gleam_basin,,W-AS,,IR,IRN,,35.246,47.009,349000,2952
+G-SDJ,Sendai,,,gleam_basin,,W-AS,,JP,JPN,,38.14,140.917,2250000,3122
+G-SDK,Sandakan,,,gleam_basin,,W-AS,,MY,MYS,,5.901,118.059,392000,176
+G-SDL,Sundsvall,,,gleam_basin,,W-EU,,SE,SWE,,62.528,17.444,73000,2554
 G-SDP,Sand Point,,,gleam_basin,,W-NA,,US,USA,US-AK,55.315,-160.523,,2240
 G-SDQ,Santo Domingo (DO),,,gleam_basin,,W-NA,,DO,DOM,,18.43,-69.669,,1201
-G-SDR,Santander,,,gleam_basin,,W-EU,,ES,ESP,,43.427,-3.82,209000.0,2890
-G-SDT,Saidu Sharif,,,gleam_basin,,W-AS,,PK,PAK,,34.814,72.353,8500000.0,117
-G-SDY,Sidney,,,gleam_basin,,W-NA,,US,USA,US-OH,47.707,-104.193,21000.0,2326
-G-SEA,Seattle,,,gleam_basin,,W-NA,,US,USA,US-WA,47.449,-122.309,3644000.0,2429
+G-SDR,Santander,,,gleam_basin,,W-EU,,ES,ESP,,43.427,-3.82,209000,2890
+G-SDT,Saidu Sharif,,,gleam_basin,,W-AS,,PK,PAK,,34.814,72.353,8500000,117
+G-SDY,Sidney,,,gleam_basin,,W-NA,,US,USA,US-OH,47.707,-104.193,21000,2326
+G-SEA,Seattle,,,gleam_basin,,W-NA,,US,USA,US-WA,47.449,-122.309,3644000,2429
 G-SEB,Sebha,,,gleam_basin,,W-AF,,LY,LBY,,26.987,14.472,,156
-G-SEK,Srednekolymsk,,,gleam_basin,,W-EU,,RU,RUS,,67.481,153.736,3000.0,1830
-G-SER,Seymour,,,gleam_basin,,W-NA,,US,USA,US-IN,,,23000.0,2215
+G-SEK,Srednekolymsk,,,gleam_basin,,W-EU,,RU,RUS,,67.481,153.736,3000,1830
+G-SER,Seymour,,,gleam_basin,,W-NA,,US,USA,US-IN,,,23000,2215
 G-SEU,Seronera,,,gleam_basin,,W-AF,,TZ,TZA,,-2.458,34.822,,204
 G-SEZ,Mahe Island,,,gleam_basin,,W-AF,,SC,SYC,,-4.674,55.522,,552
-G-SFA,Sfax,,,gleam_basin,,W-AF,,TN,TUN,,34.718,10.691,453000.0,1793
+G-SFA,Sfax,,,gleam_basin,,W-AF,,TN,TUN,,34.718,10.691,453000,1793
 G-SFJ,Kangerlussuaq,,,gleam_basin,,W-NA,,GL,GRL,,67.012,-50.712,,946
 G-SFL,Sao Filipe,,,gleam_basin,,W-AF,,CV,CPV,,14.885,-24.48,,134
 G-SFN,Santa Fe (AR),,,gleam_basin,,W-SA,,AR,ARG,,-31.712,-60.812,,3194
-G-SFO,San Francisco,,,gleam_basin,,W-NA,,US,USA,US-CA,37.619,-122.375,3604000.0,2375
-G-SFT,Skelleftea,,,gleam_basin,,W-EU,,SE,SWE,,64.625,21.077,31000.0,2556
-G-SGC,Surgut,,,gleam_basin,,W-EU,,RU,RUS,,61.344,73.402,400000.0,1856
-G-SGD,Sonderborg,,,gleam_basin,,W-EU,,DK,DNK,,54.964,9.792,27000.0,1561
+G-SFO,San Francisco,,,gleam_basin,,W-NA,,US,USA,US-CA,37.619,-122.375,3604000,2375
+G-SFT,Skelleftea,,,gleam_basin,,W-EU,,SE,SWE,,64.625,21.077,31000,2556
+G-SGC,Surgut,,,gleam_basin,,W-EU,,RU,RUS,,61.344,73.402,400000,1856
+G-SGD,Sonderborg,,,gleam_basin,,W-EU,,DK,DNK,,54.964,9.792,27000,1561
 G-SGF,Springfield (US-MO),,,gleam_basin,,W-NA,,US,USA,US-MO,37.246,-93.389,,2270
 G-SGK,Sangapi,,,gleam_basin,,W-OC,,PG,PNG,,,,,2988
-G-SGN,Ho Chi Minh City,,,gleam_basin,,W-AS,,VN,VNM,,10.819,106.652,5314000.0,1129
+G-SGN,Ho Chi Minh City,,,gleam_basin,,W-AS,,VN,VNM,,10.819,106.652,5314000,1129
 G-SGO,St George (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-28.05,148.595,,1682
 G-SGS,Sanga Sanga,,,gleam_basin,,W-AS,,PH,PHL,,,,,605
 G-SGU,St George (US),,,gleam_basin,,W-NA,,US,USA,US-UT,37.036,-113.51,,2268
-G-SGX,Songea,,,gleam_basin,,W-AF,,TZ,TZA,,-10.683,35.583,126000.0,208
+G-SGX,Songea,,,gleam_basin,,W-AF,,TZ,TZA,,-10.683,35.583,126000,208
 G-SHB,Nakashibetsu,,,gleam_basin,,W-AS,,JP,JPN,,43.577,144.96,,3130
 G-SHC,Inda Selassie,,,gleam_basin,,W-AF,,ET,ETH,,,,,234
-G-SHE,Shenyang,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.64,123.483,4787000.0,413
+G-SHE,Shenyang,,,gleam_basin,,W-AS,,CN,CHN,CN-LN,41.64,123.483,4787000,413
 G-SHH,Shishmaref,,,gleam_basin,,W-NA,,US,USA,US-AK,66.25,-166.089,,2314
-G-SHL,Shillong,,,gleam_basin,,W-AS,,IN,IND,,25.704,91.979,376000.0,1087
+G-SHL,Shillong,,,gleam_basin,,W-AS,,IN,IND,,25.704,91.979,376000,1087
 G-SHM,Shirahama,,,gleam_basin,,W-AS,,JP,JPN,,33.662,135.364,,3131
-G-SHP,Qinhuangdao,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,39.968,119.731,1002999.0,411
-G-SHR,Sheridan,,,gleam_basin,,W-NA,,US,USA,US-WY,44.769,-106.98,19000.0,2310
-G-SHV,Shreveport,,,gleam_basin,,W-NA,,US,USA,US-LA,32.447,-93.826,287000.0,2311
+G-SHP,Qinhuangdao,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,39.968,119.731,1002999,411
+G-SHR,Sheridan,,,gleam_basin,,W-NA,,US,USA,US-WY,44.769,-106.98,19000,2310
+G-SHV,Shreveport,,,gleam_basin,,W-NA,,US,USA,US-LA,32.447,-93.826,287000,2311
 G-SHW,Sharurah,,,gleam_basin,,W-AS,,SA,SAU,,17.467,47.121,,260
 G-SHX,Shageluk,,,gleam_basin,,W-NA,,US,USA,US-AK,62.692,-159.569,,2348
 G-SID,Sal Island,,,gleam_basin,,W-AF,,CV,CPV,,16.741,-22.949,,135
 G-SIF,Simara,,,gleam_basin,,W-AS,,NP,NPL,,27.16,84.98,,559
 G-SIN,Singapore,,,gleam_basin,,W-AS,,SG,SGP,,,,,2821
-G-SIP,Simferopol,,,gleam_basin,,W-EU,,UA,UKR,,45.052,33.975,336000.0,2789
-G-SIT,Sitka,,,gleam_basin,,W-NA,,US,USA,US-AK,57.047,-135.362,7000.0,2276
+G-SIP,Simferopol,,,gleam_basin,,W-EU,,UA,UKR,,45.052,33.975,336000,2789
+G-SIT,Sitka,,,gleam_basin,,W-NA,,US,USA,US-AK,57.047,-135.362,7000,2276
 G-SJD,San Jose Cabo,,,gleam_basin,,W-NA,,MX,MEX,,23.152,-109.721,,1022
-G-SJE,San Jose del Guaviare,,,gleam_basin,,W-SA,,CO,COL,,2.58,-72.639,22000.0,1392
+G-SJE,San Jose del Guaviare,,,gleam_basin,,W-SA,,CO,COL,,2.58,-72.639,22000,1392
 G-SJI,San Jose (PH),,,gleam_basin,,W-AS,,PH,PHL,,12.361,121.047,,611
-G-SJJ,Sarajevo,,,gleam_basin,,W-EU,,BA,BIH,,43.825,18.331,697000.0,2819
-G-SJK,Sao Jose Dos Campos,,,gleam_basin,,W-SA,,BR,BRA,,-23.229,-45.861,754000.0,2011
-G-SJL,Sao Gabriel,,,gleam_basin,,W-SA,,BR,BRA,,-0.148,-66.986,55000.0,2012
+G-SJJ,Sarajevo,,,gleam_basin,,W-EU,,BA,BIH,,43.825,18.331,697000,2819
+G-SJK,Sao Jose Dos Campos,,,gleam_basin,,W-SA,,BR,BRA,,-23.229,-45.861,754000,2011
+G-SJL,Sao Gabriel,,,gleam_basin,,W-SA,,BR,BRA,,-0.148,-66.986,55000,2012
 G-SJO,San Jose (CR),,,gleam_basin,,W-NA,,CR,CRI,,9.994,-84.209,,802
-G-SJP,Sao Jose do Rio Preto,,,gleam_basin,,W-SA,,BR,BRA,,-20.817,-49.407,375000.0,2010
-G-SJT,San Angelo,,,gleam_basin,,W-NA,,US,USA,US-TX,31.358,-100.496,100000.0,2374
+G-SJP,Sao Jose do Rio Preto,,,gleam_basin,,W-SA,,BR,BRA,,-20.817,-49.407,375000,2010
+G-SJT,San Angelo,,,gleam_basin,,W-NA,,US,USA,US-TX,31.358,-100.496,100000,2374
 G-SJU,San Juan (PR),,,gleam_basin,,W-NA,,PR,PRI,,18.439,-66.002,,197
-G-SJW,Shijiazhuang,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,38.281,114.697,2417000.0,440
+G-SJW,Shijiazhuang,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,38.281,114.697,2417000,440
 G-SJY,Seinajoki,,,gleam_basin,,W-EU,,FI,FIN,,62.692,22.832,,506
 G-SKB,St Kitts,,,gleam_basin,,W-NA,,KN,KNA,,17.311,-62.719,,489
-G-SKD,Samarkand,,,gleam_basin,,W-AS,,UZ,UZB,,39.701,66.984,708000.0,2842
-G-SKG,Thessaloniki,,,gleam_basin,,W-EU,,GR,GRC,,40.52,22.971,828000.0,927
+G-SKD,Samarkand,,,gleam_basin,,W-AS,,UZ,UZB,,39.701,66.984,708000,2842
+G-SKG,Thessaloniki,,,gleam_basin,,W-EU,,GR,GRC,,40.52,22.971,828000,927
 G-SKH,Surkhet,,,gleam_basin,,W-AS,,NP,NPL,,28.586,81.636,,562
 G-SKK,Shaktoolik,,,gleam_basin,,W-NA,,US,USA,US-AK,64.371,-161.224,,2342
-G-SKO,Sokoto,,,gleam_basin,,W-AF,,NG,NGA,,12.916,5.207,732000.0,1422
-G-SKP,Skopje,,,gleam_basin,,W-EU,,MK,MKD,,41.962,21.621,494000.0,1327
-G-SKT,Sialkot,,,gleam_basin,,W-AS,,PK,PAK,,32.536,74.364,15500000.0,125
+G-SKO,Sokoto,,,gleam_basin,,W-AF,,NG,NGA,,12.916,5.207,732000,1422
+G-SKP,Skopje,,,gleam_basin,,W-EU,,MK,MKD,,41.962,21.621,494000,1327
+G-SKT,Sialkot,,,gleam_basin,,W-AS,,PK,PAK,,32.536,74.364,15500000,125
 G-SKU,Skyros,,,gleam_basin,,W-EU,,GR,GRC,,38.968,24.487,,926
-G-SKX,Saransk,,,gleam_basin,,W-EU,,RU,RUS,,54.125,45.212,303000.0,1881
-G-SKZ,Sukkur,,,gleam_basin,,W-AS,,PK,PAK,,27.722,68.792,3800000.0,110
-G-SLA,Salta,,,gleam_basin,,W-SA,,AR,ARG,,-24.856,-65.486,513000.0,3214
-G-SLC,Salt Lake City,,,gleam_basin,,W-NA,,US,USA,US-UT,40.788,-111.978,1098000.0,2303
+G-SKX,Saransk,,,gleam_basin,,W-EU,,RU,RUS,,54.125,45.212,303000,1881
+G-SKZ,Sukkur,,,gleam_basin,,W-AS,,PK,PAK,,27.722,68.792,3800000,110
+G-SLA,Salta,,,gleam_basin,,W-SA,,AR,ARG,,-24.856,-65.486,513000,3214
+G-SLC,Salt Lake City,,,gleam_basin,,W-NA,,US,USA,US-UT,40.788,-111.978,1098000,2303
 G-SLD,Sliac,,,gleam_basin,,W-EU,,SK,SVK,,48.638,19.134,,2815
 G-SLH,Sola,,,gleam_basin,,W-OC,,VU,VUT,,-13.852,167.537,,1324
-G-SLI,Solwezi,,,gleam_basin,,W-AF,,ZM,ZMB,,,,65000.0,1552
+G-SLI,Solwezi,,,gleam_basin,,W-AF,,ZM,ZMB,,,,65000,1552
 G-SLJ,Solomon,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-22.255,117.763,,1669
-G-SLK,Saranac Lake,,,gleam_basin,,W-NA,,US,USA,US-NY,44.385,-74.206,8000.0,2461
-G-SLL,Salalah,,,gleam_basin,,W-AS,,OM,OMN,,17.039,54.091,204000.0,1785
-G-SLM,Salamanca,,,gleam_basin,,W-EU,,ES,ESP,,40.952,-5.502,198000.0,2908
-G-SLN,Salina,,,gleam_basin,,W-NA,,US,USA,US-KS,38.791,-97.652,47000.0,2460
-G-SLP,San Luis Potosi,,,gleam_basin,,W-NA,,MX,MEX,,22.254,-100.931,992000.0,1031
-G-SLW,Saltillo,,,gleam_basin,,W-NA,,MX,MEX,,25.549,-100.929,754000.0,1030
-G-SLY,Salekhard,,,gleam_basin,,W-EU,,RU,RUS,,66.591,66.611,38000.0,1914
+G-SLK,Saranac Lake,,,gleam_basin,,W-NA,,US,USA,US-NY,44.385,-74.206,8000,2461
+G-SLL,Salalah,,,gleam_basin,,W-AS,,OM,OMN,,17.039,54.091,204000,1785
+G-SLM,Salamanca,,,gleam_basin,,W-EU,,ES,ESP,,40.952,-5.502,198000,2908
+G-SLN,Salina,,,gleam_basin,,W-NA,,US,USA,US-KS,38.791,-97.652,47000,2460
+G-SLP,San Luis Potosi,,,gleam_basin,,W-NA,,MX,MEX,,22.254,-100.931,992000,1031
+G-SLW,Saltillo,,,gleam_basin,,W-NA,,MX,MEX,,25.549,-100.929,754000,1030
+G-SLY,Salekhard,,,gleam_basin,,W-EU,,RU,RUS,,66.591,66.611,38000,1914
 G-SLZ,Sao Luiz,,,gleam_basin,,W-SA,,BR,BRA,,-2.585,-44.234,,2025
 G-SMA,Santa Maria Island,,,gleam_basin,,W-EU,,PT,PRT,,36.971,-25.171,,1437
-G-SMF,Sacramento,,,gleam_basin,,W-NA,,US,USA,US-CA,38.695,-121.591,1855000.0,2382
+G-SMF,Sacramento,,,gleam_basin,,W-NA,,US,USA,US-CA,38.695,-121.591,1855000,2382
 G-SMI,Samos,,,gleam_basin,,W-EU,,GR,GRC,,37.69,26.912,,929
 G-SMK,St Michael,,,gleam_basin,,W-NA,,US,USA,US-AK,63.49,-162.11,,2402
-G-SMQ,Sampit,,,gleam_basin,,W-AS,,ID,IDN,,-2.499,112.975,93000.0,1294
-G-SMR,Santa Marta,,,gleam_basin,,W-SA,,CO,COL,,11.12,-74.231,432000.0,1394
+G-SMQ,Sampit,,,gleam_basin,,W-AS,,ID,IDN,,-2.499,112.975,93000,1294
+G-SMR,Santa Marta,,,gleam_basin,,W-SA,,CO,COL,,11.12,-74.231,432000,1394
 G-SMS,Ste Marie,,,gleam_basin,,W-AF,,MG,MDG,,-17.094,49.816,,1457
 G-SNE,Sao Nicolau Island,,,gleam_basin,,W-AF,,CV,CPV,,16.588,-24.285,,136
-G-SNN,Shannon,,,gleam_basin,,W-EU,,IE,IRL,,52.702,-8.925,9000.0,2921
-G-SNO,Sakon Nakhon,,,gleam_basin,,W-AS,,TH,THA,,17.195,104.119,76000.0,521
+G-SNN,Shannon,,,gleam_basin,,W-EU,,IE,IRL,,52.702,-8.925,9000,2921
+G-SNO,Sakon Nakhon,,,gleam_basin,,W-AS,,TH,THA,,17.195,104.119,76000,521
 G-SNP,St Paul Island,,,gleam_basin,,W-NA,,US,USA,US-AK,57.167,-170.22,,2084
-G-SNU,Santa Clara,,,gleam_basin,,W-NA,,CU,CUB,,22.492,-79.944,251000.0,3251
-G-SNV,Santa Elena,,,gleam_basin,,W-SA,,VE,VEN,,4.555,-61.15,42000.0,1716
+G-SNU,Santa Clara,,,gleam_basin,,W-NA,,CU,CUB,,22.492,-79.944,251000,3251
+G-SNV,Santa Elena,,,gleam_basin,,W-SA,,VE,VEN,,4.555,-61.15,42000,1716
 G-SNW,Thandwe,,,gleam_basin,,W-AS,,MM,MMR,,18.461,94.3,,885
 G-SOB,Balaton,,,gleam_basin,,W-EU,,HU,HUN,,46.686,17.159,,832
-G-SOF,Sofia,,,gleam_basin,,W-EU,,BG,BGR,,42.697,23.411,1185000.0,84
+G-SOF,Sofia,,,gleam_basin,,W-EU,,BG,BGR,,42.697,23.411,1185000,84
 G-SOG,Sogndal,,,gleam_basin,,W-EU,,NO,NOR,,61.156,7.138,,1152
 G-SOJ,Sorkjosen,,,gleam_basin,,W-EU,,NO,NOR,,69.787,20.959,,1154
 G-SOM,San Tome,,,gleam_basin,,W-SA,,VE,VEN,,8.945,-64.151,,1720
 G-SON,Espiritu Santo,,,gleam_basin,,W-OC,,VU,VUT,,-15.505,167.22,,1320
-G-SOQ,Sorong,,,gleam_basin,,W-AS,,ID,IDN,,-0.894,131.287,126000.0,1284
-G-SOU,Southampton,,,gleam_basin,,W-EU,,GB,GBR,,50.95,-1.357,384000.0,781
-G-SOW,Show Low,,,gleam_basin,,W-NA,,US,USA,US-AZ,34.265,-110.006,11000.0,2500
-G-SPC,Santa Cruz de la Palma,,,gleam_basin,,W-EU,,ES,ESP,,28.626,-17.756,17000.0,2882
-G-SPD,Saidpur,,,gleam_basin,,W-AS,,BD,BGD,,25.759,88.909,232000.0,61
+G-SOQ,Sorong,,,gleam_basin,,W-AS,,ID,IDN,,-0.894,131.287,126000,1284
+G-SOU,Southampton,,,gleam_basin,,W-EU,,GB,GBR,,50.95,-1.357,384000,781
+G-SOW,Show Low,,,gleam_basin,,W-NA,,US,USA,US-AZ,34.265,-110.006,11000,2500
+G-SPC,Santa Cruz de la Palma,,,gleam_basin,,W-EU,,ES,ESP,,28.626,-17.756,17000,2882
+G-SPD,Saidpur,,,gleam_basin,,W-AS,,BD,BGD,,25.759,88.909,232000,61
 G-SPI,Springfield (US-IL),,,gleam_basin,,W-NA,,US,USA,US-IL,39.844,-89.678,,2066
-G-SPN,Saipan,,,gleam_basin,,W-OC,,MP,MNP,,15.119,145.729,48000.0,827
-G-SPP,Menongue,,,gleam_basin,,W-AF,,AO,AGO,,-14.658,17.72,13000.0,0
-G-SPS,Wichita Falls,,,gleam_basin,,W-NA,,US,USA,US-TX,33.989,-98.492,100000.0,2056
-G-SPU,Split,,,gleam_basin,,W-EU,,HR,HRV,,43.539,16.298,215000.0,284
+G-SPN,Saipan,,,gleam_basin,,W-OC,,MP,MNP,,15.119,145.729,48000,827
+G-SPP,Menongue,,,gleam_basin,,W-AF,,AO,AGO,,-14.658,17.72,13000,0
+G-SPS,Wichita Falls,,,gleam_basin,,W-NA,,US,USA,US-TX,33.989,-98.492,100000,2056
+G-SPU,Split,,,gleam_basin,,W-EU,,HR,HRV,,43.539,16.298,215000,284
 G-SQG,Sintang,,,gleam_basin,,W-AS,,ID,IDN,,0.064,111.473,,1311
-G-SRE,Sucre,,,gleam_basin,,W-SA,,BO,BOL,,-19.007,-65.289,225000.0,98
-G-SRG,Semarang,,,gleam_basin,,W-AS,,ID,IDN,,-6.973,110.375,1396000.0,1248
-G-SRI,Samarinda,,,gleam_basin,,W-AS,,ID,IDN,,-0.485,117.157,592000.0,1249
+G-SRE,Sucre,,,gleam_basin,,W-SA,,BO,BOL,,-19.007,-65.289,225000,98
+G-SRG,Semarang,,,gleam_basin,,W-AS,,ID,IDN,,-6.973,110.375,1396000,1248
+G-SRI,Samarinda,,,gleam_basin,,W-AS,,ID,IDN,,-0.485,117.157,592000,1249
 G-SRP,Stord,,,gleam_basin,,W-EU,,NO,NOR,,59.792,5.341,,1140
-G-SRQ,Sarasota,,,gleam_basin,,W-NA,,US,USA,US-FL,27.395,-82.554,706000.0,2124
-G-SRX,Sirte,,,gleam_basin,,W-AF,,LY,LBY,,31.063,16.595,128000.0,155
-G-SRY,Sari,,,gleam_basin,,W-AS,,IR,IRN,,36.636,53.194,255000.0,2934
-G-SSA,Salvador,,,gleam_basin,,W-SA,,BR,BRA,,-12.909,-38.322,3484000.0,1994
-G-SSG,Malabo,,,gleam_basin,,W-AF,,GQ,GNQ,,3.755,8.709,156000.0,2053
+G-SRQ,Sarasota,,,gleam_basin,,W-NA,,US,USA,US-FL,27.395,-82.554,706000,2124
+G-SRX,Sirte,,,gleam_basin,,W-AF,,LY,LBY,,31.063,16.595,128000,155
+G-SRY,Sari,,,gleam_basin,,W-AS,,IR,IRN,,36.636,53.194,255000,2934
+G-SSA,Salvador,,,gleam_basin,,W-SA,,BR,BRA,,-12.909,-38.322,3484000,1994
+G-SSG,Malabo,,,gleam_basin,,W-AF,,GQ,GNQ,,3.755,8.709,156000,2053
 G-SSH,Sharm El-Sheikh,,,gleam_basin,,W-AF,,EG,EGY,,27.977,34.395,,50
 G-SSY,M'Banza Congo,,,gleam_basin,,W-AF,,AO,AGO,,-6.27,14.247,,2
 G-STC,St Cloud,,,gleam_basin,,W-NA,,US,USA,US-MN,45.547,-94.06,,2189
 G-STD,Santo Domingo (VE),,,gleam_basin,,W-SA,,VE,VEN,,7.565,-72.035,,1709
 G-STG,St George Island,,,gleam_basin,,W-NA,,US,USA,US-AK,56.578,-169.662,,2188
-G-STI,Santiago,,,gleam_basin,,W-NA,,DO,DOM,,19.406,-70.605,5720000.0,1199
+G-STI,Santiago,,,gleam_basin,,W-NA,,DO,DOM,,19.406,-70.605,5720000,1199
 G-STL,St Louis,,,gleam_basin,,W-NA,,US,USA,US-MO,38.749,-90.37,,2190
-G-STM,Santarem,,,gleam_basin,,W-SA,,BR,BRA,,-2.425,-54.786,230000.0,1967
-G-STR,Stuttgart,,,gleam_basin,,W-EU,,DE,DEU,,48.69,9.222,2945000.0,732
+G-STM,Santarem,,,gleam_basin,,W-SA,,BR,BRA,,-2.425,-54.786,230000,1967
+G-STR,Stuttgart,,,gleam_basin,,W-EU,,DE,DEU,,48.69,9.222,2945000,732
 G-STS,Santa Rosa (US),,,gleam_basin,,W-NA,,US,USA,US-CA,38.509,-122.813,,2191
 G-STT,St Thomas Island,,,gleam_basin,,W-NA,,VI,VIR,,18.337,-64.973,,649
-G-STV,Surat,,,gleam_basin,,W-AS,,IN,IND,,21.114,72.742,3842000.0,1066
-G-STW,Stavropol,,,gleam_basin,,W-EU,,RU,RUS,,45.109,42.113,409000.0,1825
+G-STV,Surat,,,gleam_basin,,W-AS,,IN,IND,,21.114,72.742,3842000,1066
+G-STW,Stavropol,,,gleam_basin,,W-EU,,RU,RUS,,45.109,42.113,409000,1825
 G-STX,St Croix Island,,,gleam_basin,,W-NA,,VI,VIR,,17.702,-64.799,,648
-G-STY,Salto,,,gleam_basin,,W-SA,,UY,URY,,-31.438,-57.985,106000.0,517
-G-SUB,Surabaya,,,gleam_basin,,W-AS,,ID,IDN,,-7.38,112.787,2845000.0,1254
-G-SUF,Lamezia Terme,,,gleam_basin,,W-EU,,IT,ITA,,38.905,16.242,71000.0,3072
-G-SUG,Surigao,,,gleam_basin,,W-AS,,PH,PHL,,9.756,125.481,88000.0,598
-G-SUJ,Satu Mare,,,gleam_basin,,W-EU,,RO,ROU,,47.703,22.886,112000.0,142
+G-STY,Salto,,,gleam_basin,,W-SA,,UY,URY,,-31.438,-57.985,106000,517
+G-SUB,Surabaya,,,gleam_basin,,W-AS,,ID,IDN,,-7.38,112.787,2845000,1254
+G-SUF,Lamezia Terme,,,gleam_basin,,W-EU,,IT,ITA,,38.905,16.242,71000,3072
+G-SUG,Surigao,,,gleam_basin,,W-AS,,PH,PHL,,9.756,125.481,88000,598
+G-SUJ,Satu Mare,,,gleam_basin,,W-EU,,RO,ROU,,47.703,22.886,112000,142
 G-SUK,Sakkyryr,,,gleam_basin,,W-EU,,RU,RUS,,67.792,130.394,,1816
-G-SUL,Sui,,,gleam_basin,,W-AS,,PK,PAK,,28.645,69.177,3100000.0,112
-G-SUN,Sun Valley,,,gleam_basin,,W-NA,,US,USA,US-NV,43.504,-114.296,21000.0,2145
+G-SUL,Sui,,,gleam_basin,,W-AS,,PK,PAK,,28.645,69.177,3100000,112
+G-SUN,Sun Valley,,,gleam_basin,,W-NA,,US,USA,US-NV,43.504,-114.296,21000,2145
 G-SUR,Summer Beaver,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.709,-88.542,,2612
-G-SUT,Sumbawanga,,,gleam_basin,,W-AF,,TZ,TZA,,,,89000.0,202
-G-SUV,Suva,,,gleam_basin,,W-OC,,FJ,FJI,,-18.043,178.559,175000.0,1183
-G-SUX,Sioux City,,,gleam_basin,,W-NA,,US,USA,US-IA,42.403,-96.384,106000.0,2146
-G-SUY,Suntar,,,gleam_basin,,W-EU,,RU,RUS,,62.185,117.635,9000.0,1817
+G-SUT,Sumbawanga,,,gleam_basin,,W-AF,,TZ,TZA,,,,89000,202
+G-SUV,Suva,,,gleam_basin,,W-OC,,FJ,FJI,,-18.043,178.559,175000,1183
+G-SUX,Sioux City,,,gleam_basin,,W-NA,,US,USA,US-IA,42.403,-96.384,106000,2146
+G-SUY,Suntar,,,gleam_basin,,W-EU,,RU,RUS,,62.185,117.635,9000,1817
 G-SVA,Savoonga,,,gleam_basin,,W-NA,,US,USA,US-AK,63.686,-170.493,,2249
-G-SVB,Sambava,,,gleam_basin,,W-AF,,MG,MDG,,-14.279,50.175,43000.0,1448
-G-SVC,Silver City,,,gleam_basin,,W-NA,,US,USA,US-NM,,,12000.0,2358
+G-SVB,Sambava,,,gleam_basin,,W-AF,,MG,MDG,,-14.279,50.175,43000,1448
+G-SVC,Silver City,,,gleam_basin,,W-NA,,US,USA,US-NM,,,12000,2358
 G-SVD,St Vincent,,,gleam_basin,,W-NA,,VC,VCT,,13.157,-61.15,,1118
-G-SVG,Stavanger,,,gleam_basin,,W-EU,,NO,NOR,,58.877,5.638,173000.0,1147
-G-SVI,San Vicente del Caguan,,,gleam_basin,,W-SA,,CO,COL,,2.152,-74.766,2000.0,1390
-G-SVL,Savonlinna,,,gleam_basin,,W-EU,,FI,FIN,,61.943,28.945,27000.0,507
+G-SVG,Stavanger,,,gleam_basin,,W-EU,,NO,NOR,,58.877,5.638,173000,1147
+G-SVI,San Vicente del Caguan,,,gleam_basin,,W-SA,,CO,COL,,2.152,-74.766,2000,1390
+G-SVL,Savonlinna,,,gleam_basin,,W-EU,,FI,FIN,,61.943,28.945,27000,507
 G-SVP,Kuito,,,gleam_basin,,W-AF,,AO,AGO,,-12.405,16.947,,5
-G-SVQ,Sevilla,,,gleam_basin,,W-EU,,ES,ESP,,37.418,-5.893,1212000.0,2891
-G-SVR,Savissivik,,,gleam_basin,,W-NA,,GL,GRL,,,,0.0,944
-G-SVS,Stevens Village,,,gleam_basin,,W-NA,,US,USA,US-MI,,,100.0,2250
-G-SVX,Yekaterinburg,,,gleam_basin,,W-EU,,RU,RUS,,56.743,60.803,1313000.0,1849
-G-SWA,Shantou,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,23.552,116.503,1601000.0,363
-G-SWF,Newburgh,,,gleam_basin,,W-NA,,US,USA,US-NY,41.504,-74.105,28000.0,2121
-G-SWV,Evensk,,,gleam_basin,,W-EU,,RU,RUS,,,,2000.0,1834
-G-SXB,Strasbourg,,,gleam_basin,,W-EU,,FR,FRA,,48.538,7.628,440000.0,1512
+G-SVQ,Sevilla,,,gleam_basin,,W-EU,,ES,ESP,,37.418,-5.893,1212000,2891
+G-SVR,Savissivik,,,gleam_basin,,W-NA,,GL,GRL,,,,0,944
+G-SVS,Stevens Village,,,gleam_basin,,W-NA,,US,USA,US-MI,,,100,2250
+G-SVX,Yekaterinburg,,,gleam_basin,,W-EU,,RU,RUS,,56.743,60.803,1313000,1849
+G-SWA,Shantou,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,23.552,116.503,1601000,363
+G-SWF,Newburgh,,,gleam_basin,,W-NA,,US,USA,US-NY,41.504,-74.105,28000,2121
+G-SWV,Evensk,,,gleam_basin,,W-EU,,RU,RUS,,,,2000,1834
+G-SXB,Strasbourg,,,gleam_basin,,W-EU,,FR,FRA,,48.538,7.628,440000,1512
 G-SXK,Saumlaki,,,gleam_basin,,W-AS,,ID,IDN,,-7.989,131.306,,1265
 G-SXM,St Maarten,,,gleam_basin,,W-NA,,SX,SXM,,18.041,-63.109,,645
-G-SXR,Srinagar,,,gleam_basin,,W-AS,,IN,IND,,33.987,74.774,1140000.0,1081
+G-SXR,Srinagar,,,gleam_basin,,W-AS,,IN,IND,,33.987,74.774,1140000,1081
 G-SYD,Sydney (AU),,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-33.946,151.177,,1612
-G-SYJ,Sirjan,,,gleam_basin,,W-AS,,IR,IRN,,29.551,55.673,175000.0,2939
-G-SYM,Simao,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,22.793,100.959,163000.0,371
+G-SYJ,Sirjan,,,gleam_basin,,W-AS,,IR,IRN,,29.551,55.673,175000,2939
+G-SYM,Simao,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,22.793,100.959,163000,371
 G-SYO,Shonai,,,gleam_basin,,W-AS,,JP,JPN,,38.812,139.787,,3120
-G-SYR,Syracuse,,,gleam_basin,,W-NA,,US,USA,US-NY,43.111,-76.106,407000.0,2333
+G-SYR,Syracuse,,,gleam_basin,,W-NA,,US,USA,US-NY,43.111,-76.106,407000,2333
 G-SYS,Sashylakh,,,gleam_basin,,W-EU,,RU,RUS,,71.928,114.08,,1827
-G-SYX,Sanya,,,gleam_basin,,W-AS,,CN,CHN,CN-HI,18.303,109.412,363000.0,373
+G-SYX,Sanya,,,gleam_basin,,W-AS,,CN,CHN,CN-HI,18.303,109.412,363000,373
 G-SYY,Stornoway,,,gleam_basin,,W-EU,,GB,GBR,,58.216,-6.331,,772
-G-SYZ,Shiraz,,,gleam_basin,,W-AS,,IR,IRN,,29.539,52.59,1240000.0,2940
+G-SYZ,Shiraz,,,gleam_basin,,W-AS,,IR,IRN,,29.539,52.59,1240000,2940
 G-SZA,Soyo,,,gleam_basin,,W-AF,,AO,AGO,,-6.141,12.372,,3
 G-SZE,Semera,,,gleam_basin,,W-AF,,ET,ETH,,,,,233
-G-SZF,Carsamba,,,gleam_basin,,W-AS,,TR,TUR,,41.255,36.567,50000.0,1770
-G-SZG,Salzburg,,,gleam_basin,,W-EU,,AT,AUT,,47.793,13.004,206000.0,1698
-G-SZI,Zaysan,,,gleam_basin,,W-AS,,KZ,KAZ,,,,18000.0,661
-G-SZL,Warrensburg,,,gleam_basin,,W-NA,,US,USA,US-MO,38.73,-93.548,22000.0,2275
-G-SZZ,Szczecin,,,gleam_basin,,W-EU,,PL,POL,,53.585,14.902,408000.0,2853
+G-SZF,Carsamba,,,gleam_basin,,W-AS,,TR,TUR,,41.255,36.567,50000,1770
+G-SZG,Salzburg,,,gleam_basin,,W-EU,,AT,AUT,,47.793,13.004,206000,1698
+G-SZI,Zaysan,,,gleam_basin,,W-AS,,KZ,KAZ,,,,18000,661
+G-SZL,Warrensburg,,,gleam_basin,,W-NA,,US,USA,US-MO,38.73,-93.548,22000,2275
+G-SZZ,Szczecin,,,gleam_basin,,W-EU,,PL,POL,,53.585,14.902,408000,2853
 G-TAB,Tobago,,,gleam_basin,,W-NA,,TT,TTO,,11.15,-60.832,,225
-G-TAC,Tacloban,,,gleam_basin,,W-AS,,PH,PHL,,11.228,125.028,280000.0,607
-G-TAE,Daegu,,,gleam_basin,,W-AS,,KR,KOR,,35.897,128.655,2460000.0,2804
+G-TAC,Tacloban,,,gleam_basin,,W-AS,,PH,PHL,,11.228,125.028,280000,607
+G-TAE,Daegu,,,gleam_basin,,W-AS,,KR,KOR,,35.897,128.655,2460000,2804
 G-TAG,Tagbilaran,,,gleam_basin,,W-AS,,PH,PHL,,9.665,123.854,,606
 G-TAH,Tanna,,,gleam_basin,,W-OC,,VU,VUT,,-19.455,169.224,,1316
 G-TAI,Taizz,,,gleam_basin,,W-AS,,YE,YEM,,13.686,44.139,,585
-G-TAK,Takamatsu,,,gleam_basin,,W-AS,,JP,JPN,,34.214,134.016,334000.0,3145
+G-TAK,Takamatsu,,,gleam_basin,,W-AS,,JP,JPN,,34.214,134.016,334000,3145
 G-TAL,Tanana,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2277
-G-TAM,Tampico,,,gleam_basin,,W-NA,,MX,MEX,,22.296,-97.866,859000.0,1008
-G-TAO,Qingdao,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.266,120.374,2866000.0,391
-G-TAP,Tapachula,,,gleam_basin,,W-NA,,MX,MEX,,14.794,-92.37,222000.0,1007
-G-TAS,Tashkent,,,gleam_basin,,W-AS,,UZ,UZB,,41.258,69.281,2184000.0,2841
-G-TAT,Poprad,,,gleam_basin,,W-EU,,SK,SVK,,49.074,20.241,57000.0,2813
-G-TAY,Tartu,,,gleam_basin,,W-EU,,EE,EST,,58.307,26.69,101000.0,2865
+G-TAM,Tampico,,,gleam_basin,,W-NA,,MX,MEX,,22.296,-97.866,859000,1008
+G-TAO,Qingdao,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.266,120.374,2866000,391
+G-TAP,Tapachula,,,gleam_basin,,W-NA,,MX,MEX,,14.794,-92.37,222000,1007
+G-TAS,Tashkent,,,gleam_basin,,W-AS,,UZ,UZB,,41.258,69.281,2184000,2841
+G-TAT,Poprad,,,gleam_basin,,W-EU,,SK,SVK,,49.074,20.241,57000,2813
+G-TAY,Tartu,,,gleam_basin,,W-EU,,EE,EST,,58.307,26.69,101000,2865
 G-TBB,Tuyhoa,,,gleam_basin,,W-AS,,VN,VNM,,13.05,109.334,,1133
 G-TBG,Tabubil,,,gleam_basin,,W-OC,,PG,PNG,,-5.279,141.226,,2983
 G-TBI,The Bight,,,gleam_basin,,W-NA,,BS,BHS,,24.315,-75.452,,3221
-G-TBN,Fort Leonard Wood,,,gleam_basin,,W-NA,,US,USA,US-MO,37.742,-92.141,16000.0,2300
-G-TBO,Tabora,,,gleam_basin,,W-AF,,TZ,TZA,,-5.076,32.833,146000.0,209
-G-TBP,Tumbes,,,gleam_basin,,W-SA,,PE,PER,,-3.553,-80.381,109000.0,1222
-G-TBS,Tbilisi,,,gleam_basin,,W-AS,,GE,GEO,,41.669,44.955,1100000.0,843
-G-TBU,Nuku'alofa,,,gleam_basin,,W-OC,,TO,TON,,-21.241,-175.15,22000.0,2581
-G-TBW,Tambov,,,gleam_basin,,W-EU,,RU,RUS,,52.806,41.483,301000.0,1920
-G-TBZ,Tabriz,,,gleam_basin,,W-AS,,IR,IRN,,38.134,46.235,1413000.0,2950
+G-TBN,Fort Leonard Wood,,,gleam_basin,,W-NA,,US,USA,US-MO,37.742,-92.141,16000,2300
+G-TBO,Tabora,,,gleam_basin,,W-AF,,TZ,TZA,,-5.076,32.833,146000,209
+G-TBP,Tumbes,,,gleam_basin,,W-SA,,PE,PER,,-3.553,-80.381,109000,1222
+G-TBS,Tbilisi,,,gleam_basin,,W-AS,,GE,GEO,,41.669,44.955,1100000,843
+G-TBU,Nuku'alofa,,,gleam_basin,,W-OC,,TO,TON,,-21.241,-175.15,22000,2581
+G-TBW,Tambov,,,gleam_basin,,W-EU,,RU,RUS,,52.806,41.483,301000,1920
+G-TBZ,Tabriz,,,gleam_basin,,W-AS,,IR,IRN,,38.134,46.235,1413000,2950
 G-TCD,Tarapaca,,,gleam_basin,,W-SA,,CO,COL,,,,,1386
-G-TCG,Tacheng,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,46.673,83.341,50000.0,424
-G-TCO,Tumaco,,,gleam_basin,,W-SA,,CO,COL,,1.814,-78.749,87000.0,1385
+G-TCG,Tacheng,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,46.673,83.341,50000,424
+G-TCO,Tumaco,,,gleam_basin,,W-SA,,CO,COL,,1.814,-78.749,87000,1385
 G-TCP,Taba,,,gleam_basin,,W-AF,,EG,EGY,,29.588,34.778,,60
-G-TCQ,Tacna,,,gleam_basin,,W-SA,,PE,PER,,-18.053,-70.276,280000.0,1227
-G-TCR,Tuticorin,,,gleam_basin,,W-AS,,IN,IND,,,,436000.0,1091
-G-TCX,Tabas,,,gleam_basin,,W-AS,,IR,IRN,,33.668,56.893,50000.0,2954
+G-TCQ,Tacna,,,gleam_basin,,W-SA,,PE,PER,,-18.053,-70.276,280000,1227
+G-TCR,Tuticorin,,,gleam_basin,,W-AS,,IN,IND,,,,436000,1091
+G-TCX,Tabas,,,gleam_basin,,W-AS,,IR,IRN,,33.668,56.893,50000,2954
 G-TCZ,Tengchong,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,24.938,98.486,,421
-G-TDD,Trinidad,,,gleam_basin,,W-SA,,BO,BOL,,-14.819,-64.918,84000.0,86
-G-TDX,Trat,,,gleam_basin,,W-AS,,TH,THA,,12.275,102.319,22000.0,520
-G-TEE,Tebessa,,,gleam_basin,,W-AF,,DZ,DZA,,35.432,8.121,172000.0,19
-G-TEN,Tongren,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.883,109.309,118000.0,338
-G-TEQ,Tekirdag,,,gleam_basin,,W-AS,,TR,TUR,,41.138,27.919,122000.0,1755
+G-TDD,Trinidad,,,gleam_basin,,W-SA,,BO,BOL,,-14.819,-64.918,84000,86
+G-TDX,Trat,,,gleam_basin,,W-AS,,TH,THA,,12.275,102.319,22000,520
+G-TEE,Tebessa,,,gleam_basin,,W-AF,,DZ,DZA,,35.432,8.121,172000,19
+G-TEN,Tongren,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.883,109.309,118000,338
+G-TEQ,Tekirdag,,,gleam_basin,,W-AS,,TR,TUR,,41.138,27.919,122000,1755
 G-TER,Terceira,,,gleam_basin,,W-EU,,PT,PRT,,38.762,-27.091,,1430
-G-TET,Tete,,,gleam_basin,,W-AF,,MZ,MOZ,,-16.105,33.64,129000.0,967
+G-TET,Tete,,,gleam_basin,,W-AF,,MZ,MOZ,,-16.105,33.64,129000,967
 G-TEX,Telluride,,,gleam_basin,,W-NA,,US,USA,US-CO,37.954,-107.908,,2149
-G-TFF,Tefe,,,gleam_basin,,W-SA,,BR,BRA,,-3.383,-64.724,51000.0,1968
+G-TFF,Tefe,,,gleam_basin,,W-SA,,BR,BRA,,-3.383,-64.724,51000,1968
 G-TFI,Tufi,,,gleam_basin,,W-OC,,PG,PNG,,,,,2985
-G-TFN,Santa Cruz de Tenerife,,,gleam_basin,,W-EU,,ES,ESP,,28.483,-16.341,336000.0,2886
+G-TFN,Santa Cruz de Tenerife,,,gleam_basin,,W-EU,,ES,ESP,,28.483,-16.341,336000,2886
 G-TFS,Tenerife,,,gleam_basin,,W-EU,,ES,ESP,,28.045,-16.573,,2896
 G-TGC,Tanjung Manis,,,gleam_basin,,W-AS,,MY,MYS,,,,,171
-G-TGD,Podgorica,,,gleam_basin,,W-EU,,ME,MNE,,42.359,19.252,146000.0,844
-G-TGG,Kuala Terengganu,,,gleam_basin,,W-AS,,MY,MYS,,5.383,103.103,350000.0,194
-G-TGK,Taganrog,,,gleam_basin,,W-EU,,RU,RUS,,47.198,38.849,279000.0,1835
+G-TGD,Podgorica,,,gleam_basin,,W-EU,,ME,MNE,,42.359,19.252,146000,844
+G-TGG,Kuala Terengganu,,,gleam_basin,,W-AS,,MY,MYS,,5.383,103.103,350000,194
+G-TGK,Taganrog,,,gleam_basin,,W-EU,,RU,RUS,,47.198,38.849,279000,1835
 G-TGM,Tirgu Mures,,,gleam_basin,,W-EU,,RO,ROU,,46.468,24.413,,143
-G-TGO,Tongliao,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,43.557,122.2,884000.0,368
-G-TGP,Bor,,,gleam_basin,,W-EU,,RU,RUS,,61.59,89.994,27000.0,1814
-G-TGR,Touggourt,,,gleam_basin,,W-AF,,DZ,DZA,,33.068,6.089,134000.0,26
-G-TGT,Tanga,,,gleam_basin,,W-AF,,TZ,TZA,,-5.092,39.071,225000.0,203
-G-TGU,Tegucigalpa,,,gleam_basin,,W-NA,,HN,HND,,14.061,-87.217,946000.0,1191
-G-TGZ,Tuxtla Gutierrez,,,gleam_basin,,W-NA,,MX,MEX,,16.564,-93.022,641000.0,999
-G-THE,Teresina,,,gleam_basin,,W-SA,,BR,BRA,,-5.06,-42.824,907000.0,2030
-G-THL,Tachilek,,,gleam_basin,,W-AS,,MM,MMR,,20.484,99.935,52000.0,886
-G-THN,Trollhattan,,,gleam_basin,,W-EU,,SE,SWE,,58.318,12.345,45000.0,2568
-G-THO,Thorshofn,,,gleam_basin,,W-EU,,IS,ISL,,66.218,-15.336,530.0,1353
-G-THQ,Tianshui,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,34.559,105.86,3500000.0,462
-G-THR,Tehran,,,gleam_basin,,W-AS,,IR,IRN,,35.689,51.313,7873000.0,2966
-G-THS,Sukhothai,,,gleam_basin,,W-AS,,TH,THA,,17.238,99.818,10000.0,548
+G-TGO,Tongliao,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,43.557,122.2,884000,368
+G-TGP,Bor,,,gleam_basin,,W-EU,,RU,RUS,,61.59,89.994,27000,1814
+G-TGR,Touggourt,,,gleam_basin,,W-AF,,DZ,DZA,,33.068,6.089,134000,26
+G-TGT,Tanga,,,gleam_basin,,W-AF,,TZ,TZA,,-5.092,39.071,225000,203
+G-TGU,Tegucigalpa,,,gleam_basin,,W-NA,,HN,HND,,14.061,-87.217,946000,1191
+G-TGZ,Tuxtla Gutierrez,,,gleam_basin,,W-NA,,MX,MEX,,16.564,-93.022,641000,999
+G-THE,Teresina,,,gleam_basin,,W-SA,,BR,BRA,,-5.06,-42.824,907000,2030
+G-THL,Tachilek,,,gleam_basin,,W-AS,,MM,MMR,,20.484,99.935,52000,886
+G-THN,Trollhattan,,,gleam_basin,,W-EU,,SE,SWE,,58.318,12.345,45000,2568
+G-THO,Thorshofn,,,gleam_basin,,W-EU,,IS,ISL,,66.218,-15.336,530,1353
+G-THQ,Tianshui,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,34.559,105.86,3500000,462
+G-THR,Tehran,,,gleam_basin,,W-AS,,IR,IRN,,35.689,51.313,7873000,2966
+G-THS,Sukhothai,,,gleam_basin,,W-AS,,TH,THA,,17.238,99.818,10000,548
 G-THU,Pituffik,,,gleam_basin,,W-NA,,GL,GRL,,76.531,-68.703,,952
-G-THW,Trincomalee,,,gleam_basin,,W-AS,,LK,LKA,,,,108000.0,757
-G-THX,Turukhansk,,,gleam_basin,,W-EU,,RU,RUS,,65.797,87.935,5000.0,1824
-G-TIA,Tirana,,,gleam_basin,,W-EU,,AL,ALB,,41.415,19.721,895000.0,1783
-G-TID,Tiaret,,,gleam_basin,,W-AF,,DZ,DZA,,35.341,1.463,184000.0,47
+G-THW,Trincomalee,,,gleam_basin,,W-AS,,LK,LKA,,,,108000,757
+G-THX,Turukhansk,,,gleam_basin,,W-EU,,RU,RUS,,65.797,87.935,5000,1824
+G-TIA,Tirana,,,gleam_basin,,W-EU,,AL,ALB,,41.415,19.721,895000,1783
+G-TID,Tiaret,,,gleam_basin,,W-AF,,DZ,DZA,,35.341,1.463,184000,47
 G-TIF,Taif,,,gleam_basin,,W-AS,,SA,SAU,,21.483,40.543,,267
 G-TIH,Tikehau,,,gleam_basin,,W-OC,,PF,PYF,,-15.12,-148.231,,696
-G-TII,Tarin Kot,,,gleam_basin,,W-AS,,AF,AFG,,32.604,65.866,10000.0,899
-G-TIJ,Tijuana,,,gleam_basin,,W-NA,,MX,MEX,,32.541,-116.97,1553000.0,1034
+G-TII,Tarin Kot,,,gleam_basin,,W-AS,,AF,AFG,,32.604,65.866,10000,899
+G-TIJ,Tijuana,,,gleam_basin,,W-NA,,MX,MEX,,32.541,-116.97,1553000,1034
 G-TIM,Tembagapura,,,gleam_basin,,W-AS,,ID,IDN,,-4.528,136.887,,1309
-G-TIN,Tindouf,,,gleam_basin,,W-AF,,DZ,DZA,,27.7,-8.167,18000.0,46
-G-TIP,Tripoli,,,gleam_basin,,W-AF,,LY,LBY,,32.664,13.159,2189000.0,165
-G-TIR,Tirupati,,,gleam_basin,,W-AS,,IN,IND,,13.632,79.543,287000.0,1113
-G-TIU,Timaru,,,gleam_basin,,W-OC,,NZ,NZL,,-44.303,171.225,27000.0,3062
+G-TIN,Tindouf,,,gleam_basin,,W-AF,,DZ,DZA,,27.7,-8.167,18000,46
+G-TIP,Tripoli,,,gleam_basin,,W-AF,,LY,LBY,,32.664,13.159,2189000,165
+G-TIR,Tirupati,,,gleam_basin,,W-AS,,IN,IND,,13.632,79.543,287000,1113
+G-TIU,Timaru,,,gleam_basin,,W-OC,,NZ,NZL,,-44.303,171.225,27000,3062
 G-TIZ,Tari,,,gleam_basin,,W-OC,,PG,PNG,,-5.845,142.948,,3000
-G-TJA,Tarija,,,gleam_basin,,W-SA,,BO,BOL,,-21.556,-64.701,159000.0,87
-G-TJM,Tyumen,,,gleam_basin,,W-EU,,RU,RUS,,57.19,65.324,519000.0,1799
-G-TJQ,Tanjung Pandan,,,gleam_basin,,W-AS,,ID,IDN,,-2.746,107.755,62000.0,1237
-G-TJU,Kulob,,,gleam_basin,,W-AS,,TJ,TJK,,37.988,69.805,115000.0,976
-G-TKD,Takoradi,,,gleam_basin,,W-AF,,GH,GHA,,4.896,-1.775,233000.0,100
-G-TKG,Bandar Lampung,,,gleam_basin,,W-AS,,ID,IDN,,-5.241,105.176,865000.0,1250
+G-TJA,Tarija,,,gleam_basin,,W-SA,,BO,BOL,,-21.556,-64.701,159000,87
+G-TJM,Tyumen,,,gleam_basin,,W-EU,,RU,RUS,,57.19,65.324,519000,1799
+G-TJQ,Tanjung Pandan,,,gleam_basin,,W-AS,,ID,IDN,,-2.746,107.755,62000,1237
+G-TJU,Kulob,,,gleam_basin,,W-AS,,TJ,TJK,,37.988,69.805,115000,976
+G-TKD,Takoradi,,,gleam_basin,,W-AF,,GH,GHA,,4.896,-1.775,233000,100
+G-TKG,Bandar Lampung,,,gleam_basin,,W-AS,,ID,IDN,,-5.241,105.176,865000,1250
 G-TKJ,Tok,,,gleam_basin,,W-NA,,US,USA,US-AK,63.329,-142.954,,2083
 G-TKK,Chuuk,,,gleam_basin,,W-OC,,FM,FSM,,7.462,151.843,,1209
-G-TKQ,Kigoma,,,gleam_basin,,W-AF,,TZ,TZA,,-4.886,29.671,164000.0,201
-G-TKS,Tokushima,,,gleam_basin,,W-AS,,JP,JPN,,34.133,134.607,444000.0,3126
-G-TKU,Turku,,,gleam_basin,,W-EU,,FI,FIN,,60.514,22.263,176000.0,508
+G-TKQ,Kigoma,,,gleam_basin,,W-AF,,TZ,TZA,,-4.886,29.671,164000,201
+G-TKS,Tokushima,,,gleam_basin,,W-AS,,JP,JPN,,34.133,134.607,444000,3126
+G-TKU,Turku,,,gleam_basin,,W-EU,,FI,FIN,,60.514,22.263,176000,508
 G-TKV,Tatakoto,,,gleam_basin,,W-OC,,PF,PYF,,-17.355,-138.445,,691
 G-TKX,Takaroa,,,gleam_basin,,W-OC,,PF,PYF,,-14.456,-145.025,,685
-G-TLC,Toluca,,,gleam_basin,,W-NA,,MX,MEX,,19.337,-99.566,1531000.0,1016
-G-TLE,Toliara,,,gleam_basin,,W-AF,,MG,MDG,,-23.383,43.729,115000.0,1452
-G-TLH,Tallahassee,,,gleam_basin,,W-NA,,US,USA,US-FL,30.396,-84.35,253000.0,2110
-G-TLL,Tallinn,,,gleam_basin,,W-EU,,EE,EST,,59.413,24.833,394000.0,2867
-G-TLM,Tlemcen,,,gleam_basin,,W-AF,,DZ,DZA,,35.017,-1.45,230000.0,35
-G-TLN,Toulon,,,gleam_basin,,W-EU,,FR,FRA,,43.097,6.146,358000.0,1520
-G-TLQ,Turpan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.031,89.099,255000.0,415
-G-TLS,Toulouse,,,gleam_basin,,W-EU,,FR,FRA,,43.629,1.364,847000.0,1519
-G-TLV,Tel Aviv,,,gleam_basin,,W-AS,,IL,ISR,,32.011,34.887,433000.0,1205
+G-TLC,Toluca,,,gleam_basin,,W-NA,,MX,MEX,,19.337,-99.566,1531000,1016
+G-TLE,Toliara,,,gleam_basin,,W-AF,,MG,MDG,,-23.383,43.729,115000,1452
+G-TLH,Tallahassee,,,gleam_basin,,W-NA,,US,USA,US-FL,30.396,-84.35,253000,2110
+G-TLL,Tallinn,,,gleam_basin,,W-EU,,EE,EST,,59.413,24.833,394000,2867
+G-TLM,Tlemcen,,,gleam_basin,,W-AF,,DZ,DZA,,35.017,-1.45,230000,35
+G-TLN,Toulon,,,gleam_basin,,W-EU,,FR,FRA,,43.097,6.146,358000,1520
+G-TLQ,Turpan,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.031,89.099,255000,415
+G-TLS,Toulouse,,,gleam_basin,,W-EU,,FR,FRA,,43.629,1.364,847000,1519
+G-TLV,Tel Aviv,,,gleam_basin,,W-AS,,IL,ISR,,32.011,34.887,433000,1205
 G-TMC,Tambolaka,,,gleam_basin,,W-AS,,ID,IDN,,-9.41,119.244,,1279
-G-TME,Tame,,,gleam_basin,,W-SA,,CO,COL,,6.451,-71.76,29000.0,1406
+G-TME,Tame,,,gleam_basin,,W-SA,,CO,COL,,6.451,-71.76,29000,1406
 G-TMI,Tumlingtar,,,gleam_basin,,W-AS,,NP,NPL,,27.315,87.193,,564
-G-TMJ,Termez,,,gleam_basin,,W-AS,,UZ,UZB,,37.287,67.31,116000.0,2844
-G-TML,Tamale,,,gleam_basin,,W-AF,,GH,GHA,,9.557,-0.863,361000.0,102
-G-TMM,Toamasina,,,gleam_basin,,W-AF,,MG,MDG,,-18.11,49.393,210000.0,1454
-G-TMP,Tampere,,,gleam_basin,,W-EU,,FI,FIN,,61.414,23.604,259000.0,511
-G-TMR,Tamanrasset,,,gleam_basin,,W-AF,,DZ,DZA,,22.812,5.451,76000.0,38
-G-TMS,Sao Tome,,,gleam_basin,,W-AF,,ST,STP,,0.378,6.712,88000.0,551
+G-TMJ,Termez,,,gleam_basin,,W-AS,,UZ,UZB,,37.287,67.31,116000,2844
+G-TML,Tamale,,,gleam_basin,,W-AF,,GH,GHA,,9.557,-0.863,361000,102
+G-TMM,Toamasina,,,gleam_basin,,W-AF,,MG,MDG,,-18.11,49.393,210000,1454
+G-TMP,Tampere,,,gleam_basin,,W-EU,,FI,FIN,,61.414,23.604,259000,511
+G-TMR,Tamanrasset,,,gleam_basin,,W-AF,,DZ,DZA,,22.812,5.451,76000,38
+G-TMS,Sao Tome,,,gleam_basin,,W-AF,,ST,STP,,0.378,6.712,88000,551
 G-TMT,Trombetas,,,gleam_basin,,W-SA,,BR,BRA,,-1.49,-56.397,,2004
 G-TMU,Tambor,,,gleam_basin,,W-NA,,CR,CRI,,9.739,-85.014,,801
-G-TMW,Tamworth,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.084,150.847,39000.0,1642
-G-TMX,Timimoun,,,gleam_basin,,W-AF,,DZ,DZA,,29.237,0.276,49000.0,39
-G-TNA,Jinan,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.857,117.216,2798000.0,476
-G-TNG,Tangier,,,gleam_basin,,W-AF,,MA,MAR,,35.727,-5.917,750000.0,823
-G-TNJ,Tanjung Pinang,,,gleam_basin,,W-AS,,ID,IDN,,0.923,104.532,192000.0,1291
-G-TNR,Antananarivo,,,gleam_basin,,W-AF,,MG,MDG,,-18.797,47.479,1697000.0,1449
-G-TNW,Tena,,,gleam_basin,,W-SA,,EC,ECU,,-1.06,-77.583,31000.0,1470
+G-TMW,Tamworth,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.084,150.847,39000,1642
+G-TMX,Timimoun,,,gleam_basin,,W-AF,,DZ,DZA,,29.237,0.276,49000,39
+G-TNA,Jinan,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.857,117.216,2798000,476
+G-TNG,Tangier,,,gleam_basin,,W-AF,,MA,MAR,,35.727,-5.917,750000,823
+G-TNJ,Tanjung Pinang,,,gleam_basin,,W-AS,,ID,IDN,,0.923,104.532,192000,1291
+G-TNR,Antananarivo,,,gleam_basin,,W-AF,,MG,MDG,,-18.797,47.479,1697000,1449
+G-TNW,Tena,,,gleam_basin,,W-SA,,EC,ECU,,-1.06,-77.583,31000,1470
 G-TNZ,Tosontsengel,,,gleam_basin,,W-AS,,MN,MNG,,,,,851
-G-TOB,Tobruk,,,gleam_basin,,W-AF,,LY,LBY,,31.861,23.907,264000.0,164
+G-TOB,Tobruk,,,gleam_basin,,W-AF,,LY,LBY,,31.861,23.907,264000,164
 G-TOD,Tioman Island,,,gleam_basin,,W-AS,,MY,MYS,,2.818,104.16,,189
-G-TOE,Tozeur,,,gleam_basin,,W-AF,,TN,TUN,,33.94,8.111,40000.0,1794
-G-TOF,Tomsk,,,gleam_basin,,W-EU,,RU,RUS,,56.38,85.208,535000.0,1900
+G-TOE,Tozeur,,,gleam_basin,,W-AF,,TN,TUN,,33.94,8.111,40000,1794
+G-TOF,Tomsk,,,gleam_basin,,W-EU,,RU,RUS,,56.38,85.208,535000,1900
 G-TOG,Togiak,,,gleam_basin,,W-NA,,US,USA,US-AK,59.053,-160.397,,2154
-G-TOH,Torres,,,gleam_basin,,W-OC,,VU,VUT,,-13.328,166.638,33000.0,1322
-G-TOL,Toledo,,,gleam_basin,,W-NA,,US,USA,US-OH,41.587,-83.808,489000.0,2411
-G-TOS,Tromso,,,gleam_basin,,W-EU,,NO,NOR,,69.683,18.919,52000.0,1165
+G-TOH,Torres,,,gleam_basin,,W-OC,,VU,VUT,,-13.328,166.638,33000,1322
+G-TOL,Toledo,,,gleam_basin,,W-NA,,US,USA,US-OH,41.587,-83.808,489000,2411
+G-TOS,Tromso,,,gleam_basin,,W-EU,,NO,NOR,,69.683,18.919,52000,1165
 G-TOU,Touho,,,gleam_basin,,W-OC,,NC,NCL,,-20.79,165.259,,3175
-G-TOY,Toyama,,,gleam_basin,,W-AS,,JP,JPN,,36.648,137.188,333000.0,3143
-G-TPA,Tampa,,,gleam_basin,,W-NA,,US,USA,US-FL,27.976,-82.533,2804000.0,2195
-G-TPE,Taipei,,,gleam_basin,,W-AS,,TW,TWN,,25.078,121.233,6900000.0,2825
-G-TPP,Tarapoto,,,gleam_basin,,W-SA,,PE,PER,,-6.509,-76.373,1000.0,1217
-G-TPQ,Tepic,,,gleam_basin,,W-NA,,MX,MEX,,21.419,-104.843,319000.0,1001
-G-TPS,Trapani,,,gleam_basin,,W-EU,,IT,ITA,,37.911,12.488,59000.0,3074
+G-TOY,Toyama,,,gleam_basin,,W-AS,,JP,JPN,,36.648,137.188,333000,3143
+G-TPA,Tampa,,,gleam_basin,,W-NA,,US,USA,US-FL,27.976,-82.533,2804000,2195
+G-TPE,Taipei,,,gleam_basin,,W-AS,,TW,TWN,,25.078,121.233,6900000,2825
+G-TPP,Tarapoto,,,gleam_basin,,W-SA,,PE,PER,,-6.509,-76.373,1000,1217
+G-TPQ,Tepic,,,gleam_basin,,W-NA,,MX,MEX,,21.419,-104.843,319000,1001
+G-TPS,Trapani,,,gleam_basin,,W-EU,,IT,ITA,,37.911,12.488,59000,3074
 G-TQL,Tarko-Sale,,,gleam_basin,,W-EU,,RU,RUS,,64.931,77.818,,1837
 G-TQR,San Domino Island,,,gleam_basin,,W-EU,,IT,ITA,,,,,3078
-G-TRC,Torreon,,,gleam_basin,,W-NA,,MX,MEX,,25.568,-103.411,1144000.0,1003
-G-TRD,Trondheim,,,gleam_basin,,W-EU,,NO,NOR,,63.458,10.924,147000.0,1149
+G-TRC,Torreon,,,gleam_basin,,W-NA,,MX,MEX,,25.568,-103.411,1144000,1003
+G-TRD,Trondheim,,,gleam_basin,,W-EU,,NO,NOR,,63.458,10.924,147000,1149
 G-TRE,Tiree,,,gleam_basin,,W-EU,,GB,GBR,,56.499,-6.869,,776
-G-TRG,Tauranga,,,gleam_basin,,W-OC,,NZ,NZL,,-37.672,176.196,121000.0,3063
+G-TRG,Tauranga,,,gleam_basin,,W-OC,,NZ,NZL,,-37.672,176.196,121000,3063
 G-TRI,Tri-Cities,,,gleam_basin,,W-NA,,US,USA,US-TN,36.475,-82.407,,2253
-G-TRK,Tarakan,,,gleam_basin,,W-AS,,ID,IDN,,3.327,117.569,193000.0,1266
-G-TRN,Turin,,,gleam_basin,,W-EU,,IT,ITA,,45.201,7.65,1652000.0,3082
-G-TRO,Taree,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.889,152.514,44000.0,1624
-G-TRS,Trieste,,,gleam_basin,,W-EU,,IT,ITA,,45.827,13.472,216000.0,3083
-G-TRU,Trujillo,,,gleam_basin,,W-SA,,PE,PER,,-8.081,-79.109,765000.0,1220
-G-TRV,Thiruvananthapuram,,,gleam_basin,,W-AS,,IN,IND,,8.482,76.92,954000.0,1084
-G-TRW,Tarawa,,,gleam_basin,,W-OC,,KI,KIR,,1.382,173.147,29000.0,644
-G-TRZ,Tiruchchirappalli,,,gleam_basin,,W-AS,,IN,IND,,10.765,78.71,866000.0,1065
-G-TSE,Astana,,,gleam_basin,,W-AS,,KZ,KAZ,,51.022,71.467,346000.0,662
-G-TSH,Tshikapa,,,gleam_basin,,W-AF,,CD,COD,,-6.438,20.795,267000.0,1340
-G-TSJ,Tsushima,,,gleam_basin,,W-AS,,JP,JPN,,34.285,129.331,68000.0,3125
-G-TSN,Tianjin,,,gleam_basin,,W-AS,,CN,CHN,CN-TJ,39.124,117.346,7180000.0,322
-G-TSR,Timisoara,,,gleam_basin,,W-EU,,RO,ROU,,45.81,21.338,315000.0,150
-G-TST,Trang,,,gleam_basin,,W-AS,,TH,THA,,7.509,99.617,148000.0,533
-G-TSV,Townsville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-19.253,146.765,139000.0,1627
-G-TTA,Tan Tan,,,gleam_basin,,W-AF,,MA,MAR,,28.448,-11.161,65000.0,811
-G-TTE,Ternate,,,gleam_basin,,W-AS,,ID,IDN,,0.831,127.381,188000.0,1236
-G-TTJ,Tottori,,,gleam_basin,,W-AS,,JP,JPN,,35.53,134.167,154000.0,3109
-G-TTN,Trenton,,,gleam_basin,,W-NA,,US,USA,US-NJ,40.277,-74.813,297000.0,2109
+G-TRK,Tarakan,,,gleam_basin,,W-AS,,ID,IDN,,3.327,117.569,193000,1266
+G-TRN,Turin,,,gleam_basin,,W-EU,,IT,ITA,,45.201,7.65,1652000,3082
+G-TRO,Taree,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-31.889,152.514,44000,1624
+G-TRS,Trieste,,,gleam_basin,,W-EU,,IT,ITA,,45.827,13.472,216000,3083
+G-TRU,Trujillo,,,gleam_basin,,W-SA,,PE,PER,,-8.081,-79.109,765000,1220
+G-TRV,Thiruvananthapuram,,,gleam_basin,,W-AS,,IN,IND,,8.482,76.92,954000,1084
+G-TRW,Tarawa,,,gleam_basin,,W-OC,,KI,KIR,,1.382,173.147,29000,644
+G-TRZ,Tiruchchirappalli,,,gleam_basin,,W-AS,,IN,IND,,10.765,78.71,866000,1065
+G-TSE,Astana,,,gleam_basin,,W-AS,,KZ,KAZ,,51.022,71.467,346000,662
+G-TSH,Tshikapa,,,gleam_basin,,W-AF,,CD,COD,,-6.438,20.795,267000,1340
+G-TSJ,Tsushima,,,gleam_basin,,W-AS,,JP,JPN,,34.285,129.331,68000,3125
+G-TSN,Tianjin,,,gleam_basin,,W-AS,,CN,CHN,CN-TJ,39.124,117.346,7180000,322
+G-TSR,Timisoara,,,gleam_basin,,W-EU,,RO,ROU,,45.81,21.338,315000,150
+G-TST,Trang,,,gleam_basin,,W-AS,,TH,THA,,7.509,99.617,148000,533
+G-TSV,Townsville,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-19.253,146.765,139000,1627
+G-TTA,Tan Tan,,,gleam_basin,,W-AF,,MA,MAR,,28.448,-11.161,65000,811
+G-TTE,Ternate,,,gleam_basin,,W-AS,,ID,IDN,,0.831,127.381,188000,1236
+G-TTJ,Tottori,,,gleam_basin,,W-AS,,JP,JPN,,35.53,134.167,154000,3109
+G-TTN,Trenton,,,gleam_basin,,W-NA,,US,USA,US-NJ,40.277,-74.813,297000,2109
 G-TTQ,Tortuquero,,,gleam_basin,,W-NA,,CR,CRI,,10.42,-83.609,,798
 G-TTR,Tana Toraja,,,gleam_basin,,W-AS,,ID,IDN,,-3.045,119.822,,1234
-G-TTT,Taitung,,,gleam_basin,,W-AS,,TW,TWN,,22.755,121.102,175000.0,2824
-G-TTU,Tetouan,,,gleam_basin,,W-AF,,MA,MAR,,35.594,-5.32,326000.0,813
-G-TUA,Tulcan,,,gleam_basin,,W-SA,,EC,ECU,,0.81,-77.708,83000.0,1460
+G-TTT,Taitung,,,gleam_basin,,W-AS,,TW,TWN,,22.755,121.102,175000,2824
+G-TTU,Tetouan,,,gleam_basin,,W-AF,,MA,MAR,,35.594,-5.32,326000,813
+G-TUA,Tulcan,,,gleam_basin,,W-SA,,EC,ECU,,0.81,-77.708,83000,1460
 G-TUB,Tubuai,,,gleam_basin,,W-OC,,PF,PYF,,-23.365,-149.524,,678
 G-TUC,Tucuman,,,gleam_basin,,W-SA,,AR,ARG,,-26.841,-65.105,,3184
-G-TUF,Tours,,,gleam_basin,,W-EU,,FR,FRA,,47.432,0.728,236000.0,1495
-G-TUG,Tuguegarao,,,gleam_basin,,W-AS,,PH,PHL,,17.643,121.733,115000.0,592
-G-TUI,Turaif,,,gleam_basin,,W-AS,,SA,SAU,,31.692,38.732,41000.0,246
-G-TUK,Turbat,,,gleam_basin,,W-AS,,PK,PAK,,25.986,63.03,643000.0,109
-G-TUL,Tulsa,,,gleam_basin,,W-NA,,US,USA,US-OK,36.198,-95.888,672000.0,2099
-G-TUN,Tunis,,,gleam_basin,,W-AF,,TN,TUN,,36.851,10.227,2413000.0,1790
-G-TUO,Taupo,,,gleam_basin,,W-OC,,NZ,NZL,,-38.74,176.084,23000.0,3043
-G-TUP,Tupelo,,,gleam_basin,,W-NA,,US,USA,US-MS,34.268,-88.77,45000.0,2338
-G-TUR,Tucurui,,,gleam_basin,,W-SA,,BR,BRA,,-3.786,-49.72,76000.0,1944
-G-TUS,Tucson,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.116,-110.941,868000.0,2098
-G-TUU,Tabuk,,,gleam_basin,,W-AS,,SA,SAU,,28.365,36.619,548000.0,245
-G-TVC,Traverse City,,,gleam_basin,,W-NA,,US,USA,US-MI,44.741,-85.582,50000.0,2123
-G-TVF,Thief River Falls,,,gleam_basin,,W-NA,,US,USA,US-MN,48.066,-96.185,9000.0,2122
-G-TVS,Tangshan,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,,,1879000.0,332
+G-TUF,Tours,,,gleam_basin,,W-EU,,FR,FRA,,47.432,0.728,236000,1495
+G-TUG,Tuguegarao,,,gleam_basin,,W-AS,,PH,PHL,,17.643,121.733,115000,592
+G-TUI,Turaif,,,gleam_basin,,W-AS,,SA,SAU,,31.692,38.732,41000,246
+G-TUK,Turbat,,,gleam_basin,,W-AS,,PK,PAK,,25.986,63.03,643000,109
+G-TUL,Tulsa,,,gleam_basin,,W-NA,,US,USA,US-OK,36.198,-95.888,672000,2099
+G-TUN,Tunis,,,gleam_basin,,W-AF,,TN,TUN,,36.851,10.227,2413000,1790
+G-TUO,Taupo,,,gleam_basin,,W-OC,,NZ,NZL,,-38.74,176.084,23000,3043
+G-TUP,Tupelo,,,gleam_basin,,W-NA,,US,USA,US-MS,34.268,-88.77,45000,2338
+G-TUR,Tucurui,,,gleam_basin,,W-SA,,BR,BRA,,-3.786,-49.72,76000,1944
+G-TUS,Tucson,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.116,-110.941,868000,2098
+G-TUU,Tabuk,,,gleam_basin,,W-AS,,SA,SAU,,28.365,36.619,548000,245
+G-TVC,Traverse City,,,gleam_basin,,W-NA,,US,USA,US-MI,44.741,-85.582,50000,2123
+G-TVF,Thief River Falls,,,gleam_basin,,W-NA,,US,USA,US-MN,48.066,-96.185,9000,2122
+G-TVS,Tangshan,,,gleam_basin,,W-AS,,CN,CHN,CN-HE,,,1879000,332
 G-TVU,Taveuni Island,,,gleam_basin,,W-OC,,FJ,FJI,,-16.691,-179.877,,1181
-G-TVY,Dawei,,,gleam_basin,,W-AS,,MM,MMR,,14.104,98.204,146000.0,876
-G-TWB,Toowoomba,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.543,151.916,93000.0,1596
-G-TWF,Twin Falls,,,gleam_basin,,W-NA,,US,USA,US-ID,42.482,-114.488,54000.0,2155
-G-TWU,Tawau,,,gleam_basin,,W-AS,,MY,MYS,,4.32,118.128,306000.0,169
-G-TXK,Texarkana,,,gleam_basin,,W-NA,,US,USA,US-TX,33.454,-93.991,80000.0,2381
-G-TXL,Berlin,,,gleam_basin,,W-EU,,DE,DEU,,52.56,13.288,3406000.0,742
-G-TXN,Huangshan,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,29.733,118.256,77000.0,443
-G-TYL,Talara,,,gleam_basin,,W-SA,,PE,PER,,-4.577,-81.254,99000.0,1226
-G-TYN,Taiyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,37.747,112.628,2913000.0,453
-G-TYR,Tyler,,,gleam_basin,,W-NA,,US,USA,US-TX,32.354,-95.402,141000.0,2434
-G-TYS,Knoxville,,,gleam_basin,,W-NA,,US,USA,US-TN,35.811,-83.994,585000.0,2435
-G-TZL,Tuzla,,,gleam_basin,,W-EU,,BA,BIH,,44.459,18.725,144000.0,2820
-G-TZX,Trabzon,,,gleam_basin,,W-AS,,TR,TUR,,40.995,39.79,765000.0,1751
+G-TVY,Dawei,,,gleam_basin,,W-AS,,MM,MMR,,14.104,98.204,146000,876
+G-TWB,Toowoomba,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.543,151.916,93000,1596
+G-TWF,Twin Falls,,,gleam_basin,,W-NA,,US,USA,US-ID,42.482,-114.488,54000,2155
+G-TWU,Tawau,,,gleam_basin,,W-AS,,MY,MYS,,4.32,118.128,306000,169
+G-TXK,Texarkana,,,gleam_basin,,W-NA,,US,USA,US-TX,33.454,-93.991,80000,2381
+G-TXL,Berlin,,,gleam_basin,,W-EU,,DE,DEU,,52.56,13.288,3406000,742
+G-TXN,Huangshan,,,gleam_basin,,W-AS,,CN,CHN,CN-AH,29.733,118.256,77000,443
+G-TYL,Talara,,,gleam_basin,,W-SA,,PE,PER,,-4.577,-81.254,99000,1226
+G-TYN,Taiyuan,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,37.747,112.628,2913000,453
+G-TYR,Tyler,,,gleam_basin,,W-NA,,US,USA,US-TX,32.354,-95.402,141000,2434
+G-TYS,Knoxville,,,gleam_basin,,W-NA,,US,USA,US-TN,35.811,-83.994,585000,2435
+G-TZL,Tuzla,,,gleam_basin,,W-EU,,BA,BIH,,44.459,18.725,144000,2820
+G-TZX,Trabzon,,,gleam_basin,,W-AS,,TR,TUR,,40.995,39.79,765000,1751
 G-UAH,Ua Huka,,,gleam_basin,,W-OC,,PF,PYF,,-8.936,-139.552,,705
-G-UAK,Narsarsuaq,,,gleam_basin,,W-NA,,GL,GRL,,61.16,-45.426,0.0,957
+G-UAK,Narsarsuaq,,,gleam_basin,,W-NA,,GL,GRL,,61.16,-45.426,0,957
 G-UAP,Ua Pou,,,gleam_basin,,W-OC,,PF,PYF,,-9.352,-140.078,,704
 G-UAQ,San Juan (AR),,,gleam_basin,,W-SA,,AR,ARG,,-31.572,-68.418,,3207
 G-UAS,Samburu,,,gleam_basin,,W-AF,,KE,KEN,,0.531,37.534,,1731
-G-UBA,Uberaba,,,gleam_basin,,W-SA,,BR,BRA,,-19.765,-47.966,261000.0,2007
-G-UBP,Ubon Ratchathani,,,gleam_basin,,W-AS,,TH,THA,,15.251,104.87,274000.0,537
-G-UCT,Ukhta,,,gleam_basin,,W-EU,,RU,RUS,,63.567,53.805,102000.0,1885
-G-UDI,Uberlandia,,,gleam_basin,,W-SA,,BR,BRA,,-18.884,-48.225,564000.0,1978
-G-UDJ,Uzhhorod,,,gleam_basin,,W-EU,,UA,UKR,,48.634,22.263,151000.0,2786
-G-UDR,Udaipur,,,gleam_basin,,W-AS,,IN,IND,,24.618,73.896,470000.0,1086
-G-UEL,Quelimane,,,gleam_basin,,W-AF,,MZ,MOZ,,-17.855,36.869,189000.0,972
+G-UBA,Uberaba,,,gleam_basin,,W-SA,,BR,BRA,,-19.765,-47.966,261000,2007
+G-UBP,Ubon Ratchathani,,,gleam_basin,,W-AS,,TH,THA,,15.251,104.87,274000,537
+G-UCT,Ukhta,,,gleam_basin,,W-EU,,RU,RUS,,63.567,53.805,102000,1885
+G-UDI,Uberlandia,,,gleam_basin,,W-SA,,BR,BRA,,-18.884,-48.225,564000,1978
+G-UDJ,Uzhhorod,,,gleam_basin,,W-EU,,UA,UKR,,48.634,22.263,151000,2786
+G-UDR,Udaipur,,,gleam_basin,,W-AS,,IN,IND,,24.618,73.896,470000,1086
+G-UEL,Quelimane,,,gleam_basin,,W-AF,,MZ,MOZ,,-17.855,36.869,189000,972
 G-UEO,Kume Jima,,,gleam_basin,,W-AS,,JP,JPN,,26.364,126.714,,3124
-G-UET,Quetta,,,gleam_basin,,W-AS,,PK,PAK,,30.251,66.938,3600000.0,121
-G-UFA,Ufa,,,gleam_basin,,W-EU,,RU,RUS,,54.557,55.874,1018000.0,1861
-G-UGB,Pilot Point,,,gleam_basin,,W-NA,,US,USA,US-TX,,,4000.0,2537
+G-UET,Quetta,,,gleam_basin,,W-AS,,PK,PAK,,30.251,66.938,3600000,121
+G-UFA,Ufa,,,gleam_basin,,W-EU,,RU,RUS,,54.557,55.874,1018000,1861
+G-UGB,Pilot Point,,,gleam_basin,,W-NA,,US,USA,US-TX,,,4000,2537
 G-UGC,Urgench,,,gleam_basin,,W-AS,,UZ,UZB,,41.584,60.642,,2847
-G-UIB,Quibdo,,,gleam_basin,,W-SA,,CO,COL,,5.691,-76.641,93000.0,1367
+G-UIB,Quibdo,,,gleam_basin,,W-SA,,CO,COL,,5.691,-76.641,93000,1367
 G-UIH,Quinhon,,,gleam_basin,,W-AS,,VN,VNM,,13.955,109.042,,1134
-G-UIN,Quincy,,,gleam_basin,,W-NA,,US,USA,US-MA,39.943,-91.195,94000.0,2131
-G-UIO,Quito,,,gleam_basin,,W-SA,,EC,ECU,,-0.129,-78.358,1701000.0,1462
-G-UIP,Quimper,,,gleam_basin,,W-EU,,FR,FRA,,47.975,-4.168,64000.0,1498
+G-UIN,Quincy,,,gleam_basin,,W-NA,,US,USA,US-MA,39.943,-91.195,94000,2131
+G-UIO,Quito,,,gleam_basin,,W-SA,,EC,ECU,,-0.129,-78.358,1701000,1462
+G-UIP,Quimper,,,gleam_basin,,W-EU,,FR,FRA,,47.975,-4.168,64000,1498
 G-UKK,Ust-Kamenogorsk,,,gleam_basin,,W-AS,,KZ,KAZ,,50.037,82.494,,656
-G-UKS,Sevastopol,,,gleam_basin,,W-EU,,UA,UKR,,44.689,33.571,416000.0,2780
+G-UKS,Sevastopol,,,gleam_basin,,W-EU,,UA,UKR,,44.689,33.571,416000,2780
 G-UKX,Ust-Kut,,,gleam_basin,,W-EU,,RU,RUS,,56.857,105.73,,1802
-G-ULD,Ulundi,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.321,31.417,21000.0,642
+G-ULD,Ulundi,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.321,31.417,21000,642
 G-ULG,Olgii,,,gleam_basin,,W-AS,,MN,MNG,,48.993,89.923,,854
 G-ULH,Al Ula,,,gleam_basin,,W-AS,,SA,SAU,,26.48,38.129,,269
-G-ULK,Lensk,,,gleam_basin,,W-EU,,RU,RUS,,60.721,114.826,26000.0,1927
-G-ULN,Ulaanbaatar,,,gleam_basin,,W-AS,,MN,MNG,,47.843,106.767,885000.0,856
-G-ULO,Ulaangom,,,gleam_basin,,W-AS,,MN,MNG,,50.067,91.938,36000.0,853
-G-ULP,Quilpie,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.612,144.253,1000.0,1692
-G-ULV,Ulyanovsk,,,gleam_basin,,W-EU,,RU,RUS,,54.268,48.227,641000.0,1929
+G-ULK,Lensk,,,gleam_basin,,W-EU,,RU,RUS,,60.721,114.826,26000,1927
+G-ULN,Ulaanbaatar,,,gleam_basin,,W-AS,,MN,MNG,,47.843,106.767,885000,856
+G-ULO,Ulaangom,,,gleam_basin,,W-AS,,MN,MNG,,50.067,91.938,36000,853
+G-ULP,Quilpie,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-26.612,144.253,1000,1692
+G-ULV,Ulyanovsk,,,gleam_basin,,W-EU,,RU,RUS,,54.268,48.227,641000,1929
 G-ULZ,Uliastai,,,gleam_basin,,W-AS,,MN,MNG,,47.709,96.526,,855
-G-UME,Umea,,,gleam_basin,,W-EU,,SE,SWE,,63.792,20.283,78000.0,2570
-G-UMU,Umuarama,,,gleam_basin,,W-SA,,BR,BRA,,-23.799,-53.314,107000.0,2032
-G-UND,Kunduz,,,gleam_basin,,W-AS,,AF,AFG,,36.665,68.911,260000.0,896
+G-UME,Umea,,,gleam_basin,,W-EU,,SE,SWE,,63.792,20.283,78000,2570
+G-UMU,Umuarama,,,gleam_basin,,W-SA,,BR,BRA,,-23.799,-53.314,107000,2032
+G-UND,Kunduz,,,gleam_basin,,W-AS,,AF,AFG,,36.665,68.911,260000,896
 G-UNG,Kiunga,,,gleam_basin,,W-OC,,PG,PNG,,-6.126,141.282,,2996
 G-UNK,Unalakleet,,,gleam_basin,,W-NA,,US,USA,US-AK,63.888,-160.799,,2069
-G-UNN,Ranong,,,gleam_basin,,W-AS,,TH,THA,,9.778,98.586,25000.0,547
-G-UPG,Makassar,,,gleam_basin,,W-AS,,ID,IDN,,-5.062,119.554,1262000.0,1286
-G-UPN,Uruapan,,,gleam_basin,,W-NA,,MX,MEX,,19.397,-102.039,265000.0,1020
-G-URA,Uralsk,,,gleam_basin,,W-AS,,KZ,KAZ,,51.151,51.543,244000.0,664
-G-URC,Urumqi,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.907,87.474,2151000.0,379
+G-UNN,Ranong,,,gleam_basin,,W-AS,,TH,THA,,9.778,98.586,25000,547
+G-UPG,Makassar,,,gleam_basin,,W-AS,,ID,IDN,,-5.062,119.554,1262000,1286
+G-UPN,Uruapan,,,gleam_basin,,W-NA,,MX,MEX,,19.397,-102.039,265000,1020
+G-URA,Uralsk,,,gleam_basin,,W-AS,,KZ,KAZ,,51.151,51.543,244000,664
+G-URC,Urumqi,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.907,87.474,2151000,379
 G-URE,Kuressaare,,,gleam_basin,,W-EU,,EE,EST,,58.23,22.51,,2866
-G-URG,Uruguaiana,,,gleam_basin,,W-SA,,BR,BRA,,-29.782,-57.038,123000.0,1995
-G-URJ,Uray,,,gleam_basin,,W-EU,,RU,RUS,,60.103,64.827,40000.0,1866
-G-URS,Kursk,,,gleam_basin,,W-EU,,RU,RUS,,51.751,36.296,409000.0,1867
-G-URT,Surat Thani,,,gleam_basin,,W-AS,,TH,THA,,9.133,99.136,158000.0,535
+G-URG,Uruguaiana,,,gleam_basin,,W-SA,,BR,BRA,,-29.782,-57.038,123000,1995
+G-URJ,Uray,,,gleam_basin,,W-EU,,RU,RUS,,60.103,64.827,40000,1866
+G-URS,Kursk,,,gleam_basin,,W-EU,,RU,RUS,,51.751,36.296,409000,1867
+G-URT,Surat Thani,,,gleam_basin,,W-AS,,TH,THA,,9.133,99.136,158000,535
 G-URY,Gurayat,,,gleam_basin,,W-AS,,SA,SAU,,31.412,37.279,,250
-G-USH,Ushuaia,,,gleam_basin,,W-SA,,AR,ARG,,-54.843,-68.296,58000.0,3195
-G-USK,Usinsk,,,gleam_basin,,W-EU,,RU,RUS,,66.005,57.367,44000.0,1803
-G-USM,Ko Samui,,,gleam_basin,,W-AS,,TH,THA,,9.548,100.062,50000.0,530
-G-USN,Ulsan,,,gleam_basin,,W-AS,,KR,KOR,,35.593,129.352,1061000.0,2809
+G-USH,Ushuaia,,,gleam_basin,,W-SA,,AR,ARG,,-54.843,-68.296,58000,3195
+G-USK,Usinsk,,,gleam_basin,,W-EU,,RU,RUS,,66.005,57.367,44000,1803
+G-USM,Ko Samui,,,gleam_basin,,W-AS,,TH,THA,,9.548,100.062,50000,530
+G-USN,Ulsan,,,gleam_basin,,W-AS,,KR,KOR,,35.593,129.352,1061000,2809
 G-USU,Coron,,,gleam_basin,,W-AS,,PH,PHL,,12.122,120.1,,604
-G-UTH,Udon Thani,,,gleam_basin,,W-AS,,TH,THA,,17.386,102.788,247000.0,528
-G-UTN,Upington,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.399,21.26,71000.0,630
+G-UTH,Udon Thani,,,gleam_basin,,W-AS,,TH,THA,,17.386,102.788,247000,528
+G-UTN,Upington,,,gleam_basin,,W-AF,,ZA,ZAF,,-28.399,21.26,71000,630
 G-UTP,U-Tapao,,,gleam_basin,,W-AS,,TH,THA,,12.68,101.005,,529
 G-UTS,Ust-Tsilma,,,gleam_basin,,W-EU,,RU,RUS,,65.437,52.2,,1871
-G-UTT,Umtata,,,gleam_basin,,W-AF,,ZA,ZAF,,-31.546,28.673,138000.0,631
+G-UTT,Umtata,,,gleam_basin,,W-AF,,ZA,ZAF,,-31.546,28.673,138000,631
 G-UUA,Bugulma,,,gleam_basin,,W-EU,,RU,RUS,,54.64,52.802,,1833
-G-UUD,Ulan-Ude,,,gleam_basin,,W-EU,,RU,RUS,,51.808,107.438,360000.0,1832
-G-UUS,Yuzhno-Sakhalinsk,,,gleam_basin,,W-EU,,RU,RUS,,46.889,142.718,176000.0,1831
+G-UUD,Ulan-Ude,,,gleam_basin,,W-EU,,RU,RUS,,51.808,107.438,360000,1832
+G-UUS,Yuzhno-Sakhalinsk,,,gleam_basin,,W-EU,,RU,RUS,,46.889,142.718,176000,1831
 G-UVE,Ouvea,,,gleam_basin,,W-OC,,NC,NCL,,-20.641,166.573,,3167
 G-UVF,St Lucia,,,gleam_basin,,W-NA,,LC,LCA,,13.733,-60.953,,1038
-G-UYL,Nyala,,,gleam_basin,,W-AF,,SD,SDN,,12.054,24.956,392000.0,3010
-G-UYN,Yulin,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,38.36,109.591,1127000.0,387
-G-UYU,Uyuni,,,gleam_basin,,W-SA,,BO,BOL,,-20.446,-66.848,13000.0,88
-G-VAA,Vaasa,,,gleam_basin,,W-EU,,FI,FIN,,63.051,21.762,57000.0,500
-G-VAG,Varginha,,,gleam_basin,,W-SA,,BR,BRA,,-21.59,-45.473,117000.0,1958
-G-VAI,Vanimo,,,gleam_basin,,W-OC,,PG,PNG,,-2.693,141.303,11000.0,2984
+G-UYL,Nyala,,,gleam_basin,,W-AF,,SD,SDN,,12.054,24.956,392000,3010
+G-UYN,Yulin,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,38.36,109.591,1127000,387
+G-UYU,Uyuni,,,gleam_basin,,W-SA,,BO,BOL,,-20.446,-66.848,13000,88
+G-VAA,Vaasa,,,gleam_basin,,W-EU,,FI,FIN,,63.051,21.762,57000,500
+G-VAG,Varginha,,,gleam_basin,,W-SA,,BR,BRA,,-21.59,-45.473,117000,1958
+G-VAI,Vanimo,,,gleam_basin,,W-OC,,PG,PNG,,-2.693,141.303,11000,2984
 G-VAK,Chevak,,,gleam_basin,,W-NA,,US,USA,US-AK,61.541,-165.601,,2169
 G-VAM,Maamigili Island,,,gleam_basin,,W-AS,,MV,MDV,,3.471,72.836,,1477
-G-VAN,Van,,,gleam_basin,,W-AS,,TR,TUR,,38.468,43.332,372000.0,1750
+G-VAN,Van,,,gleam_basin,,W-AS,,TR,TUR,,38.468,43.332,372000,1750
 G-VAO,Suavanao,,,gleam_basin,,W-OC,,SB,SLB,,-7.586,158.731,,3023
-G-VAR,Varna,,,gleam_basin,,W-EU,,BG,BGR,,43.232,27.825,313000.0,82
-G-VAS,Sivas,,,gleam_basin,,W-AS,,TR,TUR,,39.814,36.904,264000.0,1741
+G-VAR,Varna,,,gleam_basin,,W-EU,,BG,BGR,,43.232,27.825,313000,82
+G-VAS,Sivas,,,gleam_basin,,W-AS,,TR,TUR,,39.814,36.904,264000,1741
 G-VAW,Vardo,,,gleam_basin,,W-EU,,NO,NOR,,70.355,31.045,,1155
 G-VBV,Vanuabalavu Island,,,gleam_basin,,W-OC,,FJ,FJI,,-17.269,-178.976,,1182
-G-VBY,Visby,,,gleam_basin,,W-EU,,SE,SWE,,57.663,18.346,23000.0,2542
+G-VBY,Visby,,,gleam_basin,,W-EU,,SE,SWE,,57.663,18.346,23000,2542
 G-VCA,Cantho,,,gleam_basin,,W-AS,,VN,VNM,,10.085,105.712,,1136
-G-VCE,Venice,,,gleam_basin,,W-EU,,IT,ITA,,45.505,12.352,271000.0,3085
+G-VCE,Venice,,,gleam_basin,,W-EU,,IT,ITA,,45.505,12.352,271000,3085
 G-VCL,Tamky,,,gleam_basin,,W-AS,,VN,VNM,,15.403,108.706,,1121
-G-VCP,Campinas,,,gleam_basin,,W-SA,,BR,BRA,,-23.007,-47.134,2791000.0,2014
+G-VCP,Campinas,,,gleam_basin,,W-SA,,BR,BRA,,-23.007,-47.134,2791000,2014
 G-VCS,Con Dao,,,gleam_basin,,W-AS,,VN,VNM,,8.732,106.633,,1122
 G-VCT,Victoria,,,gleam_basin,,W-NA,,US,USA,US-TX,28.853,-96.919,,2102
 G-VDB,Fagernes,,,gleam_basin,,W-EU,,NO,NOR,,61.016,9.288,,1163
-G-VDC,Vitoria Da Conquista,,,gleam_basin,,W-SA,,BR,BRA,,-14.863,-40.863,308000.0,1983
-G-VDE,Valverde,,,gleam_basin,,W-EU,,ES,ESP,,27.815,-17.887,10.0,2892
-G-VDH,Dong Hoi,,,gleam_basin,,W-AS,,VN,VNM,,17.515,106.591,189000.0,1127
-G-VDM,Viedma,,,gleam_basin,,W-SA,,AR,ARG,,-40.869,-63,59000.0,3193
-G-VDZ,Valdez,,,gleam_basin,,W-NA,,US,USA,US-AK,61.134,-146.248,11000.0,2254
+G-VDC,Vitoria Da Conquista,,,gleam_basin,,W-SA,,BR,BRA,,-14.863,-40.863,308000,1983
+G-VDE,Valverde,,,gleam_basin,,W-EU,,ES,ESP,,27.815,-17.887,10,2892
+G-VDH,Dong Hoi,,,gleam_basin,,W-AS,,VN,VNM,,17.515,106.591,189000,1127
+G-VDM,Viedma,,,gleam_basin,,W-SA,,AR,ARG,,-40.869,-63,59000,3193
+G-VDZ,Valdez,,,gleam_basin,,W-NA,,US,USA,US-AK,61.134,-146.248,11000,2254
 G-VEE,Venetie,,,gleam_basin,,W-NA,,US,USA,US-AK,67.009,-146.366,,2166
-G-VEL,Vernal,,,gleam_basin,,W-NA,,US,USA,US-UT,40.441,-109.51,20000.0,2168
-G-VER,Veracruz,,,gleam_basin,,W-NA,,MX,MEX,,19.146,-96.187,579000.0,1013
-G-VFA,Victoria Falls,,,gleam_basin,,W-AF,,ZW,ZWE,,-18.096,25.839,36000.0,959
-G-VGA,Vijayawada,,,gleam_basin,,W-AS,,IN,IND,,16.53,80.797,875000.0,1074
-G-VGO,Vigo,,,gleam_basin,,W-EU,,ES,ESP,,42.232,-8.627,379000.0,2888
-G-VGZ,Mocoa,,,gleam_basin,,W-SA,,CO,COL,,0.979,-76.606,22000.0,1376
-G-VHC,Saurimo,,,gleam_basin,,W-AF,,AO,AGO,,-9.689,20.432,41000.0,10
+G-VEL,Vernal,,,gleam_basin,,W-NA,,US,USA,US-UT,40.441,-109.51,20000,2168
+G-VER,Veracruz,,,gleam_basin,,W-NA,,MX,MEX,,19.146,-96.187,579000,1013
+G-VFA,Victoria Falls,,,gleam_basin,,W-AF,,ZW,ZWE,,-18.096,25.839,36000,959
+G-VGA,Vijayawada,,,gleam_basin,,W-AS,,IN,IND,,16.53,80.797,875000,1074
+G-VGO,Vigo,,,gleam_basin,,W-EU,,ES,ESP,,42.232,-8.627,379000,2888
+G-VGZ,Mocoa,,,gleam_basin,,W-SA,,CO,COL,,0.979,-76.606,22000,1376
+G-VHC,Saurimo,,,gleam_basin,,W-AF,,AO,AGO,,-9.689,20.432,41000,10
 G-VHM,Vilhelmina,,,gleam_basin,,W-EU,,SE,SWE,,64.579,16.834,,2561
 G-VHZ,Vahitahi,,,gleam_basin,,W-OC,,PF,PYF,,-18.78,-138.853,,701
-G-VIE,Vienna,,,gleam_basin,,W-EU,,AT,AUT,,48.11,16.57,2400000.0,1699
+G-VIE,Vienna,,,gleam_basin,,W-EU,,AT,AUT,,48.11,16.57,2400000,1699
 G-VIF,Vieste,,,gleam_basin,,W-EU,,IT,ITA,,,,,3092
-G-VIG,El Vigia,,,gleam_basin,,W-SA,,VE,VEN,,8.624,-71.673,59000.0,1717
+G-VIG,El Vigia,,,gleam_basin,,W-SA,,VE,VEN,,8.624,-71.673,59000,1717
 G-VII,Vinh City,,,gleam_basin,,W-AS,,VN,VNM,,18.738,105.671,,1138
-G-VIL,Dakhla,,,gleam_basin,,W-AF,,MA,MAR,,23.718,-15.932,75000.0,825
+G-VIL,Dakhla,,,gleam_basin,,W-AF,,MA,MAR,,23.718,-15.932,75000,825
 G-VIN,Vinnytsia,,,gleam_basin,,W-EU,,UA,UKR,,49.243,28.614,,2792
-G-VIS,Visalia,,,gleam_basin,,W-NA,,US,USA,US-CA,36.319,-119.393,235000.0,2433
-G-VIX,Vitoria,,,gleam_basin,,W-SA,,BR,BRA,,-20.258,-40.286,1704000.0,2020
+G-VIS,Visalia,,,gleam_basin,,W-NA,,US,USA,US-CA,36.319,-119.393,235000,2433
+G-VIX,Vitoria,,,gleam_basin,,W-SA,,BR,BRA,,-20.258,-40.286,1704000,2020
 G-VKG,Rachgia,,,gleam_basin,,W-AS,,VN,VNM,,9.958,105.132,,1135
-G-VKT,Vorkuta,,,gleam_basin,,W-EU,,RU,RUS,,67.489,63.993,80000.0,1884
+G-VKT,Vorkuta,,,gleam_basin,,W-EU,,RU,RUS,,67.489,63.993,80000,1884
 G-VLC,Valencia (ES),,,gleam_basin,,W-EU,,ES,ESP,,39.489,-0.482,,2883
-G-VLD,Valdosta,,,gleam_basin,,W-NA,,US,USA,US-GA,30.782,-83.277,79000.0,2060
-G-VLG,Villa Gesell,,,gleam_basin,,W-SA,,AR,ARG,,-37.235,-57.029,23000.0,3219
-G-VLI,Port Vila,,,gleam_basin,,W-OC,,VU,VUT,,-17.699,168.32,44000.0,1315
-G-VLL,Valladolid,,,gleam_basin,,W-EU,,ES,ESP,,41.706,-4.852,322000.0,2880
+G-VLD,Valdosta,,,gleam_basin,,W-NA,,US,USA,US-GA,30.782,-83.277,79000,2060
+G-VLG,Villa Gesell,,,gleam_basin,,W-SA,,AR,ARG,,-37.235,-57.029,23000,3219
+G-VLI,Port Vila,,,gleam_basin,,W-OC,,VU,VUT,,-17.699,168.32,44000,1315
+G-VLL,Valladolid,,,gleam_basin,,W-EU,,ES,ESP,,41.706,-4.852,322000,2880
 G-VLN,Valencia (VE),,,gleam_basin,,W-SA,,VE,VEN,,10.15,-67.928,,1704
-G-VLV,Valera,,,gleam_basin,,W-SA,,VE,VEN,,9.34,-70.584,191000.0,1702
+G-VLV,Valera,,,gleam_basin,,W-SA,,VE,VEN,,9.34,-70.584,191000,1702
 G-VLY,Anglesey,,,gleam_basin,,W-EU,,GB,GBR,,53.248,-4.535,,761
-G-VME,Villa Mercedes,,,gleam_basin,,W-SA,,AR,ARG,,-33.73,-65.387,49000.0,3202
-G-VNO,Vilnius,,,gleam_basin,,W-EU,,LT,LTU,,54.634,25.286,542000.0,1541
-G-VNS,Varanasi,,,gleam_basin,,W-AS,,IN,IND,,25.452,82.859,1352000.0,1107
+G-VME,Villa Mercedes,,,gleam_basin,,W-SA,,AR,ARG,,-33.73,-65.387,49000,3202
+G-VNO,Vilnius,,,gleam_basin,,W-EU,,LT,LTU,,54.634,25.286,542000,1541
+G-VNS,Varanasi,,,gleam_basin,,W-AS,,IN,IND,,25.452,82.859,1352000,1107
 G-VNX,Vilankulos,,,gleam_basin,,W-AF,,MZ,MOZ,,-22.018,35.313,,973
-G-VOG,Volgograd,,,gleam_basin,,W-EU,,RU,RUS,,48.783,44.346,984000.0,1926
-G-VOL,Volos,,,gleam_basin,,W-EU,,GR,GRC,,39.22,22.794,111000.0,938
-G-VOZ,Voronezh,,,gleam_basin,,W-EU,,RU,RUS,,51.814,39.23,844000.0,1928
-G-VPE,Ondjiva,,,gleam_basin,,W-AF,,AO,AGO,,-17.044,15.684,10000.0,8
-G-VPN,Vopnafjordur,,,gleam_basin,,W-EU,,IS,ISL,,65.721,-14.851,990.0,1349
-G-VPS,Valparaiso,,,gleam_basin,,W-NA,,US,USA,US-FL,30.483,-86.525,854000.0,2187
-G-VPY,Chimoio,,,gleam_basin,,W-AF,,MZ,MOZ,,-19.151,33.429,257000.0,969
+G-VOG,Volgograd,,,gleam_basin,,W-EU,,RU,RUS,,48.783,44.346,984000,1926
+G-VOL,Volos,,,gleam_basin,,W-EU,,GR,GRC,,39.22,22.794,111000,938
+G-VOZ,Voronezh,,,gleam_basin,,W-EU,,RU,RUS,,51.814,39.23,844000,1928
+G-VPE,Ondjiva,,,gleam_basin,,W-AF,,AO,AGO,,-17.044,15.684,10000,8
+G-VPN,Vopnafjordur,,,gleam_basin,,W-EU,,IS,ISL,,65.721,-14.851,990,1349
+G-VPS,Valparaiso,,,gleam_basin,,W-NA,,US,USA,US-FL,30.483,-86.525,854000,2187
+G-VPY,Chimoio,,,gleam_basin,,W-AF,,MZ,MOZ,,-19.151,33.429,257000,969
 G-VQS,Vieques,,,gleam_basin,,W-NA,,PR,PRI,,18.116,-65.423,,195
-G-VRA,Varadero,,,gleam_basin,,W-NA,,CU,CUB,,23.034,-81.435,20000.0,3242
-G-VRC,Virac,,,gleam_basin,,W-AS,,PH,PHL,,13.576,124.206,15000.0,595
+G-VRA,Varadero,,,gleam_basin,,W-NA,,CU,CUB,,23.034,-81.435,20000,3242
+G-VRC,Virac,,,gleam_basin,,W-AS,,PH,PHL,,13.576,124.206,15000,595
 G-VRI,Varandey,,,gleam_basin,,W-EU,,RU,RUS,,,,,1813
-G-VRK,Varkaus,,,gleam_basin,,W-EU,,FI,FIN,,62.171,27.869,22000.0,498
-G-VRL,Vila Real,,,gleam_basin,,W-EU,,PT,PRT,,41.274,-7.72,17000.0,1429
-G-VRN,Verona,,,gleam_basin,,W-EU,,IT,ITA,,45.396,10.889,347000.0,3069
-G-VSA,Villahermosa,,,gleam_basin,,W-NA,,MX,MEX,,17.997,-92.817,429000.0,1004
-G-VSG,Luhansk,,,gleam_basin,,W-EU,,UA,UKR,,48.417,39.374,452000.0,2788
-G-VST,Vasteras,,,gleam_basin,,W-EU,,SE,SWE,,59.589,16.634,107000.0,2546
-G-VTE,Vientiane,,,gleam_basin,,W-AS,,LA,LAO,,17.988,102.563,754000.0,575
+G-VRK,Varkaus,,,gleam_basin,,W-EU,,FI,FIN,,62.171,27.869,22000,498
+G-VRL,Vila Real,,,gleam_basin,,W-EU,,PT,PRT,,41.274,-7.72,17000,1429
+G-VRN,Verona,,,gleam_basin,,W-EU,,IT,ITA,,45.396,10.889,347000,3069
+G-VSA,Villahermosa,,,gleam_basin,,W-NA,,MX,MEX,,17.997,-92.817,429000,1004
+G-VSG,Luhansk,,,gleam_basin,,W-EU,,UA,UKR,,48.417,39.374,452000,2788
+G-VST,Vasteras,,,gleam_basin,,W-EU,,SE,SWE,,59.589,16.634,107000,2546
+G-VTE,Vientiane,,,gleam_basin,,W-AS,,LA,LAO,,17.988,102.563,754000,575
 G-VTM,Nevatim,,,gleam_basin,,W-AS,,IL,ISR,,31.208,35.012,,1204
-G-VTU,Las Tunas,,,gleam_basin,,W-NA,,CU,CUB,,20.988,-76.936,204000.0,3246
-G-VTZ,Vishakhapatnam,,,gleam_basin,,W-AS,,IN,IND,,17.721,83.225,1529000.0,1046
-G-VUP,Valledupar,,,gleam_basin,,W-SA,,CO,COL,,10.435,-73.249,308000.0,1387
+G-VTU,Las Tunas,,,gleam_basin,,W-NA,,CU,CUB,,20.988,-76.936,204000,3246
+G-VTZ,Vishakhapatnam,,,gleam_basin,,W-AS,,IN,IND,,17.721,83.225,1529000,1046
+G-VUP,Valledupar,,,gleam_basin,,W-SA,,CO,COL,,10.435,-73.249,308000,1387
 G-VUS,Veliky Ustyug,,,gleam_basin,,W-EU,,RU,RUS,,60.788,46.26,,1806
-G-VVC,Villavicencio,,,gleam_basin,,W-SA,,CO,COL,,4.168,-73.614,375000.0,1388
-G-VVI,Santa Cruz,,,gleam_basin,,W-SA,,BO,BOL,,-17.645,-63.135,2103000.0,90
-G-VVO,Vladivostok,,,gleam_basin,,W-EU,,RU,RUS,,43.399,132.148,587000.0,1859
-G-VVZ,Illizi,,,gleam_basin,,W-AF,,DZ,DZA,,26.723,8.623,8000.0,27
-G-VXC,Lichinga,,,gleam_basin,,W-AF,,MZ,MOZ,,-13.274,35.266,110000.0,970
+G-VVC,Villavicencio,,,gleam_basin,,W-SA,,CO,COL,,4.168,-73.614,375000,1388
+G-VVI,Santa Cruz,,,gleam_basin,,W-SA,,BO,BOL,,-17.645,-63.135,2103000,90
+G-VVO,Vladivostok,,,gleam_basin,,W-EU,,RU,RUS,,43.399,132.148,587000,1859
+G-VVZ,Illizi,,,gleam_basin,,W-AF,,DZ,DZA,,26.723,8.623,8000,27
+G-VXC,Lichinga,,,gleam_basin,,W-AF,,MZ,MOZ,,-13.274,35.266,110000,970
 G-VXE,Sao Vicente Island,,,gleam_basin,,W-AF,,CV,CPV,,16.833,-25.055,,133
-G-VXO,Vaxjo,,,gleam_basin,,W-EU,,SE,SWE,,56.929,14.728,60000.0,2567
+G-VXO,Vaxjo,,,gleam_basin,,W-EU,,SE,SWE,,56.929,14.728,60000,2567
 G-WAA,Wales,,,gleam_basin,,W-NA,,US,USA,US-AK,65.623,-168.095,,2383
 G-WAE,Wadi al Dawaser,,,gleam_basin,,W-AS,,SA,SAU,,20.504,45.2,,254
-G-WAG,Wanganui,,,gleam_basin,,W-OC,,NZ,NZL,,-39.962,175.025,40000.0,3048
-G-WAT,Waterford,,,gleam_basin,,W-EU,,IE,IRL,,52.187,-7.087,49000.0,2924
-G-WAW,Warsaw,,,gleam_basin,,W-EU,,PL,POL,,52.166,20.967,1707000.0,2852
+G-WAG,Wanganui,,,gleam_basin,,W-OC,,NZ,NZL,,-39.962,175.025,40000,3048
+G-WAT,Waterford,,,gleam_basin,,W-EU,,IE,IRL,,52.187,-7.087,49000,2924
+G-WAW,Warsaw,,,gleam_basin,,W-EU,,PL,POL,,52.166,20.967,1707000,2852
 G-WBQ,Beaver,,,gleam_basin,,W-NA,,US,USA,US-AK,66.362,-147.407,,2325
-G-WDH,Windhoek,,,gleam_basin,,W-AF,,NA,NAM,,-22.48,17.471,268000.0,76
-G-WEF,Weifang,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.647,119.119,1553000.0,327
-G-WEH,Weihai,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.187,122.229,560000.0,328
-G-WEI,Weipa,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-12.679,141.925,3000.0,1658
-G-WGA,Wagga Wagga,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-35.165,147.466,55000.0,1600
-G-WGP,Waingapu,,,gleam_basin,,W-AS,,ID,IDN,,-9.669,120.302,49000.0,1278
-G-WHK,Whakatane,,,gleam_basin,,W-OC,,NZ,NZL,,-37.921,176.914,19000.0,3040
-G-WIC,Wick,,,gleam_basin,,W-EU,,GB,GBR,,58.459,-3.093,7000.0,794
-G-WIN,Winton,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.364,143.086,11000.0,1690
-G-WJR,Wajir,,,gleam_basin,,W-AF,,KE,KEN,,1.733,40.092,46000.0,1726
+G-WDH,Windhoek,,,gleam_basin,,W-AF,,NA,NAM,,-22.48,17.471,268000,76
+G-WEF,Weifang,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,36.647,119.119,1553000,327
+G-WEH,Weihai,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.187,122.229,560000,328
+G-WEI,Weipa,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-12.679,141.925,3000,1658
+G-WGA,Wagga Wagga,,,gleam_basin,,W-OC,,AU,AUS,AU-NSW,-35.165,147.466,55000,1600
+G-WGP,Waingapu,,,gleam_basin,,W-AS,,ID,IDN,,-9.669,120.302,49000,1278
+G-WHK,Whakatane,,,gleam_basin,,W-OC,,NZ,NZL,,-37.921,176.914,19000,3040
+G-WIC,Wick,,,gleam_basin,,W-EU,,GB,GBR,,58.459,-3.093,7000,794
+G-WIN,Winton,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-22.364,143.086,11000,1690
+G-WJR,Wajir,,,gleam_basin,,W-AF,,KE,KEN,,1.733,40.092,46000,1726
 G-WJU,Won-ju,,,gleam_basin,,W-AS,,KR,KOR,,37.441,127.964,,2798
-G-WKA,Wanaka,,,gleam_basin,,W-OC,,NZ,NZL,,-44.722,169.246,5000.0,3044
-G-WKJ,Wakkanai,,,gleam_basin,,W-AS,,JP,JPN,,45.404,141.801,42000.0,3148
-G-WLG,Wellington,,,gleam_basin,,W-OC,,NZ,NZL,,-41.327,174.805,393000.0,3057
+G-WKA,Wanaka,,,gleam_basin,,W-OC,,NZ,NZL,,-44.722,169.246,5000,3044
+G-WKJ,Wakkanai,,,gleam_basin,,W-AS,,JP,JPN,,45.404,141.801,42000,3148
+G-WLG,Wellington,,,gleam_basin,,W-OC,,NZ,NZL,,-41.327,174.805,393000,3057
 G-WLK,Selawik,,,gleam_basin,,W-NA,,US,USA,US-AK,66.6,-159.986,,2388
 G-WLS,Wallis Island,,,gleam_basin,,W-OC,,WF,WLF,,-13.238,-176.199,,1555
-G-WMN,Maroantsetra,,,gleam_basin,,W-AF,,MG,MDG,,-15.437,49.688,38000.0,1447
+G-WMN,Maroantsetra,,,gleam_basin,,W-AF,,MG,MDG,,-15.437,49.688,38000,1447
 G-WMR,Mananara Avaratra,,,gleam_basin,,W-AF,,MG,MDG,,-16.164,49.774,,1455
 G-WMX,Wamena,,,gleam_basin,,W-AS,,ID,IDN,,-4.103,138.957,,1283
 G-WNH,Wenshan,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,,,,464
 G-WNN,Wunnummin Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.894,-89.289,,2763
-G-WNP,Naga,,,gleam_basin,,W-AS,,PH,PHL,,13.585,123.27,29000.0,618
-G-WNR,Windorah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.413,142.667,0.0,1675
-G-WNS,Nawabshah,,,gleam_basin,,W-AS,,PK,PAK,,26.219,68.39,3900000.0,132
-G-WNZ,Wenzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,27.912,120.852,2350000.0,465
-G-WRE,Whangarei,,,gleam_basin,,W-OC,,NZ,NZL,,-35.768,174.365,52000.0,3058
-G-WRL,Worland,,,gleam_basin,,W-NA,,US,USA,US-WY,43.966,-107.951,5000.0,2390
-G-WRO,Wroclaw,,,gleam_basin,,W-EU,,PL,POL,,51.103,16.886,635000.0,2858
-G-WSZ,Westport,,,gleam_basin,,W-OC,,NZ,NZL,,-41.738,171.581,28000.0,3055
+G-WNP,Naga,,,gleam_basin,,W-AS,,PH,PHL,,13.585,123.27,29000,618
+G-WNR,Windorah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-25.413,142.667,0,1675
+G-WNS,Nawabshah,,,gleam_basin,,W-AS,,PK,PAK,,26.219,68.39,3900000,132
+G-WNZ,Wenzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,27.912,120.852,2350000,465
+G-WRE,Whangarei,,,gleam_basin,,W-OC,,NZ,NZL,,-35.768,174.365,52000,3058
+G-WRL,Worland,,,gleam_basin,,W-NA,,US,USA,US-WY,43.966,-107.951,5000,2390
+G-WRO,Wroclaw,,,gleam_basin,,W-EU,,PL,POL,,51.103,16.886,635000,2858
+G-WSZ,Westport,,,gleam_basin,,W-OC,,NZ,NZL,,-41.738,171.581,28000,3055
 G-WTK,Noatak,,,gleam_basin,,W-NA,,US,USA,US-AK,67.566,-162.975,,2232
 G-WTL,Tuntutuliak,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2536
-G-WUA,Wuhai,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,39.793,106.799,218000.0,347
-G-WUH,Wuhan,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.784,114.208,7243000.0,477
-G-WUS,Wuyishan,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,27.702,118.001,23000.0,344
-G-WUX,Wuxi,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.494,120.429,1749000.0,346
-G-WUZ,Wuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,23.457,111.248,442000.0,345
-G-WVB,Walvis Bay,,,gleam_basin,,W-AF,,NA,NAM,,-22.98,14.645,52000.0,77
-G-WWK,Wewak,,,gleam_basin,,W-OC,,PG,PNG,,-3.584,143.669,25000.0,2987
+G-WUA,Wuhai,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,39.793,106.799,218000,347
+G-WUH,Wuhan,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.784,114.208,7243000,477
+G-WUS,Wuyishan,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,27.702,118.001,23000,344
+G-WUX,Wuxi,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,31.494,120.429,1749000,346
+G-WUZ,Wuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-GX,23.457,111.248,442000,345
+G-WVB,Walvis Bay,,,gleam_basin,,W-AF,,NA,NAM,,-22.98,14.645,52000,77
+G-WWK,Wewak,,,gleam_basin,,W-OC,,PG,PNG,,-3.584,143.669,25000,2987
 G-WWT,Newtok,,,gleam_basin,,W-NA,,US,USA,US-AK,,,,2226
 G-WXN,Wanzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-CQ,30.802,108.433,,334
-G-WYA,Whyalla,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-33.059,137.514,23000.0,1580
+G-WYA,Whyalla,,,gleam_basin,,W-OC,,AU,AUS,AU-SA,-33.059,137.514,23000,1580
 G-WYS,West Yellowstone,,,gleam_basin,,W-NA,,US,USA,US-MT,44.688,-111.118,,2091
-G-XAP,Chapeco,,,gleam_basin,,W-SA,,BR,BRA,,-27.134,-52.657,160000.0,2038
+G-XAP,Chapeco,,,gleam_basin,,W-SA,,BR,BRA,,-27.134,-52.657,160000,2038
 G-XBE,Bearskin Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.966,-91.027,,2582
-G-XBJ,Birjand,,,gleam_basin,,W-AS,,IR,IRN,,32.898,59.266,325000.0,2961
+G-XBJ,Birjand,,,gleam_basin,,W-AS,,IR,IRN,,32.898,59.266,325000,2961
 G-XCH,Christmas Island,,,gleam_basin,,W-AS,,CX,CXR,,,,,570
 G-XCR,Chalons-en-Champagne,,,gleam_basin,,W-EU,,FR,FRA,,48.773,4.206,,1494
-G-XFN,Xiangyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,32.151,112.291,1069000.0,353
+G-XFN,Xiangyang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,32.151,112.291,1069000,353
 G-XGR,Kangiqsualujjuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.711,-65.993,,2652
-G-XIC,Xichang,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,27.989,102.184,380000.0,400
+G-XIC,Xichang,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,27.989,102.184,380000,400
 G-XIL,Xilinhot,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,43.916,115.964,,468
-G-XIY,Xi'an,,,gleam_basin,,W-AS,,CN,CHN,CN-SN,34.447,108.752,4009000.0,348
+G-XIY,Xi'an,,,gleam_basin,,W-AS,,CN,CHN,CN-SN,34.447,108.752,4009000,348
 G-XKH,Phonsavan,,,gleam_basin,,W-AS,,LA,LAO,,19.45,103.158,,576
 G-XKS,Kasabonika,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.525,-88.643,,2600
 G-XMH,Manihi,,,gleam_basin,,W-OC,,PF,PYF,,-14.437,-146.07,,698
-G-XMN,Xiamen,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,24.544,118.128,2519000.0,430
-G-XMS,Macas,,,gleam_basin,,W-SA,,EC,ECU,,-2.299,-78.121,24000.0,1468
+G-XMN,Xiamen,,,gleam_basin,,W-AS,,CN,CHN,CN-FJ,24.544,118.128,2519000,430
+G-XMS,Macas,,,gleam_basin,,W-SA,,EC,ECU,,-2.299,-78.121,24000,1468
 G-XNA,Fayetteville (US-AR),,,gleam_basin,,W-NA,,US,USA,US-AR,36.282,-94.307,,2197
-G-XNN,Xining,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,36.528,102.043,1048000.0,439
+G-XNN,Xining,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,36.528,102.043,1048000,439
 G-XQP,Quepos,,,gleam_basin,,W-NA,,CR,CRI,,9.443,-84.13,,799
 G-XRY,Jerez,,,gleam_basin,,W-EU,,ES,ESP,,36.745,-6.06,,2893
 G-XSB,Sir Bani Yas Island,,,gleam_basin,,W-AS,,AE,ARE,,24.284,52.58,,3177
-G-XTG,Thargomindah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.986,143.811,0.0,1597
-G-XUZ,Xuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,34.059,117.555,1680000.0,316
+G-XTG,Thargomindah,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,-27.986,143.811,0,1597
+G-XUZ,Xuzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,34.059,117.555,1680000,316
 G-YAA,Anahim Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,52.452,-125.303,,2706
-G-YAB,Arctic Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,73.006,-85.033,1000.0,2595
-G-YAC,Cat Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.727,-91.824,0.0,2765
+G-YAB,Arctic Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,73.006,-85.033,1000,2595
+G-YAC,Cat Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.727,-91.824,0,2765
 G-YAG,Fort Frances,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,48.654,-93.44,,2705
 G-YAK,Yakutat,,,gleam_basin,,W-NA,,US,USA,US-AK,59.503,-139.66,,2097
 G-YAM,Sault Ste Marie (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,46.485,-84.509,,2594
 G-YAP,Yap,,,gleam_basin,,W-OC,,FM,FSM,,9.499,138.083,,1210
 G-YAS,Yasawa Island,,,gleam_basin,,W-OC,,FJ,FJI,,-16.759,177.545,,1188
-G-YAT,Attawapiskat,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.928,-82.432,2000.0,2593
+G-YAT,Attawapiskat,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.928,-82.432,2000,2593
 G-YAY,St Anthony,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,51.392,-56.083,,2732
 G-YBB,Pelly Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,68.534,-89.808,,2584
-G-YBC,Baie Comeau,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,49.132,-68.204,10000.0,2681
+G-YBC,Baie Comeau,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,49.132,-68.204,10000,2681
 G-YBG,Bagotville,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.331,-70.996,,2596
-G-YBK,Baker Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.299,-96.078,2000.0,2671
-G-YBP,Yibin,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,28.801,104.545,902000.0,323
-G-YBR,Brandon,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,49.91,-99.952,113000.0,2583
+G-YBK,Baker Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.299,-96.078,2000,2671
+G-YBP,Yibin,,,gleam_basin,,W-AS,,CN,CHN,CN-SC,28.801,104.545,902000,323
+G-YBR,Brandon,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,49.91,-99.952,113000,2583
 G-YBX,Blanc Sablon,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,51.444,-57.185,,2691
-G-YCB,Cambridge Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.108,-105.138,1000.0,2746
+G-YCB,Cambridge Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.108,-105.138,1000,2746
 G-YCG,Castlegar,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.296,-117.632,,2776
 G-YCK,Colville Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,67.039,-126.08,,2743
 G-YCL,Charlo,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,47.991,-66.33,,2775
 G-YCO,Kugluktuk Coppermine,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,67.817,-115.144,,2744
-G-YCS,Chesterfield Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,63.347,-90.731,0.0,2774
-G-YCU,Yuncheng,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,35.116,111.031,202000.0,480
+G-YCS,Chesterfield Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,63.347,-90.731,0,2774
+G-YCU,Yuncheng,,,gleam_basin,,W-AS,,CN,CHN,CN-SX,35.116,111.031,202000,480
 G-YCY,Clyde River,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,70.486,-68.517,,2773
 G-YDA,Dawson City,,,gleam_basin,,W-NA,,CA,CAN,CA-YT,64.043,-139.128,,2709
 G-YDF,Deer Lake (CA-NL),,,gleam_basin,,W-NA,,CA,CAN,CA-NL,49.211,-57.391,,2665
-G-YDP,Nain,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,56.549,-61.68,1000.0,2666
-G-YDQ,Dawson Creek,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,55.742,-120.183,11000.0,2667
-G-YEG,Edmonton,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,53.31,-113.58,1058000.0,2642
-G-YEI,Bursa,,,gleam_basin,,W-AS,,TR,TUR,,40.255,29.563,1492000.0,1760
-G-YEK,Arviat,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,61.094,-94.071,2000.0,2654
-G-YER,Fort Severn,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,56.019,-87.676,0.0,2644
+G-YDP,Nain,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,56.549,-61.68,1000,2666
+G-YDQ,Dawson Creek,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,55.742,-120.183,11000,2667
+G-YEG,Edmonton,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,53.31,-113.58,1058000,2642
+G-YEI,Bursa,,,gleam_basin,,W-AS,,TR,TUR,,40.255,29.563,1492000,1760
+G-YEK,Arviat,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,61.094,-94.071,2000,2654
+G-YER,Fort Severn,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,56.019,-87.676,0,2644
 G-YES,Yasouj,,,gleam_basin,,W-AS,,IR,IRN,,30.701,51.545,,2937
-G-YEV,Inuvik,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,68.304,-133.483,3000.0,2655
-G-YFB,Iqaluit,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,63.756,-68.556,6000.0,2747
-G-YFC,Fredericton,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,45.869,-66.537,52000.0,2628
+G-YEV,Inuvik,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,68.304,-133.483,3000,2655
+G-YFB,Iqaluit,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,63.756,-68.556,6000,2747
+G-YFC,Fredericton,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,45.869,-66.537,52000,2628
 G-YFH,Fort Hope,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.562,-87.908,,2748
 G-YFJ,Snare Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,64.191,-114.077,,2629
-G-YFO,Flin Flon,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,54.678,-101.682,6000.0,2637
-G-YFS,Fort Simpson,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,61.76,-121.237,0.0,2630
-G-YFX,Fox Harbour,,,gleam_basin,,W-NA,,CA,CAN,CA-NS,52.373,-55.674,252.0,2752
-G-YGH,Fort Good Hope,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,66.241,-128.651,1000.0,2618
+G-YFO,Flin Flon,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,54.678,-101.682,6000,2637
+G-YFS,Fort Simpson,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,61.76,-121.237,0,2630
+G-YFX,Fox Harbour,,,gleam_basin,,W-NA,,CA,CAN,CA-NS,52.373,-55.674,252,2752
+G-YGH,Fort Good Hope,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,66.241,-128.651,1000,2618
 G-YGK,Kingston (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,44.225,-76.597,,2617
-G-YGL,La Grande,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,53.625,-77.704,5000.0,2616
-G-YGP,Gaspe,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.775,-64.479,4000.0,2598
+G-YGL,La Grande,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,53.625,-77.704,5000,2616
+G-YGP,Gaspe,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.775,-64.479,4000,2598
 G-YGQ,Geraldton (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.778,-86.939,,2621
 G-YGR,Iles de la Madeleine,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,47.425,-61.778,,2620
-G-YGT,Igloolik,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.365,-81.816,2000.0,2673
+G-YGT,Igloolik,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.365,-81.816,2000,2673
 G-YGV,Havre St Pierre,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,50.282,-63.611,,2754
 G-YGW,Kuujjuarapik,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,55.282,-77.765,,2619
-G-YGX,Gillam,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,56.357,-94.711,1000.0,2622
-G-YGZ,Grise Fiord,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,76.426,-82.909,0.0,2760
-G-YHD,Dryden,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.832,-92.744,8000.0,2700
+G-YGX,Gillam,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,56.357,-94.711,1000,2622
+G-YGZ,Grise Fiord,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,76.426,-82.909,0,2760
+G-YHD,Dryden,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.832,-92.744,8000,2700
 G-YHI,Ulukhaktok,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,70.763,-117.806,,2698
-G-YHK,Gjoa Haven,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,68.636,-95.85,1000.0,2690
+G-YHK,Gjoa Haven,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,68.636,-95.85,1000,2690
 G-YHM,Hamilton (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,43.174,-79.935,,2762
-G-YHO,Hopedale,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,55.448,-60.229,1000.0,2699
-G-YHY,Hay River,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,60.84,-115.783,4000.0,2692
-G-YHZ,Halifax,,,gleam_basin,,W-NA,,CA,CAN,CA-NS,44.881,-63.509,359000.0,2701
-G-YIC,Yichun (Jiangxi),,,gleam_basin,,W-AS,,CN,CHN,CN-JX,27.802,114.306,920000.0,341
+G-YHO,Hopedale,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,55.448,-60.229,1000,2699
+G-YHY,Hay River,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,60.84,-115.783,4000,2692
+G-YHZ,Halifax,,,gleam_basin,,W-NA,,CA,CAN,CA-NS,44.881,-63.509,359000,2701
+G-YIC,Yichun (Jiangxi),,,gleam_basin,,W-AS,,CN,CHN,CN-JX,27.802,114.306,920000,341
 G-YIE,Aershan,,,gleam_basin,,W-AS,,CN,CHN,CN-NM,47.311,119.912,,401
 G-YIF,Pakuashipi,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,51.212,-58.658,,2772
-G-YIH,Yichang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.557,111.48,477000.0,402
-G-YIK,Ivujivik,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,62.417,-77.925,0.0,2686
-G-YIN,Yining,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.956,81.33,358000.0,383
-G-YIO,Pond Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,72.683,-77.967,2000.0,2685
-G-YIW,Yiwu,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.345,120.032,90000.0,403
-G-YJT,Stephenville,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,48.544,-58.55,20000.0,2734
-G-YKA,Kamloops,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,50.702,-120.444,69000.0,2657
-G-YKG,Kangirsuk,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,60.027,-69.999,1000.0,2658
-G-YKL,Schefferville,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,54.805,-66.805,0.0,2659
-G-YKM,Yakima,,,gleam_basin,,W-NA,,US,USA,US-WA,46.568,-120.544,133000.0,2327
+G-YIH,Yichang,,,gleam_basin,,W-AS,,CN,CHN,CN-HB,30.557,111.48,477000,402
+G-YIK,Ivujivik,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,62.417,-77.925,0,2686
+G-YIN,Yining,,,gleam_basin,,W-AS,,CN,CHN,CN-XJ,43.956,81.33,358000,383
+G-YIO,Pond Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,72.683,-77.967,2000,2685
+G-YIW,Yiwu,,,gleam_basin,,W-AS,,CN,CHN,CN-ZJ,29.345,120.032,90000,403
+G-YJT,Stephenville,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,48.544,-58.55,20000,2734
+G-YKA,Kamloops,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,50.702,-120.444,69000,2657
+G-YKG,Kangirsuk,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,60.027,-69.999,1000,2658
+G-YKL,Schefferville,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,54.805,-66.805,0,2659
+G-YKM,Yakima,,,gleam_basin,,W-NA,,US,USA,US-WA,46.568,-120.544,133000,2327
 G-YKQ,Waskaganish,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,51.473,-78.758,,2660
-G-YKS,Yakutsk,,,gleam_basin,,W-EU,,RU,RUS,,62.093,129.771,236000.0,1876
+G-YKS,Yakutsk,,,gleam_basin,,W-EU,,RU,RUS,,62.093,129.771,236000,1876
 G-YKT,Klemtu,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,,,,2676
 G-YKU,Chisasibi,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,53.806,-78.917,,2661
-G-YLC,Kimmirut,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,62.85,-69.883,0.0,2625
+G-YLC,Kimmirut,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,62.85,-69.883,0,2625
 G-YLE,Whati,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,63.132,-117.246,,2624
-G-YLH,Lansdowne House,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.196,-87.934,0.0,2626
-G-YLL,Lloydminster,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,53.309,-110.073,16000.0,2761
-G-YLW,Kelowna,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.956,-119.378,125000.0,2623
+G-YLH,Lansdowne House,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.196,-87.934,0,2626
+G-YLL,Lloydminster,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,53.309,-110.073,16000,2761
+G-YLW,Kelowna,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.956,-119.378,125000,2623
 G-YMK,Mys-Kamenny,,,gleam_basin,,W-EU,,RU,RUS,,,,,1904
-G-YMM,Fort Mcmurray,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,56.653,-111.222,22000.0,2750
+G-YMM,Fort Mcmurray,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,56.653,-111.222,22000,2750
 G-YMN,Makkovik,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,55.077,-59.186,,2751
-G-YMO,Moosonee,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.291,-80.608,2000.0,2770
+G-YMO,Moosonee,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.291,-80.608,2000,2770
 G-YMT,Chibougamau,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,49.772,-74.528,,2767
 G-YNB,Yanbu al Bahr,,,gleam_basin,,W-AS,,SA,SAU,,24.144,38.063,,255
 G-YNC,Wemindji,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,53.011,-78.831,,2736
-G-YNG,Youngstown,,,gleam_basin,,W-NA,,US,USA,US-OH,41.261,-80.679,374000.0,2233
-G-YNJ,Yanji,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,42.883,129.451,489000.0,441
+G-YNG,Youngstown,,,gleam_basin,,W-NA,,US,USA,US-OH,41.261,-80.679,374000,2233
+G-YNJ,Yanji,,,gleam_basin,,W-AS,,CN,CHN,CN-JL,42.883,129.451,489000,441
 G-YNO,North Spirit Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.49,-92.971,,2662
 G-YNP,Natuashish,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,55.914,-61.184,,2737
 G-YNS,Nemiscau,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,51.691,-76.136,,2738
-G-YNT,Yantai,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.402,121.372,2116000.0,378
+G-YNT,Yantai,,,gleam_basin,,W-AS,,CN,CHN,CN-SD,37.402,121.372,2116000,378
 G-YNY,Yangyang,,,gleam_basin,,W-AS,,KR,KOR,,38.061,128.669,,2802
-G-YNZ,Yancheng,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,33.426,120.203,839000.0,442
+G-YNZ,Yancheng,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,33.426,120.203,839000,442
 G-YOC,Old Crow,,,gleam_basin,,W-NA,,CA,CAN,CA-YT,67.571,-139.839,,2592
 G-YOG,Ogoki,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.659,-85.902,,2719
 G-YOJ,High Level,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,58.621,-117.165,,2591
-G-YOL,Yola,,,gleam_basin,,W-AF,,NG,NGA,,9.258,12.43,96000.0,1423
+G-YOL,Yola,,,gleam_basin,,W-AF,,NG,NGA,,9.258,12.43,96000,1423
 G-YOP,Rainbow Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,58.491,-119.408,,2601
-G-YOW,Ottawa,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,45.322,-75.669,1145000.0,2720
-G-YPA,Prince Albert,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,53.214,-105.673,35000.0,2755
-G-YPC,Paulatuk,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,69.361,-124.075,0.0,2632
-G-YPH,Inukjuak,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.472,-78.077,2000.0,2634
+G-YOW,Ottawa,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,45.322,-75.669,1145000,2720
+G-YPA,Prince Albert,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,53.214,-105.673,35000,2755
+G-YPC,Paulatuk,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,69.361,-124.075,0,2632
+G-YPH,Inukjuak,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.472,-78.077,2000,2634
 G-YPJ,Aupaluk,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,59.297,-69.6,,2633
 G-YPL,Pickle Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.446,-90.214,,2635
 G-YPM,Pikangikum,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.82,-93.973,,2702
-G-YPN,Port Menier,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,49.836,-64.289,0.0,2756
+G-YPN,Port Menier,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,49.836,-64.289,0,2756
 G-YPO,Peawanuck,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,54.988,-85.443,,2757
-G-YPR,Prince Rupert,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.286,-130.445,15000.0,2753
+G-YPR,Prince Rupert,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.286,-130.445,15000,2753
 G-YPX,Puvirnituq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,60.051,-77.287,,2745
-G-YPY,Fort Chipewyan,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,58.767,-111.117,3000.0,2631
-G-YQB,Quebec,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,46.791,-71.393,624000.0,2610
+G-YPY,Fort Chipewyan,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,58.767,-111.117,3000,2631
+G-YQB,Quebec,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,46.791,-71.393,624000,2610
 G-YQC,Quaqtaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,61.046,-69.618,,2609
-G-YQD,The Pas,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,53.971,-101.091,6000.0,2672
-G-YQF,Red Deer,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,52.182,-113.894,75000.0,2656
-G-YQG,Windsor,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,42.276,-82.956,319000.0,2608
-G-YQK,Kenora,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.788,-94.363,11000.0,2607
-G-YQL,Lethbridge,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,49.63,-112.8,71000.0,2638
-G-YQM,Moncton,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,46.112,-64.679,91000.0,2636
+G-YQD,The Pas,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,53.971,-101.091,6000,2672
+G-YQF,Red Deer,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,52.182,-113.894,75000,2656
+G-YQG,Windsor,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,42.276,-82.956,319000,2608
+G-YQK,Kenora,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.788,-94.363,11000,2607
+G-YQL,Lethbridge,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,49.63,-112.8,71000,2638
+G-YQM,Moncton,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,46.112,-64.679,91000,2636
 G-YQQ,Comox,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.711,-124.887,,2764
-G-YQR,Regina,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,50.432,-104.666,176000.0,2643
-G-YQT,Thunder Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,48.372,-89.324,99000.0,2614
-G-YQU,Grande Prairie,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,55.18,-118.885,41000.0,2613
-G-YQX,Gander,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,48.937,-54.568,3000.0,2641
+G-YQR,Regina,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,50.432,-104.666,176000,2643
+G-YQT,Thunder Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,48.372,-89.324,99000,2614
+G-YQU,Grande Prairie,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,55.18,-118.885,41000,2613
+G-YQX,Gander,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,48.937,-54.568,3000,2641
 G-YQY,Sydney (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-NS,46.161,-60.048,,2611
-G-YQZ,Quesnel,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.026,-122.51,14000.0,2735
+G-YQZ,Quesnel,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.026,-122.51,14000,2735
 G-YRA,Rae Lakes,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,64.116,-117.31,,2779
-G-YRB,Resolute,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,74.717,-94.969,0.0,2603
-G-YRG,Rigolet,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,54.18,-58.458,0.0,2604
-G-YRL,Red Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.067,-93.793,2000.0,2602
-G-YRT,Rankin Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,62.811,-92.116,2000.0,2605
-G-YSB,Sudbury,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,46.625,-80.799,158000.0,2588
+G-YRB,Resolute,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,74.717,-94.969,0,2603
+G-YRG,Rigolet,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,54.18,-58.458,0,2604
+G-YRL,Red Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,51.067,-93.793,2000,2602
+G-YRT,Rankin Inlet,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,62.811,-92.116,2000,2605
+G-YSB,Sudbury,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,46.625,-80.799,158000,2588
 G-YSG,Lutselke Snowdrift,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,62.418,-110.682,,2589
 G-YSJ,St John,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,45.316,-65.89,,2586
 G-YSK,Sanikiluaq,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,56.538,-79.247,,2585
 G-YSM,Fort Smith (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-NT,60.02,-111.962,,2587
 G-YSY,Sachs Harbour,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,71.994,-125.243,,2590
-G-YTE,Cape Dorset,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.23,-76.527,1000.0,2697
-G-YTF,Alma,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.509,-71.642,16000.0,2684
-G-YTH,Thompson,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,55.801,-97.864,15000.0,2696
+G-YTE,Cape Dorset,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.23,-76.527,1000,2697
+G-YTF,Alma,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.509,-71.642,16000,2684
+G-YTH,Thompson,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,55.801,-97.864,15000,2696
 G-YTL,Big Trout Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.818,-89.897,,2683
 G-YTM,Mont Tremblant,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,46.409,-74.78,,2759
 G-YTQ,Tasiujuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.668,-69.956,,2675
-G-YTS,Timmins,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,48.57,-81.377,35000.0,2695
-G-YTY,Yangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,32.563,119.72,540000.0,395
-G-YUB,Tuktoyaktuk,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,69.433,-133.026,1000.0,2680
+G-YTS,Timmins,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,48.57,-81.377,35000,2695
+G-YTY,Yangzhou,,,gleam_basin,,W-AS,,CN,CHN,CN-JS,32.563,119.72,540000,395
+G-YUB,Tuktoyaktuk,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,69.433,-133.026,1000,2680
 G-YUD,Umiujaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,56.536,-76.518,,2599
-G-YUL,Montreal,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,45.471,-73.741,3678000.0,2777
-G-YUM,Yuma,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.657,-114.606,139000.0,2104
-G-YUS,Yushu,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,32.836,97.036,125000.0,390
-G-YUT,Repulse Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,66.521,-86.225,1000.0,2679
-G-YUX,Hall Beach,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,68.776,-81.243,1000.0,2678
+G-YUL,Montreal,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,45.471,-73.741,3678000,2777
+G-YUM,Yuma,,,gleam_basin,,W-NA,,US,USA,US-AZ,32.657,-114.606,139000,2104
+G-YUS,Yushu,,,gleam_basin,,W-AS,,CN,CHN,CN-QH,32.836,97.036,125000,390
+G-YUT,Repulse Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,66.521,-86.225,1000,2679
+G-YUX,Hall Beach,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,68.776,-81.243,1000,2678
 G-YUY,Rouyn,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.206,-78.836,,2677
 G-YVB,Bonaventure,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.071,-65.46,,2721
 G-YVM,Qikiqtarjuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,67.546,-64.031,,2669
-G-YVO,Val D'Or,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.053,-77.783,21000.0,2722
-G-YVP,Kuujjuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.096,-68.427,1000.0,2771
-G-YVQ,Norman Wells,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,65.282,-126.798,1000.0,2703
-G-YVR,Vancouver,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.194,-123.184,2313000.0,2766
+G-YVO,Val D'Or,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.053,-77.783,21000,2722
+G-YVP,Kuujjuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,58.096,-68.427,1000,2771
+G-YVQ,Norman Wells,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,65.282,-126.798,1000,2703
+G-YVR,Vancouver,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.194,-123.184,2313000,2766
 G-YVZ,Deer Lake (CA-ON),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.656,-94.061,,2668
 G-YWB,Kangiqsujuaq,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,61.589,-71.929,,2606
-G-YWG,Winnipeg,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,49.91,-97.24,632000.0,2648
-G-YWJ,Deline,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,65.211,-123.436,1000.0,2651
+G-YWG,Winnipeg,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,49.91,-97.24,632000,2648
+G-YWJ,Deline,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,65.211,-123.436,1000,2651
 G-YWK,Wabush,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,52.922,-66.864,,2650
-G-YWL,Williams Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,52.183,-122.054,14000.0,2649
+G-YWL,Williams Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,52.183,-122.054,14000,2649
 G-YWP,Webequie,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.959,-87.375,,2647
-G-YXC,Cranbrook,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.611,-115.782,19000.0,2758
-G-YXE,Saskatoon,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,52.171,-106.7,199000.0,2733
-G-YXH,Medicine Hat,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,50.019,-110.721,63000.0,2729
+G-YXC,Cranbrook,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.611,-115.782,19000,2758
+G-YXE,Saskatoon,,,gleam_basin,,W-NA,,CA,CAN,CA-SK,52.171,-106.7,199000,2733
+G-YXH,Medicine Hat,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,50.019,-110.721,63000,2729
 G-YXJ,Fort St John,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,56.238,-120.74,,2728
-G-YXL,Sioux Lookout,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,50.114,-91.905,5000.0,2731
+G-YXL,Sioux Lookout,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,50.114,-91.905,5000,2731
 G-YXN,Whale Cove,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,62.24,-92.598,,2730
-G-YXP,Pangnirtung,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,66.145,-65.714,1000.0,2726
-G-YXS,Prince George,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.889,-122.679,66000.0,2724
-G-YXT,Terrace,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.468,-128.576,19000.0,2727
+G-YXP,Pangnirtung,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,66.145,-65.714,1000,2726
+G-YXS,Prince George,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.889,-122.679,66000,2724
+G-YXT,Terrace,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.468,-128.576,19000,2727
 G-YXU,London (CA),,,gleam_basin,,W-NA,,CA,CAN,CA-ON,43.036,-81.154,,2645
-G-YXX,Abbotsford,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.025,-122.361,152000.0,2725
-G-YXY,Whitehorse,,,gleam_basin,,W-NA,,CA,CAN,CA-YT,60.71,-135.067,23000.0,2742
-G-YYB,North Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,46.364,-79.423,50000.0,2717
-G-YYC,Calgary,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,51.114,-114.02,1110000.0,2716
-G-YYD,Smithers,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.825,-127.183,6000.0,2707
-G-YYE,Fort Nelson,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,58.836,-122.597,6000.0,2714
-G-YYF,Penticton,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.463,-119.602,38000.0,2653
-G-YYG,Charlottetown,,,gleam_basin,,W-NA,,CA,CAN,CA-PE,46.29,-63.121,42000.0,2715
-G-YYH,Taloyoak,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.547,-93.577,1000.0,2664
-G-YYL,Lynn Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,56.864,-101.076,0.0,2718
-G-YYQ,Churchill,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,58.739,-94.065,1000.0,2711
+G-YXX,Abbotsford,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.025,-122.361,152000,2725
+G-YXY,Whitehorse,,,gleam_basin,,W-NA,,CA,CAN,CA-YT,60.71,-135.067,23000,2742
+G-YYB,North Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,46.364,-79.423,50000,2717
+G-YYC,Calgary,,,gleam_basin,,W-NA,,CA,CAN,CA-AB,51.114,-114.02,1110000,2716
+G-YYD,Smithers,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.825,-127.183,6000,2707
+G-YYE,Fort Nelson,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,58.836,-122.597,6000,2714
+G-YYF,Penticton,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,49.463,-119.602,38000,2653
+G-YYG,Charlottetown,,,gleam_basin,,W-NA,,CA,CAN,CA-PE,46.29,-63.121,42000,2715
+G-YYH,Taloyoak,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,69.547,-93.577,1000,2664
+G-YYL,Lynn Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,56.864,-101.076,0,2718
+G-YYQ,Churchill,,,gleam_basin,,W-NA,,CA,CAN,CA-MB,58.739,-94.065,1000,2711
 G-YYR,Goose Bay,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,53.319,-60.426,,2712
 G-YYT,St Johns,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,47.619,-52.752,,2639
-G-YYU,Kapuskasing,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.414,-82.467,9000.0,2710
+G-YYU,Kapuskasing,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,49.414,-82.467,9000,2710
 G-YYY,Mont Joli,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,48.609,-68.208,,2713
-G-YYZ,Toronto,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,43.677,-79.631,5213000.0,2682
-G-YZF,Yellowknife,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,62.463,-114.44,19000.0,2694
-G-YZG,Salluit,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,62.179,-75.667,0.0,2739
-G-YZP,Sandspit,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.254,-131.814,1000.0,2693
-G-YZR,Sarnia,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,42.999,-82.309,144000.0,2674
-G-YZS,Coral Harbour,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.193,-83.359,1000.0,2597
-G-YZT,Port Hardy,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,50.681,-127.367,2000.0,2749
-G-YZV,Sept-Iles,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,50.223,-66.266,26000.0,2769
-G-YZY,Zhangye,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,38.802,100.675,231000.0,410
-G-ZAD,Zadar,,,gleam_basin,,W-EU,,HR,HRV,,44.108,15.347,71000.0,288
-G-ZAG,Zagreb,,,gleam_basin,,W-EU,,HR,HRV,,45.743,16.069,723000.0,287
-G-ZAH,Zahedan,,,gleam_basin,,W-AS,,IR,IRN,,29.476,60.906,599000.0,2946
-G-ZAJ,Zaranj,,,gleam_basin,,W-AS,,AF,AFG,,30.972,61.866,50000.0,889
-G-ZAL,Valdivia,,,gleam_basin,,W-SA,,CL,CHL,,-39.65,-73.086,160000.0,297
-G-ZAM,Zamboanga,,,gleam_basin,,W-AS,,PH,PHL,,6.922,122.06,458000.0,600
-G-ZAT,Zhaotong,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,27.326,103.755,809000.0,419
-G-ZAZ,Zaragoza,,,gleam_basin,,W-EU,,ES,ESP,,41.666,-1.042,649000.0,2900
-G-ZBF,Bathurst,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,47.63,-65.739,6000.0,2663
-G-ZBL,Biloela,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,,,6000.0,1616
+G-YYZ,Toronto,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,43.677,-79.631,5213000,2682
+G-YZF,Yellowknife,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,62.463,-114.44,19000,2694
+G-YZG,Salluit,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,62.179,-75.667,0,2739
+G-YZP,Sandspit,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,53.254,-131.814,1000,2693
+G-YZR,Sarnia,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,42.999,-82.309,144000,2674
+G-YZS,Coral Harbour,,,gleam_basin,,W-NA,,CA,CAN,CA-NU,64.193,-83.359,1000,2597
+G-YZT,Port Hardy,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,50.681,-127.367,2000,2749
+G-YZV,Sept-Iles,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,50.223,-66.266,26000,2769
+G-YZY,Zhangye,,,gleam_basin,,W-AS,,CN,CHN,CN-GS,38.802,100.675,231000,410
+G-ZAD,Zadar,,,gleam_basin,,W-EU,,HR,HRV,,44.108,15.347,71000,288
+G-ZAG,Zagreb,,,gleam_basin,,W-EU,,HR,HRV,,45.743,16.069,723000,287
+G-ZAH,Zahedan,,,gleam_basin,,W-AS,,IR,IRN,,29.476,60.906,599000,2946
+G-ZAJ,Zaranj,,,gleam_basin,,W-AS,,AF,AFG,,30.972,61.866,50000,889
+G-ZAL,Valdivia,,,gleam_basin,,W-SA,,CL,CHL,,-39.65,-73.086,160000,297
+G-ZAM,Zamboanga,,,gleam_basin,,W-AS,,PH,PHL,,6.922,122.06,458000,600
+G-ZAT,Zhaotong,,,gleam_basin,,W-AS,,CN,CHN,CN-YN,27.326,103.755,809000,419
+G-ZAZ,Zaragoza,,,gleam_basin,,W-EU,,ES,ESP,,41.666,-1.042,649000,2900
+G-ZBF,Bathurst,,,gleam_basin,,W-NA,,CA,CAN,CA-NB,47.63,-65.739,6000,2663
+G-ZBL,Biloela,,,gleam_basin,,W-OC,,AU,AUS,AU-QLD,,,6000,1616
 G-ZBR,Chah Bahar,,,gleam_basin,,W-AS,,IR,IRN,,25.443,60.382,,2941
-G-ZCL,Zacatecas,,,gleam_basin,,W-NA,,MX,MEX,,22.897,-102.687,234000.0,1006
-G-ZCO,Temuco,,,gleam_basin,,W-SA,,CL,CHL,,-38.926,-72.651,266000.0,298
-G-ZEL,Bella Bella,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,,,1000.0,2708
+G-ZCL,Zacatecas,,,gleam_basin,,W-NA,,MX,MEX,,22.897,-102.687,234000,1006
+G-ZCO,Temuco,,,gleam_basin,,W-SA,,CL,CHL,,-38.926,-72.651,266000,298
+G-ZEL,Bella Bella,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,,,1000,2708
 G-ZEM,East Main,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,52.226,-78.522,,2646
-G-ZFM,Fort Mcpherson,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,67.408,-134.861,1000.0,2687
+G-ZFM,Fort Mcpherson,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,67.408,-134.861,1000,2687
 G-ZFN,Tulita Fort Norman,,,gleam_basin,,W-NA,,CA,CAN,CA-NT,64.91,-125.573,,2688
 G-ZGS,Gethsemani,,,gleam_basin,,W-NA,,CA,CAN,CA-QC,50.26,-60.679,,2768
-G-ZHA,Zhanjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,21.214,110.358,1590000.0,469
+G-ZHA,Zhanjiang,,,gleam_basin,,W-AS,,CN,CHN,CN-GD,21.214,110.358,1590000,469
 G-ZHY,Zhongwei,,,gleam_basin,,W-AS,,CN,CHN,CN-NX,37.573,105.154,,466
-G-ZIG,Ziguinchor,,,gleam_basin,,W-AF,,SN,SEN,,12.556,-16.282,192000.0,1474
-G-ZIH,Ixtapa,,,gleam_basin,,W-NA,,MX,MEX,,17.602,-101.461,19000.0,982
+G-ZIG,Ziguinchor,,,gleam_basin,,W-AF,,SN,SEN,,12.556,-16.282,192000,1474
+G-ZIH,Ixtapa,,,gleam_basin,,W-NA,,MX,MEX,,17.602,-101.461,19000,982
 G-ZKE,Kashechewan,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.283,-81.678,,2615
-G-ZKP,Zyryanka,,,gleam_basin,,W-EU,,RU,RUS,,65.749,150.889,4000.0,1872
+G-ZKP,Zyryanka,,,gleam_basin,,W-EU,,RU,RUS,,65.749,150.889,4000,1872
 G-ZLO,Manzanillo (MX),,,gleam_basin,,W-NA,,MX,MEX,,19.145,-104.559,,991
 G-ZLX,Zalengei,,,gleam_basin,,W-AF,,SD,SDN,,,,,3013
-G-ZMD,Sena Madureira,,,gleam_basin,,W-SA,,BR,BRA,,,,26000.0,2017
+G-ZMD,Sena Madureira,,,gleam_basin,,W-SA,,BR,BRA,,,,26000,2017
 G-ZMT,Masset,,,gleam_basin,,W-NA,,CA,CAN,CA-BC,54.028,-132.125,,2740
-G-ZND,Zinder,,,gleam_basin,,W-AF,,NE,NER,,13.779,8.984,230000.0,72
-G-ZNE,Newman,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-23.418,119.803,11000.0,1631
-G-ZNZ,Zanzibar,,,gleam_basin,,W-AF,,TZ,TZA,,-6.222,39.225,404000.0,206
-G-ZOS,Osorno,,,gleam_basin,,W-SA,,CL,CHL,,-40.611,-73.061,154000.0,301
+G-ZND,Zinder,,,gleam_basin,,W-AF,,NE,NER,,13.779,8.984,230000,72
+G-ZNE,Newman,,,gleam_basin,,W-OC,,AU,AUS,AU-WA,-23.418,119.803,11000,1631
+G-ZNZ,Zanzibar,,,gleam_basin,,W-AF,,TZ,TZA,,-6.222,39.225,404000,206
+G-ZOS,Osorno,,,gleam_basin,,W-SA,,CL,CHL,,-40.611,-73.061,154000,301
 G-ZPB,Sachigo Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.891,-92.196,,2723
-G-ZPC,Pucon,,,gleam_basin,,W-SA,,CL,CHL,,-39.293,-71.916,27000.0,304
-G-ZQN,Queenstown,,,gleam_basin,,W-OC,,NZ,NZL,,-45.021,168.739,105000.0,3037
-G-ZRH,Zurich,,,gleam_basin,,W-EU,,CH,CHE,,47.465,8.549,1108000.0,276
-G-ZRJ,Round Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.944,-91.313,5000.0,2689
+G-ZPC,Pucon,,,gleam_basin,,W-SA,,CL,CHL,,-39.293,-71.916,27000,304
+G-ZQN,Queenstown,,,gleam_basin,,W-OC,,NZ,NZL,,-45.021,168.739,105000,3037
+G-ZRH,Zurich,,,gleam_basin,,W-EU,,CH,CHE,,47.465,8.549,1108000,276
+G-ZRJ,Round Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,52.944,-91.313,5000,2689
 G-ZSA,San Salvador (BS),,,gleam_basin,,W-NA,,BS,BHS,,24.063,-74.524,,3223
 G-ZSJ,Sandy Lake,,,gleam_basin,,W-NA,,CA,CAN,CA-ON,53.064,-93.344,,2704
 G-ZTA,Tureia,,,gleam_basin,,W-OC,,PF,PYF,,-20.79,-138.57,,688
 G-ZTH,Zakinthos Island,,,gleam_basin,,W-EU,,GR,GRC,,37.751,20.884,,920
 G-ZUM,Churchill Falls,,,gleam_basin,,W-NA,,CA,CAN,CA-NL,53.562,-64.106,,2670
-G-ZVK,Savannakhet,,,gleam_basin,,W-AS,,LA,LAO,,16.557,104.76,85000.0,572
-G-ZYI,Zunyi,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.59,107.001,849000.0,330
-G-ZYL,Sylhet,,,gleam_basin,,W-AS,,BD,BGD,,24.963,91.867,237000.0,62
+G-ZVK,Savannakhet,,,gleam_basin,,W-AS,,LA,LAO,,16.557,104.76,85000,572
+G-ZYI,Zunyi,,,gleam_basin,,W-AS,,CN,CHN,CN-GZ,27.59,107.001,849000,330
+G-ZYL,Sylhet,,,gleam_basin,,W-AS,,BD,BGD,,24.963,91.867,237000,62
 G-ZZO,Zonalnoye,,,gleam_basin,,W-EU,,RU,RUS,,,,,1847


### PR DESCRIPTION
This replaces `regions-gleam.csv` with an updated version directly exported from [the Google sheet](https://docs.google.com/spreadsheets/d/1NC_PDqg102P0HvCnSGMX9U4Z2ExknSyVELWdXOBVLu8/edit#gid=2065175080).

Since the formatting is slightly different, the diff shows the whole file as being replaced, however there is an intermediary commit where I reformatted the file so it's easy to see what has actually changed. To review those changes, please view that diff [here](https://github.com/epidemics/epimodel-covid-data/pull/10/commits/350d6f752b8d831e413dc837b4c556f165935dbe).

Once this is merged, it will be much easier to diff this file for future updates because no reformatting from the Google sheets export will be required.